### PR TITLE
Weakly reference the subscriber

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.m
@@ -30,7 +30,10 @@ static const void *RACObjectDisposables = &RACObjectDisposables;
 		RACDisposable *KVODisposable = [RACDisposable disposableWithBlock:^{
 			[KVOTrampoline stopObserving];
 		}];
+
+		@weakify(subscriber);
 		RACDisposable *deallocDisposable = [RACDisposable disposableWithBlock:^{
+			@strongify(subscriber);
 			[KVODisposable dispose];
 			[subscriber sendCompleted];
 		}];

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.h
@@ -17,7 +17,8 @@
 // for most uses.
 //
 // Implementors of this protocol may receive messages and values from multiple
-// threads simultaneously, and so should be thread-safe.
+// threads simultaneously, and so should be thread-safe. Subscribers will also
+// be weakly referenced so implementations must allow that.
 @protocol RACSubscriber <NSObject>
 @required
 


### PR DESCRIPTION
Not a leak per se, but we would end up keeping the subscriber (and subsequently, all the data captured in its blocks) around longer than we needed to.
