### PR TITLE
`self` changed to `object` so that macro could be used inside blocks

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.h
@@ -23,7 +23,7 @@
 #define RACAble(...) metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(_RACAbleObject(self, __VA_ARGS__))(_RACAbleObject(__VA_ARGS__))
 
 // Do not use this directly. Use RACAble above.
-#define _RACAbleObject(object, property) [object rac_subscribableForKeyPath:RAC_KEYPATH(object, property) onObject:self]
+#define _RACAbleObject(object, property) [object rac_subscribableForKeyPath:RAC_KEYPATH(object, property) onObject:object]
 
 // Same as RACAble but the subscribable also starts with the current value of
 // the property.


### PR DESCRIPTION
Found a leak caused by using RACable(..) macro inside block. The problem is that this macro is using `self` explicitly, leading to deadlock (as we should use weak self instead). 

I'm not sure changing object to which subscribable to assign is correct, however, I didn't have any problems with this approach. 
