### PR TITLE
iOS headers included properly

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -1398,7 +1398,9 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ReactiveCocoa/ReactiveCocoa-Prefix.pch";
 				INSTALL_PATH = "/usr/local/lib/$(PROJECT_NAME)";
+				PRIVATE_HEADERS_FOLDER_PATH = "/usr/local/include/$(PROJECT_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "/usr/local/include/$(PROJECT_NAME)";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "armv6 armv7 armv7s i386";
 			};
@@ -1412,7 +1414,9 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ReactiveCocoa/ReactiveCocoa-Prefix.pch";
 				INSTALL_PATH = "/usr/local/lib/$(PROJECT_NAME)";
+				PRIVATE_HEADERS_FOLDER_PATH = "/usr/local/include/$(PROJECT_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "/usr/local/include/$(PROJECT_NAME)";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "armv6 armv7 armv7s i386";
 			};
@@ -1462,7 +1466,9 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ReactiveCocoa/ReactiveCocoa-Prefix.pch";
 				INSTALL_PATH = "/usr/local/lib/$(PROJECT_NAME)";
+				PRIVATE_HEADERS_FOLDER_PATH = "/usr/local/include/$(PROJECT_NAME)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "/usr/local/include/$(PROJECT_NAME)";
 				SDKROOT = iphoneos;
 				VALID_ARCHS = "armv6 armv7 armv7s i386";
 			};


### PR DESCRIPTION
It's probably not a big deal, but the headers weren't being included in the build for the iOS static library (they weren't included in the target, and the ones that were did not have their availability set correctly). I ended up not needing them in my project, but it might be useful to someone else. You guys make the call :)
