### PR TITLE
Update README to mention that iOS targets need -ObjC Linker Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ To add RAC to your application:
  1. Add `$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include
     $(inherited)` to the "Header Search Paths" build setting (this is only
     necessary for archive builds, but it has no negative effect otherwise).
- 1. **For iOS Targets**, Add `-ObjC` to the *Other Linker Flags* Build Setting.
+ 1. **For iOS targets**, add `-ObjC` to the "Other Linker Flags" build setting.
  1. **If you added RAC to a project (not a workspace)**, you will also need to
     add the appropriate RAC target to the "Target Dependencies" of your
     application.


### PR DESCRIPTION
The error from missing this setting is not obvious :) See #394.

[Rendered Markdown](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/ea9e4e5cab821ebfad32f6a1759a3b7b0c894fa8/README.md)
