### PR TITLE
RACTuple: add support for modern object subscripting

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.h
@@ -50,3 +50,10 @@
 - (NSArray *)allObjects;
 
 @end
+
+@interface RACTuple (ObjectSubscripting)
+// Returns the object at that index or nil if the number of objects is less
+// than the index.
+- (id)objectAtIndexedSubscript:(NSUInteger)idx; 
+@end
+

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.m
@@ -149,3 +149,11 @@
 }
 
 @end
+
+@implementation RACTuple (ObjectSubscripting)
+
+- (id)objectAtIndexedSubscript:(NSUInteger)idx {
+    return [self safeObjectAtIndex:idx];
+}
+
+@end


### PR DESCRIPTION
Added category `RACTuple(ObjectSubscripting)` which implements `-objectAtIndexedSubscript:`, allowing tuples to be accessed with subscripts (e.g. `tuple[3]`). The specific implementation is based on `-safeObjectAtIndex:`, though I'm not exactly married to the idea.

This doesn't change the backwards compatibility of RAC, but rather allows consumers with newer compilers to take advantage of Objective-C's new syntax. See [Clang/Objective-C Literals](http://clang.llvm.org/docs/ObjectiveCLiterals.html) for more information.
