### PR TITLE
Added -squelch... methods to RACSignal.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -175,6 +175,15 @@ typedef NSInteger RACSignalError;
 // Subscribe to the given signal when an error occurs.
 - (RACSignal *)catchTo:(RACSignal *)signal;
 
+// Do not propagate error.
+- (RACSignal *)squelchError;
+
+// Do not propagate completed.
+- (RACSignal *)squelchCompleted;
+
+// Do not propagate error or completed.
+- (RACSignal *)squelchErrorAndCompleted;
+
 // Returns the first `next`. Note that this is a blocking call.
 - (id)first;
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -213,6 +213,34 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 	}];
 }
 
+- (RACSignal *)squelchError {
+	return [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+		return [self subscribeNext:^(id x) {
+			[subscriber sendNext:x];
+		} completed:^{
+			[subscriber sendCompleted];
+		}];
+	}];
+}
+
+- (RACSignal *)squelchCompleted {
+	return [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+		return [self subscribeNext:^(id x) {
+			[subscriber sendNext:x];
+		} error:^(NSError *error) {
+			[subscriber sendError:error];
+		}];
+	}];
+}
+
+- (RACSignal *)squelchErrorAndCompleted {
+	return [RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+		return [self subscribeNext:^(id x) {
+			[subscriber sendNext:x];
+		}];
+	}];
+}
+
 - (RACSignal *)finally:(void (^)(void))block {
 	NSParameterAssert(block != NULL);
 	

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -1817,4 +1817,48 @@ describe(@"-collect", ^{
 	});
 });
 
+describe(@"-squelch...", ^{
+	__block RACSubject *subject;
+	__block BOOL hasReceivedError;
+	__block BOOL hasReceivedCompleted;
+#define itShouldntForwardError(SIGNAL)\
+	it(@"shouldn't forward error", ^{\
+		[SIGNAL subscribeError:^(NSError *error) {\
+			hasReceivedError = YES;\
+		}];\
+		[subject sendError:nil];\
+		expect(hasReceivedError).to.beFalsy();\
+	});
+#define itShouldntForwardCompleted(SIGNAL)\
+	it(@"shouldn't forward completed", ^{\
+		[SIGNAL subscribeCompleted:^{\
+			hasReceivedCompleted = YES;\
+		}];\
+		[subject sendCompleted];\
+		expect(hasReceivedCompleted).to.beFalsy();\
+	});
+	
+	before(^{
+		subject = [RACSubject subject];
+		hasReceivedError = NO;
+		hasReceivedCompleted = NO;
+	});
+	
+	describe(@"-squelchError", ^{
+		itShouldntForwardError([subject squelchError]);
+	});
+	
+	describe(@"-squelchCompleted", ^{
+		itShouldntForwardCompleted([subject squelchCompleted]);
+	});
+	
+	describe(@"-squelchErrorAndCompleted", ^{
+		itShouldntForwardError([subject squelchErrorAndCompleted]);
+		itShouldntForwardCompleted([subject squelchErrorAndCompleted]);
+	});
+	
+#undef itShouldntForwardError
+#undef itShouldntForwardCompleted
+});
+
 SpecEnd


### PR DESCRIPTION
Simple methods that filter out error and completed from signals so you can subscribe the same subscriber to more of them, or use `-toProperty:onObject` with signals that send error without having to use `-catch...`.
