### PR TITLE
Fixed a retain cycle in rac_whenAny

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACOperations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACOperations.m
@@ -25,9 +25,9 @@
 	
 	__block __unsafe_unretained id weakSelf = self;
 	return [RACSubscribable createSubscribable:^RACDisposable *(id<RACSubscriber> subscriber) {
-		NSObject *strongSelf = weakSelf;
 		
 		RACTuple * (^currentValues)(void) = ^{
+      NSObject *strongSelf = weakSelf;
 			NSMutableArray *values = [NSMutableArray arrayWithCapacity:keyPaths.count];
 			for(NSString *keyPath in keyPaths) {
 				[values addObject:[strongSelf valueForKeyPath:keyPath] ? : [RACTupleNil tupleNil]];
@@ -38,6 +38,7 @@
 		
 		[subscriber sendNext:reduceBlock(currentValues())];
 		
+    NSObject *strongSelf = weakSelf;
 		NSArray *subscribables = [keyPaths rac_select:^(NSString *keyPath) {
 			return [strongSelf rac_subscribableForKeyPath:keyPath onObject:strongSelf];
 		}];


### PR DESCRIPTION
While experimenting with RAC, we stumble upon a retain cycle that was preventing an object to be deallocated. 

The proposed fix solved the issue.
