### PR TITLE
Add i386 to the VALID_ARCH list.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -1140,7 +1140,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "armv6 armv7";
+				VALID_ARCHS = "armv6 armv7 i386";
 			};
 			name = Debug;
 		};
@@ -1153,7 +1153,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "armv6 armv7";
+				VALID_ARCHS = "armv6 armv7 i386";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Resolves issues with compiling ReactiveCocoa as an included project from a build server.
