### PR TITLE
Enhance +[RACObjCRuntime findMethod:inProtocol:outMethod:] to find @required methods

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACObjCRuntime.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACObjCRuntime.m
@@ -11,9 +11,11 @@
 @implementation RACObjCRuntime
 
 + (void)findMethod:(SEL)method inProtocol:(Protocol *)protocol outMethod:(struct objc_method_description *)outMethod {
-    *outMethod = protocol_getMethodDescription(protocol, method, NO, YES);
+    // First, we look for a @required method. If none is found, we look for an
+    // @optional method.
+    *outMethod = protocol_getMethodDescription(protocol, method, YES, YES);
     if (outMethod->name == NULL) {
-        *outMethod = protocol_getMethodDescription(protocol, method, YES, YES);
+        *outMethod = protocol_getMethodDescription(protocol, method, NO, YES);
     }
 }
 


### PR DESCRIPTION
This previously would only find `@optional` methods. I have added a case to have it look for a `@required` method if no `@optional` one comes up.

(I came across this while working on RAF. It seemed like it would be nice to use `RACObjCRuntime` since it was there, though it's not strictly necessary. It's of course trivial to inline the lookup in my own code if this feature isn't considered necessary for RAC.)
