### PR TITLE
Added note about RACObservablePropertySubject's thread-safety.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACObservablePropertySubject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACObservablePropertySubject.h
@@ -38,9 +38,9 @@
 // wrapper or it's bindings. Subscribers of the wrapper or it's bindings will be
 // sent the current value of `keyPath`.
 //
-// Note: RACObservablePropertySubject and the RACBinding it returns are not
-// thread-safe and should not observe atomic properties, or be bound to a
-// RACProperty whose value can be changed from a different thread.
+// Note: RACObservablePropertySubject is not thread-safe and should not observe
+// a property, or be bound to a RACProperty, whose value can be changed from
+// multiple threads at the same time.
 @interface RACObservablePropertySubject : RACPropertySubject
 
 // Returns a new RACPropertySubject wrapper for `keyPath` on `target` with a


### PR DESCRIPTION
I worded it as clear as I could. I wish "refer to the source code for more information" were a valid documentation strategy.
