### PR TITLE
Full KVO support of `RACAble...`

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.m
@@ -26,7 +26,8 @@ static const void *RACObjectScopedDisposable = &RACObjectScopedDisposable;
 	RACSignal *signal =  [self rac_signalWithChangesFor:object keyPath:keyPath observer:observer];
 	
 	signal = [signal filter:^BOOL(NSDictionary *change) {
-		BOOL isInitial = [change objectForKey:NSKeyValueChangeOldKey] == nil;
+		NSKeyValueChange kind = (NSKeyValueChange)[[change objectForKey:NSKeyValueChangeKindKey] integerValue];
+		BOOL isInitial = (kind == NSKeyValueChangeSetting && [change objectForKey:NSKeyValueChangeOldKey] == nil);
 		BOOL isPrior = [[change objectForKey:NSKeyValueChangeNotificationIsPriorKey] boolValue];
 		switch (type) {
 			case RACAbleTypeCurrent:


### PR DESCRIPTION
Discussed in Issue #212.

I implemented few other `RACAble...` macros to support common uses of KVO options and also modified the underlaying methods for getting observing signals.

New `RACAbleType` enum allows you to request the signal with different returning values on different KVO change events. Note that not every single combination is included. Comments for each of the enum value tells you what objects the signal will return. If the signals returns multiple values, they are grouped using `RACTuple`.

Added method `+rac_signalWithChangesFor:keyPath:observer:` that returns signal returning raw KVO change dictionary, so you can observe anything (not all cases are included in the enum, but it's enough 99.99% of time).

Modified `-rac_signalForKeyPath:observer:type:` appends `-filter:` and `-map:` streams to the raw KVO signal, so on output, you are receiving desired values (based on given type).
