### PR TITLE
Make -[NSString rac_sequence] work with composed characters

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACSequenceAdditions.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACSequenceAdditions.h
@@ -13,7 +13,7 @@
 @interface NSString (RACSequenceAdditions)
 
 // Creates and returns a sequence containing strings corresponding to each
-// character in the receiver.
+// composed character sequence in the receiver.
 //
 // Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStringSequence.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStringSequence.m
@@ -50,20 +50,10 @@
 	NSUInteger substringLength = self.string.length - self.offset;
 	NSMutableArray *array = [NSMutableArray arrayWithCapacity:substringLength];
 
-	@autoreleasepool {
-		unichar *characters = malloc(sizeof(*characters) * substringLength);
-		@onExit {
-			free(characters);
-		};
-		
-		[self.string getCharacters:characters range:NSMakeRange(self.offset, substringLength)];
+	[self.string enumerateSubstringsInRange:NSMakeRange(self.offset, substringLength) options:NSStringEnumerationByComposedCharacterSequences usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
+		[array addObject:substring];
+	}];
 
-		for (NSUInteger i = 0; i < substringLength; i++) {
-			NSString *charStr = [NSString stringWithCharacters:characters + i length:1];
-			[array addObject:charStr];
-		}
-	}
-	
 	return [array copy];
 }
 

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSequenceAdditionsSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSequenceAdditionsSpec.m
@@ -239,6 +239,12 @@ describe(@"NSString sequences", ^{
 			};
 		});
 	});
+
+	it(@"should work with composed characters", ^{
+		NSString  *string = @"\u2665\uFE0F\u2666\uFE0F";
+		NSArray *expectedSequence = @[ @"\u2665\uFE0F", @"\u2666\uFE0F" ];
+		expect(string.rac_sequence.array).to.equal(expectedSequence);
+	});
 });
 
 SpecEnd


### PR DESCRIPTION
The old implementation was character-based, this one uses `enumerateSubstringsInRange:options:usingBlock:` with the `NSStringEnumerationByComposedCharacterSequences` option so composed character sequences will be yielded properly. :heart:
