### PR TITLE
Add convenience methods that deliver and subscribe on the main thread

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -343,9 +343,17 @@ extern const NSInteger RACSignalErrorTimedOut;
 // This corresponds to the `ObserveOn` method in Rx.
 - (RACSignal *)deliverOn:(RACScheduler *)scheduler;
 
+// Convenience method to return a signal that delivers it's callbacks on
+// the main thread.
+- (RACSignal *)deliverOnMainThread;
+
 // Creates and returns a signal whose `didSubscribe` block is scheduled with the
 // given scheduler.
 - (RACSignal *)subscribeOn:(RACScheduler *)scheduler;
+
+// Convenience method to return a signal `didSubscribe` block is scheduled on
+// the main thread.
+- (RACSignal *)subscribeOnMainThread;
 
 // Creates a shared signal which is passed into the let block. The let block
 // then returns a signal derived from that shared signal.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -1114,6 +1114,10 @@ static RACDisposable *concatPopNextSignal(NSMutableArray *signals, BOOL *outerDo
 	}] setNameWithFormat:@"[%@] -deliverOn: %@", self.name, scheduler];
 }
 
+- (RACSignal *)deliverOnMainThread {
+	return [self deliverOn:RACScheduler.mainThreadScheduler];
+}
+
 - (RACSignal *)subscribeOn:(RACScheduler *)scheduler {
 	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
 		RACCompoundDisposable *disposable = [RACCompoundDisposable compoundDisposable];
@@ -1133,6 +1137,10 @@ static RACDisposable *concatPopNextSignal(NSMutableArray *signals, BOOL *outerDo
 		if (schedulingDisposable != nil) [disposable addDisposable:schedulingDisposable];
 		return disposable;
 	}] setNameWithFormat:@"[%@] -subscribeOn: %@", self.name, scheduler];
+}
+
+- (RACSignal *)subscribeOnMainThread {
+	return [self subscribeOn:RACScheduler.mainThreadScheduler];
 }
 
 - (RACSignal *)let:(RACSignal * (^)(RACSignal *sharedSignal))letBlock {


### PR DESCRIPTION
I'm not sure if these methods are unnecessary bloat, but they seem to go a little way toward making some of my turtles easier to read.
