### PR TITLE
Fix control's textsignal to react to stringValue's update

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACTextSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACTextSignalSupport.m
@@ -11,12 +11,14 @@
 #import "RACDisposable.h"
 #import "RACSignal.h"
 #import "RACSubscriber.h"
+#import "NSObject+RACPropertySubscribing.h"
+#import "RACSignal+Operations.h"
 
 @implementation NSControl (RACTextSignalSupport)
 
 - (RACSignal *)rac_textSignal {
 	@weakify(self);
-	return [[[[RACSignal
+	return [[[RACSignal merge:@[[[RACSignal
 		createSignal:^(id<RACSubscriber> subscriber) {
 			@strongify(self);
 			id observer = [NSNotificationCenter.defaultCenter addObserverForName:NSControlTextDidChangeNotification object:self queue:nil usingBlock:^(NSNotification *note) {
@@ -28,9 +30,11 @@
 			}];
 		}]
 		map:^(NSControl *control) {
-			return [control.stringValue copy];
+			return control.stringValue;
+		}], RACAbleWithStart(self.stringValue)]]
+		map:^(NSString *value){
+		 return [value copy];
 		}]
-		startWith:[self.stringValue copy]]
 		setNameWithFormat:@"%@ -rac_textSignal", self];
 }
 


### PR DESCRIPTION
The original rac_textsignal only reacts to editing done in the text field.
But changing stringValue of the control from outside didn't reflect in the signal, which is not desired, since it becomes out of sync with the content of the text field.

In my example application, I used the signal for a search field. But then, when inserting a new value into the table, I manually clear the search field's string value to empty. 

Yet, the signal didn't reflect the change, so further processing didn't occur and the table didn't refresh.
