### PR TITLE
Don't clear the last values in +combineLatest:reduce:

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribable+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribable+Operations.h
@@ -81,18 +81,21 @@ typedef NSInteger RACSubscribableError;
 // Take `count` `next`s and then completes.
 - (RACSubscribable *)take:(NSUInteger)count;
 
-// Takes the last `count` `next`'s after the receiving subscribable completes.
+// Takes the last `count` `next`s after the receiving subscribable completes.
 - (RACSubscribable *)takeLast:(NSUInteger)count;
 
-// Combine the latest values from each of the subscribables once all the
-// subscribables have sent a `next`. The `next` will be a RACTuple of 
-// the values from the subscribables.
+// Combine the latest values from each of the subscribables into a RACTuple, once
+// all the subscribables have sent a `next`. Any additional `next`s will result
+// in a new tuple with the changed value.
 + (RACSubscribable *)combineLatest:(NSArray *)subscribables;
 
 // Combine the latest values from each of the subscribables once all the
-// subscribables have sent a `next`. The `next` will be the return value
-// of the `reduceBlock`. The argument to `reduceBlock` is a RACTuple
-// of the values from the subscribables.
+// subscribables have sent a `next`. Any additional `next`s will result in a new
+// reduced value based on a new tuple with the changed value.
+//
+// The `next` of the returned subscribable will be the return value of the
+// `reduceBlock`. The argument to `reduceBlock` is a RACTuple of the values from
+// the subscribables.
 + (RACSubscribable *)combineLatest:(NSArray *)subscribables reduce:(id (^)(RACTuple *xs))reduceBlock;
 
 // Sends a `+[RACUnit defaultUnit]` when all the subscribables have sent a `next`.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribable+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribable+Operations.m
@@ -406,7 +406,7 @@ NSString * const RACSubscribableErrorDomain = @"RACSubscribableErrorDomain";
 						for(id<RACSubscribable> o in subscribables) {
 							[orderedValues addObject:[lastValues objectForKey:[NSString stringWithFormat:@"%p", o]]];
 						}
-						[lastValues removeAllObjects];
+
 						[subscriber sendNext:reduceBlock([RACTuple tupleWithObjectsFromArray:orderedValues])];
 					}
 				}

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSubscribableSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSubscribableSpec.m
@@ -358,7 +358,7 @@ describe(@"combineLatest", ^{
 		[subscriber2 sendNext:@"2"];
 		
 		expect(result).to.beKindOf([RACTuple class]);
-		RACTuple *tuple = (RACTuple *)result;
+		RACTuple *tuple = result;
 		expect(tuple.first).to.equal(@"1");
 		expect(tuple.second).to.equal(@"2");
 	});
@@ -375,16 +375,10 @@ describe(@"combineLatest", ^{
 		expect(result).to.beNil();
 	});
 	
-	it(@"should yield multiple times when all sources yield multiple times", ^{
-		__block int yieldCount = 0;
-		__block id result1, result2;
-		
+	it(@"should yield multiple times when any sources yield multiple times", ^{
+		NSMutableArray *results = [NSMutableArray array];
 		[combined subscribeNext:^(id x) {
-			yieldCount++;
-			if (yieldCount == 1)
-				result1 = x;
-			if (yieldCount == 2)
-				result2 = x;
+			[results addObject:x];
 		}];
 		
 		[subscriber1 sendNext:@"1"];
@@ -393,40 +387,17 @@ describe(@"combineLatest", ^{
 		[subscriber1 sendNext:@"3"];
 		[subscriber2 sendNext:@"4"];
 		
-		expect(result1).to.beKindOf([RACTuple class]);
-		RACTuple *tuple1 = (RACTuple *)result1;
-		expect(tuple1.first).to.equal(@"1");
-		expect(tuple1.second).to.equal(@"2");
+		RACTuple *result1 = [results objectAtIndex:0];
+		expect(result1.first).to.equal(@"1");
+		expect(result1.second).to.equal(@"2");
 		
-		expect(result2).to.beKindOf([RACTuple class]);
-		RACTuple *tuple2 = (RACTuple *)result2;
-		expect(tuple2.first).to.equal(@"3");
-		expect(tuple2.second).to.equal(@"4");
-	});
-	
-	it(@"should not yield multiple times when all sources do not yield multiple times", ^{
-		__block int yieldCount = 0;
-		__block id result1, result2;
+		RACTuple *result2 = [results objectAtIndex:1];
+		expect(result2.first).to.equal(@"3");
+		expect(result2.second).to.equal(@"2");
 		
-		[combined subscribeNext:^(id x) {
-			yieldCount++;
-			if (yieldCount == 1)
-				result1 = x;
-			if (yieldCount == 2)
-				result2 = x;
-		}];
-		
-		[subscriber1 sendNext:@"1"];
-		[subscriber2 sendNext:@"2"];
-		
-		[subscriber1 sendNext:@"3"];
-		
-		expect(result1).to.beKindOf([RACTuple class]);
-		RACTuple *tuple1 = (RACTuple *)result1;
-		expect(tuple1.first).to.equal(@"1");
-		expect(tuple1.second).to.equal(@"2");
-		
-		expect(result2).to.beNil();
+		RACTuple *result3 = [results objectAtIndex:2];
+		expect(result3.first).to.equal(@"3");
+		expect(result3.second).to.equal(@"4");
 	});
 	
 	it(@"should complete when all sources complete", ^{


### PR DESCRIPTION
This partially reverts commit a268f3100aefab1cf7efd889b6d6acc1ca9f821f.

This allows for incremental combination – i.e., after all subscribables have sent their initial next, any further nexts will result in a new callback, which I think is the Right Thing to do given the purpose of the method.

CC @bvanderveen
