### PR TITLE
Fix KVO crash

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACPropertySubscribingSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACPropertySubscribingSpec.m
@@ -31,13 +31,12 @@ describe(@"-rac_addDeallocDisposable:", ^{
 });
 
 describe(@"+rac_subscribableFor:keyPath:onObject:", ^{
-	it(@"shouldn't crash", ^{
+	it(@"shouldn't crash when the value is changed on a different queue", ^{
 		__block id value;
-		RACSubscribable *sub;
 		@autoreleasepool {
 			RACTestObject *object __attribute__((objc_precise_lifetime)) = [[RACTestObject alloc] init];
-			sub = [NSObject rac_subscribableFor:object keyPath:@"objectValue" onObject:self];
-			[sub subscribeNext:^(id x) {
+			RACSubscribable *subscribable = [NSObject rac_subscribableFor:object keyPath:@"objectValue" onObject:self];
+			[subscribable subscribeNext:^(id x) {
 				value = x;
 			}];
 


### PR DESCRIPTION
If the observed change happened on a different queue from the one results should be delivered on, the observed object could get dealloc'd before the notification was actually sent.
