### PR TITLE
Xcode 4.5 fixes

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -63,8 +63,6 @@
 		886F702A1551CF920045D68B /* RACGroupedSubscribable.h in Headers */ = {isa = PBXBuildFile; fileRef = 886F70281551CF920045D68B /* RACGroupedSubscribable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		886F702B1551CF920045D68B /* RACGroupedSubscribable.m in Sources */ = {isa = PBXBuildFile; fileRef = 886F70291551CF920045D68B /* RACGroupedSubscribable.m */; };
 		886F702C1551CF9D0045D68B /* RACGroupedSubscribable.m in Sources */ = {isa = PBXBuildFile; fileRef = 886F70291551CF920045D68B /* RACGroupedSubscribable.m */; };
-		888FA6A81613417F00CCAF86 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 888FA6A71613417F00CCAF86 /* metamacros.h */; };
-		888FA6A91613417F00CCAF86 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 888FA6A71613417F00CCAF86 /* metamacros.h */; };
 		88977C3E1512914A00A09EC5 /* RACSubscribable.m in Sources */ = {isa = PBXBuildFile; fileRef = 88977C3D1512914A00A09EC5 /* RACSubscribable.m */; };
 		889D0A8015974B2A00F833E3 /* RACSubjectSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 889D0A7F15974B2A00F833E3 /* RACSubjectSpec.m */; };
 		889EECC1161B9296001E94E7 /* NSObject+RACSubscribeSelector.h in Headers */ = {isa = PBXBuildFile; fileRef = 889EECBF161B9296001E94E7 /* NSObject+RACSubscribeSelector.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -844,7 +842,6 @@
 				D026A04515F69FE70052F7FE /* EXTConcreteProtocol.h in Headers */,
 				D026A04D15F69FE70052F7FE /* metamacros.h in Headers */,
 				D0D910CE15F915BD00AD2DDA /* RACSubscribableProtocol.h in Headers */,
-				888FA6A81613417F00CCAF86 /* metamacros.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -863,7 +860,6 @@
 				D026A04E15F69FE70052F7FE /* metamacros.h in Headers */,
 				D0D910CF15F915BD00AD2DDA /* RACSubscribableProtocol.h in Headers */,
 				88FC735616114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
-				888FA6A91613417F00CCAF86 /* metamacros.h in Headers */,
 				889EECC2161B9296001E94E7 /* NSObject+RACSubscribeSelector.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Just a couple of minor fixes for Xcode 4.5, including adding `armv7s` (iPhone 5) to the list of valid architectures.
