### PR TITLE
Moved +command from RACAyncCommand to RACCommand

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACAsyncCommand.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACAsyncCommand.h
@@ -27,9 +27,6 @@
 // `canExecute` will be NO.
 @property (readonly, assign) NSUInteger numberOfActiveExecutions;
 
-// Creates a new command that can always be executed and has no execution block.
-+ (instancetype)command;
-
 // Adds a new async block to be called when the command executes.
 //
 // block - a new block to perform when the command is executed. Cannot be nil.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACAsyncCommand.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACAsyncCommand.m
@@ -37,11 +37,7 @@
 
 #pragma mark RACCommand
 
-+ (instancetype)command {
-	return [[self alloc] initWithBlock:NULL canExecuteSubscribable:nil];
-}
-
-- (id)initWithBlock:(void (^)(id sender))block canExecuteSubscribable:(id<RACSubscribable>)canExecuteSubscribable {
+- (id)initWithCanExecuteSubscribable:(id<RACSubscribable>)canExecuteSubscribable block:(void (^)(id sender))block {
 	self = [super initWithCanExecuteSubscribable:nil block:block];
 	if (self == nil) return nil;
 	

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.h
@@ -22,6 +22,9 @@
 // KVC-compliant. Users can binding a subscribable to this property if needed.
 @property (readonly) BOOL canExecute;
 
+// Creates a new command that can always be executed and has no execution block.
++ (instancetype)command;
+
 // Creates a new command with the given execution block. `canExecute` will
 // always be YES.
 + (instancetype)commandWithBlock:(void (^)(id sender))block;

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
@@ -26,6 +26,10 @@
 
 #pragma mark API
 
++ (instancetype)command {
+	return [[self alloc] initWithCanExecuteSubscribable:nil block:NULL];
+}
+
 + (instancetype)commandWithBlock:(void (^)(id value))executeBlock {
 	return [[self alloc] initWithCanExecuteSubscribable:nil block:executeBlock];
 }


### PR DESCRIPTION
It was just in `RACAsyncCommand` because it didn't seem to make any sense to create a command without an execute block. But now we've come around to the idea that a command could just be a signal, in which case it certainly makes sense to have a command without an execution block.
