### PR TITLE
getReturnValue: always returns an __unsafe_unretained object

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBlockTrampoline.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBlockTrampoline.m
@@ -51,7 +51,7 @@
 
 	[invocation invoke];
 	
-	id returnVal;
+	__unsafe_unretained id returnVal;
 	[invocation getReturnValue:&returnVal];
 	return returnVal;
 }


### PR DESCRIPTION
Fixes memory management crashes from the use of `+combineLatest:reduce:` with a non-nil `reduceBlock`.

I couldn't figure out a good way to unit test this, unfortunately.
