### PR TITLE
Added note about archive builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ To add RAC to your application:
     * **On OS X**, add `ReactiveCocoa.framework`. RAC must also be added to any
       "Copy Frameworks" build phase. If you don't already have one, simply add
       a "Copy Files" build phase and target the "Frameworks" destination.
+ 1. Add `$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include
+    $(inherited)` to the "Header Search Paths" build setting (this is only
+		necessary for archive builds, but it has no negative effect otherwise).
  1. **If you added RAC to a project (not a workspace)**, you will also need to
     add the appropriate RAC target to the "Target Dependencies" of your
     application.


### PR DESCRIPTION
Follow up from [#13](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/13#issuecomment-13312180).

I wanted to explain the point of `$(inherited)`, but I couldn't phrase it clearly and concisely enough and adding it when it's not needed or is already there shouldn't have any adverse effect. People who know what it's for can decide whether they want it or not, people who don't can just copy and paste the whole thing and not get any errors because of overwritten settings and such.
