### PR TITLE
Fix text signal cycle

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACTextSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACTextSignalSupport.m
@@ -27,10 +27,10 @@
 				[NSNotificationCenter.defaultCenter removeObserver:observer];
 			}];
 		}]
-		startWith:self]
 		map:^(NSControl *control) {
 			return [control.stringValue copy];
 		}]
+		startWith:[self.stringValue copy]]
 		setNameWithFormat:@"%@ -rac_textSignal", self];
 }
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSText+RACSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSText+RACSignalSupport.m
@@ -27,10 +27,10 @@
 				[NSNotificationCenter.defaultCenter removeObserver:observer];
 			}];
 		}]
-		startWith:self]
 		map:^(NSText *text) {
 			return [text.string copy];
 		}]
+		startWith:[self.string copy]]
 		setNameWithFormat:@"%@ -rac_textSignal", self];
 }
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACDelegateProxy.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACDelegateProxy.h
@@ -10,18 +10,12 @@
 
 @class RACEventTrampoline;
 
-@interface RACDelegateProxy : NSObject {
-    Protocol *protocol;
-    NSObject *delegator;
-    id actualDelegate;
-    NSMutableSet *trampolines;
-}
+@interface RACDelegateProxy : NSObject
+
+@property (nonatomic, strong) id actualDelegate;
 
 + (instancetype)proxyWithProtocol:(Protocol *)protocol andDelegator:(NSObject *)delegator;
-- (void)addTrampoline:(RACEventTrampoline *)trampoline;
 
-@property (nonatomic, strong) Protocol *protocol;
-@property (nonatomic, strong) NSObject *delegator;
-@property (nonatomic, strong) id actualDelegate;
+- (void)addTrampoline:(RACEventTrampoline *)trampoline;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextField+RACSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextField+RACSignalSupport.m
@@ -14,10 +14,10 @@
 
 - (RACSignal *)rac_textSignal {
 	return [[[[self rac_signalForControlEvents:UIControlEventEditingChanged]
-		startWith:self]
 		map:^(UITextField *x) {
 			return x.text;
 		}]
+		startWith:self.text]
 		setNameWithFormat:@"%@ -rac_textSignal", self];
 }
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.m
@@ -29,10 +29,10 @@
 
 - (RACSignal *)rac_textSignal {
 	return [[[[self rac_signalForDelegateMethod:@selector(textViewDidChange:)]
-		startWith:self]
 		map:^(UITextView *x) {
 			return x.text;
 		}]
+		startWith:self.text]
 		setNameWithFormat:@"%@ -rac_textSignal", self];
 }
 


### PR DESCRIPTION
Fixes #414 

`startWith:self` is dangerous since it has to strongly capture the passed in object. In these cases, that meant a cycle.
