### PR TITLE
Fix -toProperty:onObject: disposal

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -734,6 +734,10 @@ static RACDisposable *concatPopNextSignal(NSMutableArray *signals, BOOL *outerDo
 
 		// Log the error if we're running with assertions disabled.
 		NSLog(@"Received error from %@ in binding for key path \"%@\" on %@: %@", self, keyPath, object, error);
+
+		[disposable dispose];
+	} completed:^{
+		[disposable dispose];
 	}];
 
 	if (subscriptionDisposable != nil) [disposable addDisposable:subscriptionDisposable];


### PR DESCRIPTION
Derp. I introduced this in #357

I was thinking we didn't have to manually dispose since completion or error would do it for us, but of course that's only true for the subscription disposable.
