### PR TITLE
Subject to support producer-consumer pattern.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5FACF1E7164676D100487DEA /* RACStashSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FACF1E5164676D100487DEA /* RACStashSubject.h */; };
+		5FACF1E8164676D100487DEA /* RACStashSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FACF1E5164676D100487DEA /* RACStashSubject.h */; };
+		5FACF1E9164676D100487DEA /* RACStashSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FACF1E6164676D100487DEA /* RACStashSubject.m */; };
+		5FACF1EA164676D100487DEA /* RACStashSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FACF1E6164676D100487DEA /* RACStashSubject.m */; };
 		866557A61557086B00B39EB5 /* RACExtensionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 866557A51557086B00B39EB5 /* RACExtensionsSpec.m */; };
 		88037F8415056328001A5B19 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88CDF7BF15000FCE00163A9F /* Cocoa.framework */; };
 		88037FB81505645C001A5B19 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 88037F8C15056328001A5B19 /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -293,6 +297,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5FACF1E5164676D100487DEA /* RACStashSubject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACStashSubject.h; sourceTree = "<group>"; };
+		5FACF1E6164676D100487DEA /* RACStashSubject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACStashSubject.m; sourceTree = "<group>"; };
 		866557A51557086B00B39EB5 /* RACExtensionsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACExtensionsSpec.m; sourceTree = "<group>"; };
 		88037F8315056328001A5B19 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88037F8C15056328001A5B19 /* ReactiveCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactiveCocoa.h; sourceTree = "<group>"; };
@@ -701,6 +707,8 @@
 				88D4AB481510F8F10011494F /* RACAsyncSubject.m */,
 				883A84D81513964B006DB4C7 /* RACBehaviorSubject.h */,
 				883A84D91513964B006DB4C7 /* RACBehaviorSubject.m */,
+				5FACF1E5164676D100487DEA /* RACStashSubject.h */,
+				5FACF1E6164676D100487DEA /* RACStashSubject.m */,
 				883A84DD1513B5EC006DB4C7 /* RACDisposable.h */,
 				883A84DE1513B5EC006DB4C7 /* RACDisposable.m */,
 				884476E2152367D100958F44 /* RACScopedDisposable.h */,
@@ -890,6 +898,7 @@
 				D0D910CE15F915BD00AD2DDA /* RACSubscribableProtocol.h in Headers */,
 				D0FA57E3162CFED200AC6F42 /* EXTKeyPathCoding.h in Headers */,
 				888439A31634E10D00DED0DB /* RACBlockTrampoline.h in Headers */,
+				5FACF1E7164676D100487DEA /* RACStashSubject.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -944,6 +953,7 @@
 				90AF46ED162553A10054F8A0 /* EXTRuntimeExtensions.h in Headers */,
 				D0FA57E4162CFED200AC6F42 /* EXTKeyPathCoding.h in Headers */,
 				888439A41634E10D00DED0DB /* RACBlockTrampoline.h in Headers */,
+				5FACF1E8164676D100487DEA /* RACStashSubject.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1182,6 +1192,7 @@
 				88FC735716114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
 				889EECC3161B9296001E94E7 /* NSObject+RACSubscribeSelector.m in Sources */,
 				888439A51634E10D00DED0DB /* RACBlockTrampoline.m in Sources */,
+				5FACF1E9164676D100487DEA /* RACStashSubject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1251,6 +1262,7 @@
 				88FC735816114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
 				889EECC4161B9296001E94E7 /* NSObject+RACSubscribeSelector.m in Sources */,
 				888439A61634E10D00DED0DB /* RACBlockTrampoline.m in Sources */,
