### PR TITLE
Add convenience method for delayed schedule on RACScheduler

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.h
@@ -85,7 +85,7 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 // Schedule the given block for execution on the scheduler after the delay.
 //
 // Converts seconds to nanoseconds and calls `-after:schedule:`.
-- (RACDisposable *)delay:(NSTimeInterval)delay schedule:(void (^)(void))block;
+- (RACDisposable *)afterDelay:(NSTimeInterval)delay schedule:(void (^)(void))block;
 
 // Schedule the given recursive block for execution on the scheduler. The
 // scheduler will automatically flatten any recursive scheduling into iteration

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.m
@@ -105,7 +105,7 @@ const void *RACSchedulerCurrentSchedulerKey = &RACSchedulerCurrentSchedulerKey;
 	return nil;
 }
 
-- (RACDisposable *)delay:(NSTimeInterval)delay schedule:(void (^)(void))block {
+- (RACDisposable *)afterDelay:(NSTimeInterval)delay schedule:(void (^)(void))block {
 	dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC));
 	return [self after:when schedule:block];
 }


### PR DESCRIPTION
Method `-after:schedule:` takes `dispatch_time_t` argument that is in nanoseconds.
New method `-delay:schedule:` takes `NSTimeInterval` as argument (in seconds) and
calls `-after:schedule:` with calculated dispatch time. Method is implemented
in superclass and is not abstract.
