### PR TITLE
Change RACPropertySubject to inherit +subject constructor.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACPropertySubject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACPropertySubject.h
@@ -16,9 +16,10 @@
 // Values sent to a RACPropertySubject are also sent to it's bindings'
 // subscribers. Values sent to a RACProperty's bindings are also sent to the
 // RACPropertySubject.
-//
-// Newly created property subjects start with a nil value.
 @interface RACPropertySubject : RACSubject
+
+// Returns a new RACPropertySubject with a starting value of `nil`.
++ (instancetype)property;
 
 // Returns a new binding of the RACPropertySubject.
 - (RACBinding *)binding;

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACPropertySubject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACPropertySubject.m
@@ -93,6 +93,10 @@
 	return self;
 }
 
++ (instancetype)property {
+	return [self subject];
+}
+
 - (RACBinding *)binding {
 	return [[RACBinding alloc] initWithSignal:self.signal subscriber:self.subscriber];
 }

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACPropertySubjectSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACPropertySubjectSpec.m
@@ -17,8 +17,16 @@ SpecBegin(RACPropertySubject)
 describe(@"RACPropertySubject", ^{
 	itShouldBehaveLike(RACPropertySubjectExamples, ^{
 		return @{
-			RACPropertySubjectExampleGetPropertyBlock: [^{ return [RACPropertySubject subject]; } copy]
+			RACPropertySubjectExampleGetPropertyBlock: [^{ return [RACPropertySubject property]; } copy]
 		};
+	});
+	
+	describe(@"created with +subject", ^{
+		itShouldBehaveLike(RACPropertySubjectExamples, ^{
+			return @{
+				RACPropertySubjectExampleGetPropertyBlock: [^{ return [RACPropertySubject subject]; } copy]
+			};
+		});
 	});
 });
 


### PR DESCRIPTION
Fixes #343. 

Breaking change, new `RACPropertySubject`s are now created with `+subject` instead of `+property`.
