### PR TITLE
-zip:reduce completion depends on order of zipped signals

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
@@ -319,7 +319,6 @@ static NSMutableSet *activeSignals() {
 					if ([completedBySignal containsIndex:i]) {
 						[subscriber sendCompleted];
 					}
-					continue;
 				}
 			}
 		};

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -1840,10 +1840,10 @@ describe(@"+zip:reduce:", ^{
 		expect(hasSentCompleted).to.beTruthy();
 	});
 	
-    it(@"outcome should not be dependent on order of signals", ^{
-        [subject2 sendCompleted];
-        expect(hasSentCompleted).to.beTruthy();
-    });
+	it(@"outcome should not be dependent on order of signals", ^{
+		[subject2 sendCompleted];
+		expect(hasSentCompleted).to.beTruthy();
+	});
     
 	it(@"should forward errors sent earlier than (time-wise) and before (position-wise) a complete", ^{
 		send2NextAndErrorTo1();


### PR DESCRIPTION
`-zip:reduce:` completion should not depend on the order of input signals.

It seems like this is one of those mean operations that contain a lot of surprises for me. :pill:
