### PR TITLE
Added <RACStream> implementation for NSArray.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5FA0DBC0164E7E5A000222AC /* NSArray+RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FA0DBBE164E7E5A000222AC /* NSArray+RACStream.h */; };
+		5FA0DBC1164E7E5A000222AC /* NSArray+RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FA0DBBE164E7E5A000222AC /* NSArray+RACStream.h */; };
+		5FA0DBC2164E7E5A000222AC /* NSArray+RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA0DBBF164E7E5A000222AC /* NSArray+RACStream.m */; };
+		5FA0DBC3164E7E5A000222AC /* NSArray+RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA0DBBF164E7E5A000222AC /* NSArray+RACStream.m */; };
+		5FA0DBC5164E8170000222AC /* NSArrayRACStreamSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FA0DBC4164E8170000222AC /* NSArrayRACStreamSpec.m */; };
 		866557A61557086B00B39EB5 /* RACExtensionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 866557A51557086B00B39EB5 /* RACExtensionsSpec.m */; };
 		88037F8415056328001A5B19 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88CDF7BF15000FCE00163A9F /* Cocoa.framework */; };
 		88037FB81505645C001A5B19 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 88037F8C15056328001A5B19 /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -340,6 +345,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5FA0DBBE164E7E5A000222AC /* NSArray+RACStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+RACStream.h"; sourceTree = "<group>"; };
+		5FA0DBBF164E7E5A000222AC /* NSArray+RACStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+RACStream.m"; sourceTree = "<group>"; };
+		5FA0DBC4164E8170000222AC /* NSArrayRACStreamSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArrayRACStreamSpec.m; sourceTree = "<group>"; };
 		866557A51557086B00B39EB5 /* RACExtensionsSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACExtensionsSpec.m; sourceTree = "<group>"; };
 		88037F8315056328001A5B19 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		88037F8C15056328001A5B19 /* ReactiveCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReactiveCocoa.h; sourceTree = "<group>"; };
@@ -636,6 +644,8 @@
 		889C04BB155DA37600F19F0C /* Foundation Support */ = {
 			isa = PBXGroup;
 			children = (
+				5FA0DBBE164E7E5A000222AC /* NSArray+RACStream.h */,
+				5FA0DBBF164E7E5A000222AC /* NSArray+RACStream.m */,
 				88CA3EAC1538B88F00AA806C /* NSArray+RACExtensions.h */,
 				88CA3EAD1538B88F00AA806C /* NSArray+RACExtensions.m */,
 				D0E967571641EF9C00FCFF06 /* NSArray+RACSequenceAdditions.h */,
@@ -753,6 +763,7 @@
 				88FC735A16114FFB00F8A774 /* RACSubscriptingAssignmentTrampolineSpec.m */,
 				88442A321608A9AD00636B49 /* RACTestObject.h */,
 				88442A331608A9AD00636B49 /* RACTestObject.m */,
+				5FA0DBC4164E8170000222AC /* NSArrayRACStreamSpec.m */,
 			);
 			path = ReactiveCocoaTests;
 			sourceTree = "<group>";
@@ -1045,6 +1056,7 @@
 				D0E967991641F0AF00FCFF06 /* NSObject+RACExtensions.h in Headers */,
 				D0D487011642550100DD7605 /* RACStream.h in Headers */,
 				888439A31634E10D00DED0DB /* RACBlockTrampoline.h in Headers */,
+				5FA0DBC0164E7E5A000222AC /* NSArray+RACStream.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1107,6 +1119,7 @@
 				D0E967961641F07900FCFF06 /* EXTScope.h in Headers */,
 				D0D487021642550100DD7605 /* RACStream.h in Headers */,
 				888439A41634E10D00DED0DB /* RACBlockTrampoline.h in Headers */,
+				5FA0DBC1164E7E5A000222AC /* NSArray+RACStream.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1358,6 +1371,7 @@
 				D0D487031642550100DD7605 /* RACStream.m in Sources */,
 				888439A51634E10D00DED0DB /* RACBlockTrampoline.m in Sources */,
 				D0EE284D164D906B006954A4 /* RACSubscribableSequence.m in Sources */,
+				5FA0DBC2164E7E5A000222AC /* NSArray+RACStream.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1389,6 +1403,7 @@
 				D05C5C9F16490C4900DE6D3E /* NSNotificationCenter+RACSupport.m in Sources */,
 				D05C5CA016490C4D00DE6D3E /* NSString+RACSupport.m in Sources */,
 				D05C5CA116490C5200DE6D3E /* NSTask+RACSupport.m in Sources */,
+				5FA0DBC5164E8170000222AC /* NSArrayRACStreamSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1449,6 +1464,7 @@
 				D0D487041642550100DD7605 /* RACStream.m in Sources */,
 				888439A61634E10D00DED0DB /* RACBlockTrampoline.m in Sources */,
 				D0EE284E164D906B006954A4 /* RACSubscribableSequence.m in Sources */,
+				5FA0DBC3164E7E5A000222AC /* NSArray+RACStream.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSArray+RACStream.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSArray+RACStream.h
@@ -1,0 +1,13 @@
+//
+//  NSArray+RACStream.h
+//  ReactiveCocoa
+//
+//  Created by Uri Baghin on 11/10/12.
+//  Copyright (c) 2012 GitHub, Inc. All rights reserved.
+//
+
+#import "RACStream.h"
+
+@interface NSArray (RACStream) <RACStream>
+
+@end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSArray+RACStream.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSArray+RACStream.m
@@ -1,0 +1,50 @@
+//
+//  NSArray+RACStream.m
+//  ReactiveCocoa
+//
+//  Created by Uri Baghin on 11/10/12.
+//  Copyright (c) 2012 GitHub, Inc. All rights reserved.
+//
+
+#import "NSArray+RACStream.h"
+
+@implementation NSArray (RACStream)
+
++ (instancetype)empty {
+  return @[];
+}
+
++ (instancetype)return:(id)value {
+  return @[value];
+}
+
+- (instancetype)flattenMap:(id (^)(id, BOOL *))block {
+  NSMutableArray *mapped = [NSMutableArray array];
+  BOOL stop = NO;
+  
+  for (id value in self) {
+    NSArray *result = block(value, &stop);
+    if (!result) {
+      break;
+    }
+    
+		NSAssert([result isKindOfClass:NSArray.class], @"-flattenMap: block returned an object that is not an array: %@", result);
+    
+    [mapped addObject:result];
+    if (stop) {
+      break;
+    }
+  }
+  
+  NSMutableArray *flattened = [NSMutableArray array];
+  for (NSArray *value in mapped) {
+    [flattened addObjectsFromArray:value];
+  }
+  return flattened.copy;
+}
+
+- (instancetype)concat:(id<RACStream>)stream {
+  return [self arrayByAddingObjectsFromArray:(NSArray *)stream];
+}
+
+@end

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/NSArrayRACStreamSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/NSArrayRACStreamSpec.m
@@ -1,0 +1,31 @@
+//
+//  NSArrayRACStreamSpec.m
+//  ReactiveCocoa
+//
+//  Created by Uri Baghin on 11/10/12.
+//  Copyright (c) 2012 GitHub, Inc. All rights reserved.
+//
+
+#import "RACSpecs.h"
+#import "RACStreamExamples.h"
+#import "RACUnit.h"
+
+SpecBegin(NSArrayRACStream)
+
+describe(@"<RACStream>", ^{
+	id verifyValues = ^(NSArray *array, NSArray *expectedValues) {
+		expect(array).notTo.beNil();
+    expect(array).to.equal(expectedValues);
+	};
+  
+  // NSArray cannot be infinite, cheat the tests for now
+	NSArray *infiniteArray = @[[RACUnit defaultUnit], [RACUnit defaultUnit], [RACUnit defaultUnit], [RACUnit defaultUnit], [RACUnit defaultUnit], [RACUnit defaultUnit], [RACUnit defaultUnit]];
+  
+	itShouldBehaveLike(RACStreamExamples, @{
+                     RACStreamExamplesClass: NSArray.class,
+                     RACStreamExamplesVerifyValuesBlock: verifyValues,
+                     RACStreamExamplesInfiniteStream: infiniteArray
+                     });
+});
+
+SpecEnd


### PR DESCRIPTION
Depends on #92, c.f. #107, #108.

Thinking about it longer, it doesn't make sense to me that the only way to treat an `NSArray` as a stream would be to convert it into a `RACSequence`.

I also realized what I did in my own code, converting arrays to subscribables to be able to compose on them, was also wrong and because`<RACSubscribable>` already defines a method to go from an array of subscribables to a subscribable of arrays (well of tuples, but those are much more similar to arrays than either of the other two), there really wasn't any need to. What made me do it at first was that the syntax ended up being more concise because of the methods `<RACSubscribable>` had that `NSArray` didn't.

From a practical point of view, since the basic "list" collection class for cocoa is `NSArray`, you are going to work with them relatively often, and being able to treat them as streams would be handy.

All three are distinct and have properties the others don't. Subscribables are push based, sequences are lazy and arrays are indexable.

Given all these disjointed thoughts, I propose implementing `<RACStream>` on `NSArray` as well.

Some notes about the issue:

I made a new issue instead of commenting on #92 because I find it very related to #107 and #108, and referring those to #92 would have been confusing.
I also did not want to hold up #92 in case there should be to discuss about this.

The code itself is mostly a proof of concept, just to make sure `NSArray` fits in the framework of `<RACStream>` without needing ugly hacks or changes to the existing interface.
