### PR TITLE
Added <RACStream> implementation for NSArray.

### DIFF
--- a/RACExtensions/NSArray+RACStream.h
+++ b/RACExtensions/NSArray+RACStream.h
@@ -6,7 +6,8 @@
 //  Copyright (c) 2012 GitHub, Inc. All rights reserved.
 //
 
-#import "RACStream.h"
+#import <Foundation/Foundation.h>
+#import <ReactiveCocoa/ReactiveCocoa.h>
 
 @interface NSArray (RACStream) <RACStream>
 

--- a/RACExtensions/NSArray+RACStream.m
+++ b/RACExtensions/NSArray+RACStream.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSArray+RACStream.h"
+#import <ReactiveCocoa/RACBlockTrampoline.h>
 
 @implementation NSArray (RACStream)
 
@@ -45,6 +46,28 @@
 
 - (instancetype)concat:(id<RACStream>)stream {
   return [self arrayByAddingObjectsFromArray:(NSArray *)stream];
+}
+
++ (instancetype)zip:(NSArray *)arrays reduce:(id)reduceBlock {
+	NSUInteger minCount = NSUIntegerMax;
+	for (NSArray *array in arrays) {
+		if (minCount > array.count) {
+			minCount = array.count;
+		}
+	}
+	NSMutableArray *zippedArray = [NSMutableArray arrayWithCapacity:minCount];
+	for (NSUInteger i = 0; i < minCount; ++i) {
+		NSMutableArray *nthValues = [NSMutableArray arrayWithCapacity:arrays.count];
+		for (NSArray *array in arrays) {
+			[nthValues addObject:array[i]];
+		}
+		if (reduceBlock == NULL) {
+			[zippedArray addObject:[RACTuple tupleWithObjectsFromArray:nthValues]];
+		} else {
+			[zippedArray addObject:[RACBlockTrampoline invokeBlock:reduceBlock withArguments:nthValues]];
+		}
+	}
+	return zippedArray.copy;
 }
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		887ACDA8165878A8009190AD /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 887ACDA5165878A7009190AD /* NSInvocation+RACTypeParsing.h */; };
 		887ACDA9165878A8009190AD /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = 887ACDA6165878A7009190AD /* NSInvocation+RACTypeParsing.m */; };
 		887ACDAA165878A8009190AD /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = 887ACDA6165878A7009190AD /* NSInvocation+RACTypeParsing.m */; };
-		888439A31634E10D00DED0DB /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 888439A11634E10D00DED0DB /* RACBlockTrampoline.h */; };
+		888439A31634E10D00DED0DB /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 888439A11634E10D00DED0DB /* RACBlockTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		888439A41634E10D00DED0DB /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = 888439A11634E10D00DED0DB /* RACBlockTrampoline.h */; };
 		888439A61634E10D00DED0DB /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 888439A21634E10D00DED0DB /* RACBlockTrampoline.m */; };
 		88977C3E1512914A00A09EC5 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 88977C3D1512914A00A09EC5 /* RACSignal.m */; };

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/NSArrayRACStreamSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/NSArrayRACStreamSpec.m
@@ -25,7 +25,7 @@ describe(@"<RACStream>", ^{
                      RACStreamExamplesClass: NSArray.class,
                      RACStreamExamplesVerifyValuesBlock: verifyValues,
                      RACStreamExamplesInfiniteStream: infiniteArray
-                     });
+                     }, nil);
 });
 
 SpecEnd


### PR DESCRIPTION
(Reopening #110 since #92 was merged in master.)

It doesn't make sense to me that the only way to treat an `NSArray` as a stream is to convert it into a `RACSequence`.

I also realized what I did in my own code, converting arrays to subscribables to be able to compose on them, was also wrong and because`<RACSubscribable>` already defines a method to go from an array of subscribables to a subscribable of arrays (well of tuples, but those are much more similar to arrays than either of the other two), there really wasn't any need to. What made me do it at first was that the syntax ended up being more concise because of the methods `<RACSubscribable>` had that `NSArray` didn't.

From a practical point of view, since the basic "list" collection class for cocoa is `NSArray`, you are going to work with them relatively often, and being able to treat them as streams would be handy.

All three are distinct and have properties the others don't. Subscribables are push based, sequences are lazy and arrays are indexable.

Given all these disjointed thoughts, I propose implementing `<RACStream>` on `NSArray` as well.
