### PR TITLE
Override implementations of -map: and -filter: in RACArraySequence.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACArraySequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACArraySequence.h
@@ -13,6 +13,6 @@
 
 // Returns a sequence for enumerating over the given array, starting from the
 // given offset. The array will be copied to prevent mutation.
-+ (RACSequence *)sequenceWithArray:(NSArray *)array offset:(NSUInteger)offset;
++ (instancetype)sequenceWithArray:(NSArray *)array offset:(NSUInteger)offset;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.m
@@ -150,7 +150,7 @@
 		NSMutableArray *tails = [NSMutableArray arrayWithCapacity:sequencesArray.count];
 		for (RACSequence *sequence in sequencesArray) {
 			RACSequence *tail = sequence.tail;
-			if (tail == nil || tail == RACSequence.empty) {
+			if (tail == nil || [tail isEqual:self.empty]) {
 				return tail;
 			}
 			[tails addObject:tail];


### PR DESCRIPTION
I used to have `RACStream` implementations for `NSArray`, but since `RACStream` is a class and not a protocol now, I switched my code to convert to and from `RACSequence` instead.

Unfortunately the size of the arrays causes the deallocation of the lazy sequences to overflow the stack.
I implemented these methods overrides to solve that.
