### PR TITLE
Copy headers to the standard location in Xcode 4.3

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,66 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		24532B5F169643E4003585AA /* ReactiveCocoa.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88037F8C15056328001A5B19 /* ReactiveCocoa.h */; };
+		24532B60169643E4003585AA /* NSObject+RACExtensions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8857BB7C152A2747009804CC /* NSObject+RACExtensions.h */; };
+		24532B61169643E4003585AA /* RACSwizzling.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8867D5F7152BDAC300321BD5 /* RACSwizzling.h */; };
+		24532B62169643E4003585AA /* RACSubscriber.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88CDF7FA150019CA00163A9F /* RACSubscriber.h */; };
+		24532B63169643E4003585AA /* RACBlockTrampoline.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 888439A11634E10D00DED0DB /* RACBlockTrampoline.h */; };
+		24532B64169643E4003585AA /* RACMaybe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8820370815096A4F002428D3 /* RACMaybe.h */; };
+		24532B65169643E4003585AA /* RACUnit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 881B37CA152260BF0079220B /* RACUnit.h */; };
+		24532B66169643E4003585AA /* RACTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88B76F8C153726B00053EAE2 /* RACTuple.h */; };
+		24532B67169643E4003585AA /* RACBacktrace.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D02538A115E2D7FB005BACB8 /* RACBacktrace.h */; };
+		24532B68169643E4003585AA /* RACSubscriptingAssignmentTrampoline.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88FC735316114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.h */; };
+		24532B69169643E4003585AA /* NSObject+RACLifting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 886CEAE0163DE942007632D1 /* NSObject+RACLifting.h */; };
+		24532B6A169643E4003585AA /* NSInvocation+RACTypeParsing.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 887ACDA5165878A7009190AD /* NSInvocation+RACTypeParsing.h */; };
+		24532B6B169643E4003585AA /* RACStream.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D486FF1642550100DD7605 /* RACStream.h */; };
+		24532B6C169643E4003585AA /* RACSignal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88CDF80415001CA800163A9F /* RACSignal.h */; };
+		24532B6D169643E4003585AA /* RACSignal+Operations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D910CC15F915BD00AD2DDA /* RACSignal+Operations.h */; };
+		24532B6E169643E4003585AA /* RACMulticastConnection.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88C5A0231692460A0045EF05 /* RACMulticastConnection.h */; };
+		24532B6F169643E4003585AA /* RACGroupedSignal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 886F70281551CF920045D68B /* RACGroupedSignal.h */; };
+		24532B70169643E4003585AA /* RACSubject.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 880B9174150B09190008488E /* RACSubject.h */; };
+		24532B71169643E4003585AA /* RACReplaySubject.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88D4AB3C1510F6C30011494F /* RACReplaySubject.h */; };
+		24532B72169643E4003585AA /* RACBehaviorSubject.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 883A84D81513964B006DB4C7 /* RACBehaviorSubject.h */; };
+		24532B73169643E4003585AA /* RACDisposable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 883A84DD1513B5EC006DB4C7 /* RACDisposable.h */; };
+		24532B74169643E4003585AA /* RACScopedDisposable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 884476E2152367D100958F44 /* RACScopedDisposable.h */; };
+		24532B75169643E4003585AA /* RACCompoundDisposable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 881E86A01669304700667F7B /* RACCompoundDisposable.h */; };
+		24532B76169643E4003585AA /* RACCommand.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 882093E91501E6EE00796685 /* RACCommand.h */; };
+		24532B77169643E4003585AA /* RACSequence.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967671641EF9C00FCFF06 /* RACSequence.h */; };
+		24532B78169643E4003585AA /* RACArraySequence.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967611641EF9C00FCFF06 /* RACArraySequence.h */; };
+		24532B79169643E4003585AA /* RACEagerSequence.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F9743F51694A2460024EB82 /* RACEagerSequence.h */; };
+		24532B7A169643E4003585AA /* RACDynamicSequence.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967631641EF9C00FCFF06 /* RACDynamicSequence.h */; };
+		24532B7B169643E4003585AA /* RACEmptySequence.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967651641EF9C00FCFF06 /* RACEmptySequence.h */; };
+		24532B7C169643E4003585AA /* RACStringSequence.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967691641EF9C00FCFF06 /* RACStringSequence.h */; };
+		24532B7D169643E4003585AA /* RACSignalSequence.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0EE2849164D906B006954A4 /* RACSignalSequence.h */; };
+		24532B7E169643E4003585AA /* RACScheduler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88E2C6B2153C771C00C7493C /* RACScheduler.h */; };
+		24532B7F169643E4003585AA /* RACQueueScheduler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 881E87AA16695C5600667F7B /* RACQueueScheduler.h */; };
+		24532B80169643E4003585AA /* RACImmediateScheduler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 881E87B016695EDF00667F7B /* RACImmediateScheduler.h */; };
+		24532B81169643E5003585AA /* RACSubscriptionScheduler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 881E87C21669635F00667F7B /* RACSubscriptionScheduler.h */; };
+		24532B82169643E5003585AA /* NSArray+RACSequenceAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967571641EF9C00FCFF06 /* NSArray+RACSequenceAdditions.h */; };
+		24532B83169643E5003585AA /* NSDictionary+RACSequenceAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967591641EF9C00FCFF06 /* NSDictionary+RACSequenceAdditions.h */; };
+		24532B84169643E5003585AA /* NSOrderedSet+RACSequenceAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E9675B1641EF9C00FCFF06 /* NSOrderedSet+RACSequenceAdditions.h */; };
+		24532B85169643E5003585AA /* NSSet+RACSequenceAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E9675D1641EF9C00FCFF06 /* NSSet+RACSequenceAdditions.h */; };
+		24532B86169643E5003585AA /* NSString+RACSequenceAdditions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E9675F1641EF9C00FCFF06 /* NSString+RACSequenceAdditions.h */; };
+		24532B87169643E5003585AA /* RACDelegateProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A1FCC3761567DED0008C9686 /* RACDelegateProxy.h */; };
+		24532B88169643E5003585AA /* RACEventTrampoline.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A1FCC36B15673FA3008C9686 /* RACEventTrampoline.h */; };
+		24532B89169643E5003585AA /* UIControl+RACSignalSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88F4425F153DC0450097B4C3 /* UIControl+RACSignalSupport.h */; };
+		24532B8A169643E5003585AA /* UITextField+RACSignalSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88F44264153DCAC50097B4C3 /* UITextField+RACSignalSupport.h */; };
+		24532B8B169643E5003585AA /* UITextView+RACSignalSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A1FCC27215666AA3008C9686 /* UITextView+RACSignalSupport.h */; };
+		24532B8C169643E5003585AA /* NSObject+RACBindings.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88F70066152D2D7B00B32771 /* NSObject+RACBindings.h */; };
+		24532B8D169643E5003585AA /* NSObject+RACKVOWrapper.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8857BB81152A27A9009804CC /* NSObject+RACKVOWrapper.h */; };
+		24532B8E169643E5003585AA /* NSObject+RACPropertySubscribing.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88CDF82C15008C0500163A9F /* NSObject+RACPropertySubscribing.h */; };
+		24532B8F169643E5003585AA /* RACValueTransformer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88DA309515071CBA00C19D0F /* RACValueTransformer.h */; };
+		24532B90169643E5003585AA /* RACObjCRuntime.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A1FCC370156754A7008C9686 /* RACObjCRuntime.h */; };
+		24532B91169643E5003585AA /* NSData+RACSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88442C8716090C1500636B49 /* NSData+RACSupport.h */; };
+		24532B92169643E5003585AA /* NSFileHandle+RACSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88442C8916090C1500636B49 /* NSFileHandle+RACSupport.h */; };
+		24532B93169643E5003585AA /* NSNotificationCenter+RACSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88442C8B16090C1500636B49 /* NSNotificationCenter+RACSupport.h */; };
+		24532B94169643E5003585AA /* NSString+RACSupport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 88442C8D16090C1500636B49 /* NSString+RACSupport.h */; };
+		24532B9616964501003585AA /* JRSwizzle.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8809D6EC15B1F1EE007E32AA /* JRSwizzle.h */; };
+		24532B9716964501003585AA /* EXTConcreteProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D026A04015F69FE70052F7FE /* EXTConcreteProtocol.h */; };
+		24532B9816964501003585AA /* EXTKeyPathCoding.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0FA57E2162CFED200AC6F42 /* EXTKeyPathCoding.h */; };
+		24532B9916964501003585AA /* EXTRuntimeExtensions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D026A04215F69FE70052F7FE /* EXTRuntimeExtensions.h */; };
+		24532B9A16964501003585AA /* EXTScope.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0E967931641F07900FCFF06 /* EXTScope.h */; };
+		24532B9B16964501003585AA /* metamacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = D026A04415F69FE70052F7FE /* metamacros.h */; };
 		5F9743F91694A2460024EB82 /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F9743F61694A2460024EB82 /* RACEagerSequence.m */; };
 		5F9743FA1694A2460024EB82 /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F9743F61694A2460024EB82 /* RACEagerSequence.m */; };
 		866557A61557086B00B39EB5 /* RACExtensionsSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 866557A51557086B00B39EB5 /* RACExtensionsSpec.m */; };
@@ -322,6 +382,75 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		24532B5C1696436C003585AA /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = include/ReactiveCocoa;
+			dstSubfolderSpec = 16;
+			files = (
+				24532B9616964501003585AA /* JRSwizzle.h in CopyFiles */,
+				24532B9716964501003585AA /* EXTConcreteProtocol.h in CopyFiles */,
+				24532B9816964501003585AA /* EXTKeyPathCoding.h in CopyFiles */,
+				24532B9916964501003585AA /* EXTRuntimeExtensions.h in CopyFiles */,
+				24532B9A16964501003585AA /* EXTScope.h in CopyFiles */,
+				24532B9B16964501003585AA /* metamacros.h in CopyFiles */,
+				24532B5F169643E4003585AA /* ReactiveCocoa.h in CopyFiles */,
+				24532B60169643E4003585AA /* NSObject+RACExtensions.h in CopyFiles */,
+				24532B61169643E4003585AA /* RACSwizzling.h in CopyFiles */,
+				24532B62169643E4003585AA /* RACSubscriber.h in CopyFiles */,
+				24532B63169643E4003585AA /* RACBlockTrampoline.h in CopyFiles */,
+				24532B64169643E4003585AA /* RACMaybe.h in CopyFiles */,
+				24532B65169643E4003585AA /* RACUnit.h in CopyFiles */,
+				24532B66169643E4003585AA /* RACTuple.h in CopyFiles */,
+				24532B67169643E4003585AA /* RACBacktrace.h in CopyFiles */,
+				24532B68169643E4003585AA /* RACSubscriptingAssignmentTrampoline.h in CopyFiles */,
+				24532B69169643E4003585AA /* NSObject+RACLifting.h in CopyFiles */,
+				24532B6A169643E4003585AA /* NSInvocation+RACTypeParsing.h in CopyFiles */,
+				24532B6B169643E4003585AA /* RACStream.h in CopyFiles */,
+				24532B6C169643E4003585AA /* RACSignal.h in CopyFiles */,
+				24532B6D169643E4003585AA /* RACSignal+Operations.h in CopyFiles */,
+				24532B6E169643E4003585AA /* RACMulticastConnection.h in CopyFiles */,
+				24532B6F169643E4003585AA /* RACGroupedSignal.h in CopyFiles */,
+				24532B70169643E4003585AA /* RACSubject.h in CopyFiles */,
+				24532B71169643E4003585AA /* RACReplaySubject.h in CopyFiles */,
+				24532B72169643E4003585AA /* RACBehaviorSubject.h in CopyFiles */,
+				24532B73169643E4003585AA /* RACDisposable.h in CopyFiles */,
+				24532B74169643E4003585AA /* RACScopedDisposable.h in CopyFiles */,
+				24532B75169643E4003585AA /* RACCompoundDisposable.h in CopyFiles */,
+				24532B76169643E4003585AA /* RACCommand.h in CopyFiles */,
+				24532B77169643E4003585AA /* RACSequence.h in CopyFiles */,
+				24532B78169643E4003585AA /* RACArraySequence.h in CopyFiles */,
+				24532B79169643E4003585AA /* RACEagerSequence.h in CopyFiles */,
+				24532B7A169643E4003585AA /* RACDynamicSequence.h in CopyFiles */,
+				24532B7B169643E4003585AA /* RACEmptySequence.h in CopyFiles */,
+				24532B7C169643E4003585AA /* RACStringSequence.h in CopyFiles */,
+				24532B7D169643E4003585AA /* RACSignalSequence.h in CopyFiles */,
+				24532B7E169643E4003585AA /* RACScheduler.h in CopyFiles */,
+				24532B7F169643E4003585AA /* RACQueueScheduler.h in CopyFiles */,
+				24532B80169643E4003585AA /* RACImmediateScheduler.h in CopyFiles */,
+				24532B81169643E5003585AA /* RACSubscriptionScheduler.h in CopyFiles */,
+				24532B82169643E5003585AA /* NSArray+RACSequenceAdditions.h in CopyFiles */,
+				24532B83169643E5003585AA /* NSDictionary+RACSequenceAdditions.h in CopyFiles */,
+				24532B84169643E5003585AA /* NSOrderedSet+RACSequenceAdditions.h in CopyFiles */,
+				24532B85169643E5003585AA /* NSSet+RACSequenceAdditions.h in CopyFiles */,
+				24532B86169643E5003585AA /* NSString+RACSequenceAdditions.h in CopyFiles */,
+				24532B87169643E5003585AA /* RACDelegateProxy.h in CopyFiles */,
+				24532B88169643E5003585AA /* RACEventTrampoline.h in CopyFiles */,
+				24532B89169643E5003585AA /* UIControl+RACSignalSupport.h in CopyFiles */,
+				24532B8A169643E5003585AA /* UITextField+RACSignalSupport.h in CopyFiles */,
+				24532B8B169643E5003585AA /* UITextView+RACSignalSupport.h in CopyFiles */,
+				24532B8C169643E5003585AA /* NSObject+RACBindings.h in CopyFiles */,
+				24532B8D169643E5003585AA /* NSObject+RACKVOWrapper.h in CopyFiles */,
+				24532B8E169643E5003585AA /* NSObject+RACPropertySubscribing.h in CopyFiles */,
+				24532B8F169643E5003585AA /* RACValueTransformer.h in CopyFiles */,
+				24532B90169643E5003585AA /* RACObjCRuntime.h in CopyFiles */,
+				24532B91169643E5003585AA /* NSData+RACSupport.h in CopyFiles */,
+				24532B92169643E5003585AA /* NSFileHandle+RACSupport.h in CopyFiles */,
+				24532B93169643E5003585AA /* NSNotificationCenter+RACSupport.h in CopyFiles */,
+				24532B94169643E5003585AA /* NSString+RACSupport.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8820937F1501C94E00796685 /* Copy Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1167,6 +1296,7 @@
 				88F440A7153DAC820097B4C3 /* Sources */,
 				88F440A8153DAC820097B4C3 /* Frameworks */,
 				88F440A9153DAC820097B4C3 /* Headers */,
+				24532B5C1696436C003585AA /* CopyFiles */,
 			);
 			buildRules = (
 			);

--- a/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
@@ -36,7 +36,7 @@
 #import <ReactiveCocoa/RACCompoundDisposable.h>
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <ReactiveCocoa/libextobjc/extobjc/EXTKeyPathCoding.h>
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import <ReactiveCocoa/UIControl+RACSignalSupport.h>
 #import <ReactiveCocoa/UITextField+RACSignalSupport.h>
 #import <ReactiveCocoa/UITextView+RACSignalSupport.h>


### PR DESCRIPTION
From Xcode 4.3 onwards, Static Libraries have a copy files phase to copy the headers to the $(PRODUCTS_DIR)/include/$(TARGET_NAME). This is searched for headers by projects using the static library. This saves the need to add search paths to projects using ReactiveCocoa, making it easier to add ReactiveCocoa to a project.