+				5FACF1EA164676D100487DEA /* RACStashSubject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStashSubject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStashSubject.h
@@ -1,0 +1,22 @@
+//
+//  RACStashSubject.h
+//  ReactiveCocoa
+//
+//  Created by Uri Baghin on 11/4/12.
+//  Copyright (c) 2012 GitHub, Inc. All rights reserved.
+//
+
+#import "RACSubject.h"
+
+
+// A stash subject resends the `next`s it receives to it's subscribers if it has
+// any, or to the first subscriber that subscribes to it if not. It will also
+// replay an error or completion to all new subscribers.
+@interface RACStashSubject : RACSubject
+
+// Creates a new stash subject. If `latestValueOnly` is true only the latest
+// value is stashed when the subject has no subscribers, otherwise all values
+// are stashed.
++ (instancetype)stashSubjectWithLatestValueOnly:(BOOL)latestValueOnly;
+
+@end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStashSubject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStashSubject.m
@@ -1,0 +1,106 @@
+//
+//  RACStashSubject.m
+//  ReactiveCocoa
+//
+//  Created by Uri Baghin on 11/4/12.
+//  Copyright (c) 2012 GitHub, Inc. All rights reserved.
+//
+
+#import "RACStashSubject.h"
+#import "RACSubscribable+Private.h"
+#import "RACSubscriber.h"
+#import "RACTuple.h"
+#import "RACDisposable.h"
+
+@interface RACStashSubject ()
+@property (nonatomic, strong) NSMutableArray *valuesReceived;
+@property (nonatomic, assign) BOOL latestValueOnly;
+@property (assign) BOOL hasCompletedAlready;
+@property (strong) NSError *error;
+@end
+
+
+@implementation RACStashSubject
+
+- (instancetype)init {
+	self = [super init];
+	if(self == nil) return nil;
+	
+	self.valuesReceived = [NSMutableArray array];
+	
+	return self;
+}
+
+
+#pragma mark RACSubscribable
+
+- (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
+	RACDisposable *disposable = [super subscribe:subscriber];
+	NSArray *valuesCopy = nil;
+	@synchronized(self.valuesReceived) {
+		valuesCopy = [self.valuesReceived copy];
+    [self.valuesReceived removeAllObjects];
+	}
+	
+	for(id value in valuesCopy) {
+		[subscriber sendNext:[value isKindOfClass:[RACTupleNil class]] ? nil : value];
+	}
+	
+	if(self.hasCompletedAlready) {
+		[subscriber sendCompleted];
+		[disposable dispose];
+	} else if(self.error != nil) {
+		[subscriber sendError:self.error];
+		[disposable dispose];
+	}
+	
+	return disposable;
+}
+
+
+#pragma mark RACSubscriber
+
+- (void)sendNext:(id)value {
+  __block BOOL nextReceived = NO;
+  [super performBlockOnEachSubscriber:^(id<RACSubscriber> subscriber) {
+    [subscriber sendNext:value];
+    nextReceived = YES;
+  }];
+	
+  if (!nextReceived) {
+    @synchronized(self.valuesReceived) {
+      if (self.latestValueOnly) {
+        [self.valuesReceived removeAllObjects];
+      }
+      [self.valuesReceived addObject:value ? : [RACTupleNil tupleNil]];
+    }
+	}
+}
+
+- (void)sendCompleted {
+	self.hasCompletedAlready = YES;
+	
+	[super sendCompleted];
+}
+
+- (void)sendError:(NSError *)e {
+	self.error = e;
+	
+	[super sendError:e];
+}
+
+
+#pragma mark API
+
+@synthesize valuesReceived;
+@synthesize latestValueOnly;
+@synthesize hasCompletedAlready;
+@synthesize error;
+
++ (instancetype)stashSubjectWithLatestValueOnly:(BOOL)latestValueOnly {
+	RACStashSubject *subject = [self subject];
+	subject.latestValueOnly = latestValueOnly;
+	return subject;
+}
+
+@end


### PR DESCRIPTION
I added a subject to support a producer-consumer pattern. While it adds a sort of pull based behaviour to a push based framework, I thought it useful enough to merge upstream.

I called it `RACStashSubject` instead of the more obvious `RACBufferSubject` to avoid confusion with `<RACSubscribable>`'s `-buffer` methods.

I didn't write it as a subclass of `RACReplaySubject`, despite it being pretty much the same thing, because it doesn't conceptually add any functionality to it, but rather removes some of it, I figured a subclass should at least do what it's superclass does. I can change that if it's not a good idea, or if code reuse trumps it. (It is pretty much the same code in the two classes after all)

I also didn't give it a `capacity` property because I thought it wouldn't make much sense. If the subject represents a changing value, you're probably only interested in the last one. If it represents a signal, you wouldn't want to lose any part of it along the way.
