### PR TITLE
Fix ushort type code parsing for -rac_returnValue

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.m
@@ -175,7 +175,7 @@
 		WRAP_AND_RETURN(unsigned char);
 	} else if (strcmp(typeSignature, "I") == 0) {
 		WRAP_AND_RETURN(unsigned int);
-	} else if (strcmp(typeSignature, "C") == 0) {
+	} else if (strcmp(typeSignature, "S") == 0) {
 		WRAP_AND_RETURN(unsigned short);
 	} else if (strcmp(typeSignature, "L") == 0) {
 		WRAP_AND_RETURN(unsigned long);


### PR DESCRIPTION
I found another typo of type code "S" with "C" in same source file.
