### PR TITLE
Describe good signal naming conventions

### DIFF
--- a/Documentation/DesignGuidelines.md
+++ b/Documentation/DesignGuidelines.md
@@ -271,7 +271,7 @@ change the semantics. Signal properties should usually be named after events
 noun-like names (e.g., `-currentText`). A method declaration indicates that the
 signal might not be kept around, hinting that work is performed at the time of
 subscription. If the signal sends multiple values, the noun should be pluralized
-(e.g., `-currentViewModels`).
+(e.g., `-currentModels`).
 
 **Signals with side effects** should be returned from methods that have
 verb-like names (e.g., `-logIn`). The verb indicates that the method is not


### PR DESCRIPTION
Part of #304. Completes #308.

[Rendered Markdown](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/signal-naming/Documentation/DesignGuidelines.md#use-descriptive-declarations-for-methods-and-properties-that-return-a-signal)

@ReactiveCocoa/reactivecocoa This one probably requires more group review than the rest of the guidelines, since this is adding a convention where there wasn't really one before. Lemme know if anything seems unpalatable here.
