### PR TITLE
Remove unnecessary -performSelector: in NSObject+RACKVOWrapper

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACKVOWrapper.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACKVOWrapper.m
@@ -146,7 +146,7 @@ static NSMutableSet *swizzledClasses = nil;
 	// If we're currently delivering a KVO callback then niling the trampoline set might not dealloc the trampoline and therefore make them be dealloc'd. So we need to manually stop observing on all of them as well.
 	[trampolines makeObjectsPerformSelector:@selector(stopObserving)];
 
-	[self performSelector:@selector(rac_customDealloc)];
+	[self rac_customDealloc];
 }
 
 - (id)rac_addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options queue:(NSOperationQueue *)queue block:(void (^)(id observer, NSDictionary *change))block {


### PR DESCRIPTION
`-rac_customDealloc` can just be invoked directly instead.
