### PR TITLE
RACSignal contract

### DIFF
--- a/Documentation/DesignGuidelines.md
+++ b/Documentation/DesignGuidelines.md
@@ -262,8 +262,11 @@ a valid [RACScheduler][].
 
 If the subscriber's thread already has a [+currentScheduler][RACScheduler],
 scheduling takes place immediately; otherwise, scheduling occurs as soon as
-possible on a background scheduler. See the documentation for
-[-subscribe:][RACSignal] for more information.
+possible on a background scheduler. Note that the main thread is always
+associated with the [+mainThreadScheduler][RACScheduler], so subscription will
+always be immediate there.
+
+See the documentation for [-subscribe:][RACSignal] for more information.
 
 ### Errors are propagated immediately
 


### PR DESCRIPTION
Part of #304.

[Rendered Markdown](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/signal-contract/Documentation/DesignGuidelines.md#the-racsignal-contract)

Note that this doesn't include the "Side effects occur for each subscription" section, because @thenikso is already working on that in #306.
