### PR TITLE
Add README note on recursive submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ overview and more in-depth information about how it all works in practice.
 To add RAC to your application:
 
  1. Add the ReactiveCocoa repository as a submodule of your application's
-    repository.
+    repository. Make sure to update the submodules within with `git submodule update
+    -i --recursive`
  1. Drag and drop `ReactiveCocoaFramework/ReactiveCocoa.xcodeproj` into your
     application's Xcode project or workspace.
  1. On the "Build Phases" tab of your application target, add RAC to the "Link


### PR DESCRIPTION
As libextobjc also contains submodules, `git submodule add ...` may not pick them up automatically, causing the build to fail with perhaps not immediately obvious errors in the @strongify and friends macros. 

Yay git submodules! :neckbeard: 
