### PR TITLE
-stashWithStart:stop:replayCount

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.h
@@ -114,6 +114,12 @@ typedef NSInteger RACSubscribableError;
 // subscribable. The window is closed when the close subscribable sends a `next`.
 - (RACSubscribable *)windowWithStart:(id<RACSubscribable>)openSubscribable close:(id<RACSubscribable> (^)(id<RACSubscribable> start))closeBlock;
 
+// Stash the latest `replayCount` `next`s of the subscribable, or unlimited if
+// `replayCount` equals `RACReplaySubjectUnlimitedCapacity`, without sending
+// them. When `stopSubscribable` sends a next, all stashed values are sent.
+// Stashing then resumes when `startSubscribable` sends a next.
+- (id<RACSubscribable>)stashWithStart:(id<RACSubscribable>)startSubscribable stop:(id<RACSubscribable>)stopSubscribable replayUpToCount:(NSUInteger)replayCount;
+
 // Divide the `next`s into buffers with `bufferCount` items each. The `next`
 // will be a RACTuple of values.
 - (RACSubscribable *)buffer:(NSUInteger)bufferCount;


### PR DESCRIPTION
A way of telling a subscribable to hold the values and send them at a later time.

Different from `-windowWithStart:stop:` because that causes the subscribable to discard values sent when a window isn't open.
