### PR TITLE
Pass through names when using -logNext/Error/Completed

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
@@ -483,21 +483,21 @@ static NSMutableSet *activeSignals() {
 }
 
 - (RACSignal *)logNext {
-	return [self doNext:^(id x) {
+	return [[self doNext:^(id x) {
 		NSLog(@"%@ next: %@", self, x);
-	}];
+	}] setNameWithFormat:@"%@", self.name];
 }
 
 - (RACSignal *)logError {
-	return [self doError:^(NSError *error) {
+	return [[self doError:^(NSError *error) {
 		NSLog(@"%@ error: %@", self, error);
-	}];
+	}] setNameWithFormat:@"%@", self.name];
 }
 
 - (RACSignal *)logCompleted {
-	return [self doCompleted:^{
+	return [[self doCompleted:^{
 		NSLog(@"%@ completed", self);
-	}];
+	}] setNameWithFormat:@"%@", self.name];
 }
 
 @end


### PR DESCRIPTION
This way, they don't add to the existing name in a confusing way.
