### PR TITLE
Rename -switch > -switchToLatest

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -229,7 +229,7 @@ extern const NSInteger RACSignalErrorTimedOut;
 //
 // Returns a signal which passes through `next`s and `error`s from the latest
 // signal sent by the receiver, and sends `completed` when the receiver completes.
-- (RACSignal *)switch;
+- (RACSignal *)switchToLatest;
 
 // Switches between `trueSignal` and `falseSignal` based on the latest value
 // sent by `boolSignal`.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -758,11 +758,11 @@ static RACDisposable *concatPopNextSignal(NSMutableArray *signals, BOOL *outerDo
 	}] setNameWithFormat:@"[%@] -takeUntil: %@", self.name, signalTrigger];
 }
 
-- (RACSignal *)switch {
+- (RACSignal *)switchToLatest {
 	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
 		__block RACDisposable *innerDisposable = nil;
 		RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
-			NSAssert([x isKindOfClass:RACSignal.class] || x == nil, @"-switch requires that the source signal (%@) send signals. Instead we got: %@", self, x);
+			NSAssert([x isKindOfClass:RACSignal.class] || x == nil, @"-switchToLatest requires that the source signal (%@) send signals. Instead we got: %@", self, x);
 			
 			[innerDisposable dispose], innerDisposable = nil;
 			
@@ -781,7 +781,7 @@ static RACDisposable *concatPopNextSignal(NSMutableArray *signals, BOOL *outerDo
 			[innerDisposable dispose];
 			[selfDisposable dispose];
 		}];
-	}] setNameWithFormat:@"[%@] -switch", self.name];
+	}] setNameWithFormat:@"[%@] -switchToLatest", self.name];
 }
 
 + (RACSignal *)if:(RACSignal *)boolSignal then:(RACSignal *)trueSignal else:(RACSignal *)falseSignal {
@@ -795,7 +795,7 @@ static RACDisposable *concatPopNextSignal(NSMutableArray *signals, BOOL *outerDo
 			
 			return (value.boolValue ? trueSignal : falseSignal);
 		}]
-		switch]
+		switchToLatest]
 		setNameWithFormat:@"+if: %@ then: %@ else: %@", boolSignal, trueSignal, falseSignal];
 }
 

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -1278,7 +1278,7 @@ describe(@"-flatten:", ^{
 	});
 });
 
-describe(@"-switch", ^{
+describe(@"-switchToLatest", ^{
 	__block RACSubject *subject;
 
 	__block NSMutableArray *values;
@@ -1292,7 +1292,7 @@ describe(@"-switch", ^{
 		lastError = nil;
 		completed = NO;
 
-		[[subject switch] subscribeNext:^(id x) {
+		[[subject switchToLatest] subscribeNext:^(id x) {
 			expect(lastError).to.beNil();
 			expect(completed).to.beFalsy();
 


### PR DESCRIPTION
Completes #254.

I got cold feet about renaming `+if:then:else:` after trying it out in a section of code. I don't like the structure that `-whenTrue:whenFalse:` enforces.

Seemed like the general opinion was that `+return:` is fine, so that's untouched as well.
