### PR TITLE
Fix -scanWithStart:combine:

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.h
@@ -205,9 +205,9 @@ typedef NSInteger RACSubscribableError;
 // block is called to get a new start object for each subscription.
 - (RACSubscribable *)aggregateWithStartFactory:(id (^)(void))startFactory combine:(id (^)(id running, id next))combineBlock;
 
-// Similar to -aggregateWithStart:combine: with two differences: (1) it sends
-// the combined value with each `next` instead of waiting for the receiving
-// subscribable to complete, and (2) it starts by sending `start`.
+// Similar to -aggregateWithStart:combine: with an important difference: it
+// sends the combined value with each `next` instead of waiting for the
+// receiving subscribable to complete.
 - (RACSubscribable *)scanWithStart:(id)start combine:(id (^)(id running, id next))combineBlock;
 
 // Set the object's keyPath to the value of `next`.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscribableProtocol.m
@@ -735,7 +735,6 @@ NSString * const RACSubscribableErrorDomain = @"RACSubscribableErrorDomain";
 
 	return [RACSubscribable createSubscribable:^(id<RACSubscriber> subscriber) {
 		__block id runningValue = start;
-		[subscriber sendNext:start];
 
 		return [self subscribeNext:^(id x) {
 			runningValue = combineBlock(runningValue, x);

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSubscribableSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSubscribableSpec.m
@@ -680,7 +680,7 @@ describe(@"-scanWithStart:combine:", ^{
 		}];
 		
 		NSArray *values = subscribable.toArray;
-		NSArray *expected = @[ @0, @1, @3, @6, @10 ];
+		NSArray *expected = @[ @1, @3, @6, @10 ];
 		expect(values).to.equal(expected);
 	});
 });


### PR DESCRIPTION
`-scanWithStart:combine:` shouldn't actually start with the start value. That was dumb. Just use it as the starting previous value.
