### PR TITLE
Catch errors to empty

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
@@ -133,11 +133,13 @@
 			NSAssert(signal != nil, @"signalBlock returned a nil signal");
 
 			return [[[signal
-				doError:^(NSError *error) {
+				catch:^(NSError *error) {
 					[RACScheduler.mainThreadScheduler schedule:^{
 						@strongify(self);
 						if (self != nil) [self->_errors sendNext:error];
 					}];
+
+					return [RACSignal empty];
 				}]
 				finally:^{
 					@strongify(self);

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m
@@ -215,6 +215,27 @@ describe(@"with a signal block", ^{
 		expect(receivedEvent).to.beFalsy();
 	});
 
+	it(@"should catch all errors", ^{
+		RACSignal *result = [command addSignalBlock:^(id _) {
+			return [RACSignal error:[NSError errorWithDomain:@""code:-1 userInfo:nil]];
+		}];
+
+		__block BOOL errorsGotError = NO;
+		[command.errors subscribeNext:^(id _) {
+			errorsGotError = YES;
+		}];
+
+		__block BOOL resultGotError = NO;
+		[[result switchToLatest] subscribeError:^(id _) {
+			resultGotError = YES;
+		}];
+
+		[command execute:nil];
+
+		expect(errorsGotError).will.beTruthy();
+		expect(resultGotError).to.beFalsy();
+	});
+
 	it(@"should dealloc without subscribers", ^{
 		__block BOOL disposed = NO;
 


### PR DESCRIPTION
Catch errors from commands.

We're already funneling errors out into a separate signal to make it easy for callers to handle them differently. I think it also makes sense to catch errors by default, so that this Just Works:

``` objc
RACSignal *result = [command addSignalBlock:^(id x) {
    return [x doStuff];
}];
RAC(self.result) = [result switchToLatest];
RAC(self.errorLabel.text) = [command.errors map:^(NSError *error) {
    return [NSString stringWithFormat:@"An error occurred: %@", error];
}];
```

There are 3 cases, as I see it:
1. It's fine to catch errors to `+empty`: this handles it with aplomb.
2. We need to catch to something else: we'll have to do the error-funneling ourselves, but that was already the case if we did any catching.
3. We really do want errors in the same stream: fine, just merge the result and errors signals.

So we handle the simple case out of the box. For the more complex case, we're not adding any more work than we had before.

This is obviously a change in behavior. We could lean into it, or offer it as an option. I think this is the Right Behavior by default.
