### PR TITLE
Fixed imports in RACExtensions.

### DIFF
--- a/RACExtensions/NSNotificationCenter+RACSupport.m
+++ b/RACExtensions/NSNotificationCenter+RACSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSNotificationCenter+RACSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 
 @implementation NSNotificationCenter (RACSupport)
 

--- a/RACExtensions/NSTask+RACSupport.m
+++ b/RACExtensions/NSTask+RACSupport.m
@@ -9,7 +9,7 @@
 #import "NSTask+RACSupport.h"
 #import "NSFileHandle+RACSupport.h"
 #import "NSNotificationCenter+RACSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 
 NSString * const NSTaskRACSupportErrorDomain = @"NSTaskRACSupportErrorDomain";
 


### PR DESCRIPTION
The extensions import `EXTScope.h` as user header, but since they're not compiled together with the rest of the framework, and have to be compiled with the including project, the imports should treat it as a system header exported by RAC.
