### PR TITLE
Fix merge concurrency

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.m
@@ -585,8 +585,10 @@ NSString * const RACSubscribableErrorDomain = @"RACSubscribableErrorDomain";
 		return [RACDisposable disposableWithBlock:^{
 			[outerDisposable dispose];
 
-			for(RACDisposable *innerDisposable in innerDisposables) {
-				[innerDisposable dispose];
+			@synchronized(innerDisposables) {
+				for(RACDisposable *innerDisposable in innerDisposables) {
+					[innerDisposable dispose];
+				}
 			}
 		}];
 	}];


### PR DESCRIPTION
Synchronize access to the `innerDisposables` set and dispose of the outer disposable before the inners to ensure we don't get any more inner disposables while we're disposing.
