### PR TITLE
Change -bindTo: to not send unnecessary starting value.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBinding.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBinding.h
@@ -22,6 +22,9 @@
 // Binds the receiver to `binding` by subscribing each one to the other's
 // changes.
 //
+// When called, `binding`s current value will be sent to the receiver and the
+// receiver's current value will be discarded.
+//
 // Returns a disposable that can be used to stop the binding.
 - (RACDisposable *)bindTo:(RACBinding *)binding;
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBinding.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBinding.m
@@ -76,7 +76,7 @@
 
 - (RACDisposable *)bindTo:(RACBinding *)binding {
 	RACDisposable *bindingDisposable = [binding subscribe:self];
-	RACDisposable *selfDisposable = [self subscribe:binding];
+	RACDisposable *selfDisposable = [[self skip:1] subscribe:binding];
 	return [RACDisposable disposableWithBlock:^{
 		[bindingDisposable dispose];
 		[selfDisposable dispose];


### PR DESCRIPTION
Also detailed a bit better what the method does. It wasn't very clear compared to the `RACBind` documentation.

The current implementation works fine because even though the receiver's current value gets propagated, which is not supposed to happen, it is then overwritten by the other binding's value, so everything works as expected, but it falls apart when multiple schedulers are involved. This makes it a bit more correct and robust.

I haven't added any test for that because I don't want to give the impression the bindings are meant to work across multiple schedulers.
