### PR TITLE
Add type information to the RAC() macro

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h
@@ -35,7 +35,6 @@
 @interface RACSubscriptingAssignmentTrampoline : NSObject
 
 + (instancetype)trampoline;
-
-- (void)setObject:(id)obj forKeyedSubscript:(id<NSCopying>)key;
+- (void)setObject:(RACSignal *)signal forKeyedSubscript:(id<NSCopying>)key;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptingAssignmentTrampoline.m
@@ -49,10 +49,10 @@
 	return trampoline;
 }
 
-- (void)setObject:(id)obj forKeyedSubscript:(RACSubscriptingAssignmentObjectKeyPathPair *)pair {
+- (void)setObject:(RACSignal *)signal forKeyedSubscript:(RACSubscriptingAssignmentObjectKeyPathPair *)pair {
 	NSParameterAssert([pair isKindOfClass:RACSubscriptingAssignmentObjectKeyPathPair.class]);
 
-	[pair.object rac_deriveProperty:pair.keyPath from:obj];
+	[pair.object rac_deriveProperty:pair.keyPath from:signal];
 }
 
 @end


### PR DESCRIPTION
Should prevent issues like #344.
