### PR TITLE
Unify RACSignal#toArray and RACSequence#array in RACStream#toArray

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.h
@@ -29,7 +29,7 @@
 @property (nonatomic, strong, readonly) RACSequence *tail;
 
 // Evaluates the full sequence to produce an equivalently-sized array.
-@property (nonatomic, copy, readonly) NSArray *array;
+- (NSArray *)toArray;
 
 // Evaluates the full sequence on the given scheduler.
 //

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.m
@@ -142,7 +142,7 @@
 
 #pragma mark Extended methods
 
-- (NSArray *)array {
+- (NSArray *)toArray {
 	NSMutableArray *array = [NSMutableArray array];
 	for (id obj in self) {
 		[array addObject:obj];
@@ -192,7 +192,7 @@
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-	[coder encodeObject:self.array forKey:@"array"];
+	[coder encodeObject:self.toArray forKey:@"array"];
 }
 
 #pragma mark NSFastEnumeration

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
@@ -232,6 +232,36 @@ static NSMutableSet *activeSignals() {
 	}];
 }
 
+- (NSArray *)toArray {
+	NSCondition *condition = [[NSCondition alloc] init];
+	condition.name = @(__func__);
+  
+	NSMutableArray *values = [NSMutableArray array];
+	__block BOOL done = NO;
+	[self subscribeNext:^(id x) {
+		[values addObject:x ? : [NSNull null]];
+	} error:^(NSError *error) {
+		[condition lock];
+		done = YES;
+		[condition broadcast];
+		[condition unlock];
+	} completed:^{
+		[condition lock];
+		done = YES;
+		[condition broadcast];
+		[condition unlock];
+	}];
+  
+	[condition lock];
+	while (!done) {
+		[condition wait];
+	}
+  
+	[condition unlock];
+  
+	return [values copy];
+}
+
 #pragma mark RACSignal
 
 - (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignalProtocol.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignalProtocol.h
@@ -263,10 +263,6 @@ typedef NSInteger RACSignalError;
 // latest signal. This is mostly useful when combined with `-flattenMap:`.
 - (id<RACSignal>)switch;
 
-// Add every `next` to an array. Nils are represented by NSNulls. Note that this
-// is a blocking call.
-- (NSArray *)toArray;
-
 // Add every `next` to a sequence. Nils are represented by NSNulls.
 //
 // Returns a sequence which provides values from the signal as they're sent.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignalProtocol.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignalProtocol.m
@@ -57,6 +57,10 @@ NSString * const RACSignalErrorDomain = @"RACSignalErrorDomain";
 	return nil;
 }
 
+- (NSArray *)toArray {
+  return nil;
+}
+
 #pragma mark RACSignal
 
 - (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber {
@@ -936,36 +940,6 @@ NSString * const RACSignalErrorDomain = @"RACSignalErrorDomain";
 			[subscriber sendCompleted];
 		}];
 	}];
-}
-
-- (NSArray *)toArray {
-	NSCondition *condition = [[NSCondition alloc] init];
-	condition.name = @(__func__);
-
-	NSMutableArray *values = [NSMutableArray array];
-	__block BOOL done = NO;
-	[self subscribeNext:^(id x) {
-		[values addObject:x ? : [NSNull null]];
-	} error:^(NSError *error) {
-		[condition lock];
-		done = YES;
-		[condition broadcast];
-		[condition unlock];
-	} completed:^{
-		[condition lock];
-		done = YES;
-		[condition broadcast];
-		[condition unlock];
-	}];
-
-	[condition lock];
-	while (!done) {
-		[condition wait];
-	}
-
-	[condition unlock];
-
-	return [values copy];
 }
 
 - (RACSequence *)sequence {

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
@@ -66,6 +66,10 @@
 // of the same values
 + (instancetype)zip:(NSArray *)streams reduce:(id)reduceBlock;
 
+// Collect values in the stream serializing them in a \c NSArray.
+// Note that this is a blocking call.
+- (NSArray *)toArray;
+
 @concrete
 
 // Maps `block` across the values in the receiver and flattens the result.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
@@ -32,6 +32,10 @@
 	return nil;
 }
 
+- (NSArray *)toArray {
+  return nil;
+}
+
 #pragma mark Concrete methods
 
 - (instancetype)flattenMap:(id (^)(id value))block {

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSequenceExamples.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSequenceExamples.m
@@ -33,7 +33,7 @@ sharedExamplesFor(RACSequenceExamples, ^(NSDictionary *data) {
 	});
 
 	it(@"should return an array", ^{
-		expect(sequence.array).to.equal(values);
+		expect(sequence.toArray).to.equal(values);
 	});
 
 	it(@"should return an immediately scheduled signal", ^{

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSequenceSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSequenceSpec.m
@@ -104,7 +104,7 @@ describe(@"-take:", ^{
 			return sequence;
 		}];
 
-		NSArray *values = [sequence take:1].array;
+		NSArray *values = [sequence take:1].toArray;
 		expect(values).to.equal(@[ RACUnit.defaultUnit ]);
 		expect(valuesTaken).to.equal(1);
 	});


### PR DESCRIPTION
Starting to use sequences, I noticed that it took me more than necessary to find out that `toArray` was `array` for `RACSequence`.

To me the `toArray` API is more convenient to remember than a readonly `array` property. However the opposite could be easily refactored.

As from a logic point of view, every stream could be transformed in an array with a blocking call.

Thoughts?
