### PR TITLE
Add NSObject -rac_signalForSelectorInvocation:

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACSelectorSignal.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACSelectorSignal.h
@@ -33,4 +33,16 @@
 // The same as -rac_signalForSelector: but with class methods.
 + (RACSignal *)rac_signalForSelector:(SEL)selector;
 
+// Wrap an implementation of `selector` up to the receiver.
+// The receiver itself should have an existing implementation of `selector`.
+// It will replace existing implementation.
+//
+// selector - The selector for which an implementation should be wrapped.
+//
+// Returns a signal which will send the argument on each invocation.
+- (RACSignal *)rac_signalForSelectorInvocation:(SEL)selector;
+
+// The same as -rac_signalForSelectorInvocation: but with class methods.
++ (RACSignal *)rac_signalForSelectorInvocation:(SEL)selector;
+
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACSelectorSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACSelectorSignal.m
@@ -10,9 +10,11 @@
 #import "RACSubject.h"
 #import "NSObject+RACPropertySubscribing.h"
 #import "RACDisposable.h"
+#import "RACUnit.h"
 #import <objc/runtime.h>
 
 static const void *RACObjectSelectorSignals = &RACObjectSelectorSignals;
+static const void *RACObjectSelectorInvocationSignals = &RACObjectSelectorInvocationSignals;
 
 @implementation NSObject (RACSelectorSignal)
 
@@ -55,6 +57,176 @@ static RACSignal *NSObjectRACSignalForSelector(id self, SEL _cmd, SEL selector) 
 
 + (RACSignal *)rac_signalForSelector:(SEL)selector {
 	return NSObjectRACSignalForSelector(self, _cmd, selector);
+}
+
+static BOOL NSObjectRACSignalForSelectorWrapImplementation(Method originalMethod, SEL selector, const char *typeEncoding) {
+	NSString *key = NSStringFromSelector(selector);
+	RACSubject *(^subjectBlock)(id) = ^(id self) {
+		@synchronized(self) {
+			NSDictionary *selectorSignals = objc_getAssociatedObject(self, RACObjectSelectorInvocationSignals);
+			return selectorSignals[key];
+		}
+	};
+
+	__block IMP originalImp;
+	IMP wrapImp = NULL;
+
+#define WRAP_AND_SEND(type) \
+	do { \
+		wrapImp = imp_implementationWithBlock(^(id self, type arg) { \
+			((void (*)(id, SEL, type))originalImp)(self, selector, arg); \
+			RACSubject *subject = subjectBlock(self); \
+			[subject sendNext:@(arg)]; \
+		}); \
+	} while (0)
+
+#define WRAP_AND_SEND_STRUCT(type) \
+	do { \
+		wrapImp = imp_implementationWithBlock(^(id self, type arg) { \
+			((void (*)(id, SEL, type))originalImp)(self, selector, arg); \
+			RACSubject *subject = subjectBlock(self); \
+			[subject sendNext:[NSValue valueWithBytes:&arg objCType:@encode(type)]]; \
+		}); \
+	} while (0)
+
+        // Skip const type qualifier.
+	if (typeEncoding[0] == 'r') {
+		typeEncoding++;
+	}
+
+	if (strcmp(typeEncoding, @encode(id)) == 0 || strcmp(typeEncoding, @encode(Class)) == 0) {
+		wrapImp = imp_implementationWithBlock(^(id self, id arg) {
+			((void (*)(id, SEL, id))originalImp)(self, selector, arg);
+
+			RACSubject *subject = subjectBlock(self);
+			[subject sendNext:arg];
+		});
+	} else if (strcmp(typeEncoding, @encode(char)) == 0) {
+		WRAP_AND_SEND(char);
+	} else if (strcmp(typeEncoding, @encode(short)) == 0) {
+		WRAP_AND_SEND(short);
+	} else if (strcmp(typeEncoding, @encode(int)) == 0) {
+		WRAP_AND_SEND(int);
+	} else if (strcmp(typeEncoding, @encode(long)) == 0) {
+		WRAP_AND_SEND(long);
+	} else if (strcmp(typeEncoding, @encode(long long)) == 0) {
+		WRAP_AND_SEND(long long);
+	} else if (strcmp(typeEncoding, @encode(unsigned char)) == 0) {
+		WRAP_AND_SEND(unsigned char);
+	} else if (strcmp(typeEncoding, @encode(unsigned short)) == 0) {
+		WRAP_AND_SEND(unsigned short);
+	} else if (strcmp(typeEncoding, @encode(unsigned long)) == 0) {
+		WRAP_AND_SEND(unsigned long);
+	} else if (strcmp(typeEncoding, @encode(unsigned long long)) == 0) {
+		WRAP_AND_SEND(unsigned long long);
+	} else if (strcmp(typeEncoding, @encode(float)) == 0) {
+		WRAP_AND_SEND(float);
+	} else if (strcmp(typeEncoding, @encode(double)) == 0) {
+		WRAP_AND_SEND(double);
+	} else if (strcmp(typeEncoding, @encode(char *)) == 0) {
+		WRAP_AND_SEND(char *);
+	} else if (strcmp(typeEncoding, @encode(CGRect)) == 0) {
+		WRAP_AND_SEND_STRUCT(CGRect);
+	} else if (strcmp(typeEncoding, @encode(CGSize)) == 0) {
+		WRAP_AND_SEND_STRUCT(CGSize);
+	} else if (strcmp(typeEncoding, @encode(CGPoint)) == 0) {
+		WRAP_AND_SEND_STRUCT(CGPoint);
+	} else if (strcmp(typeEncoding, @encode(NSRange)) == 0) {
+		WRAP_AND_SEND_STRUCT(NSRange);
+	} else if (typeEncoding[0] == '^') {
+		wrapImp = imp_implementationWithBlock(^(id self, void *arg) {
+			((void (*)(id, SEL, void *))originalImp)(self, selector, arg);
+
+			RACSubject *subject = subjectBlock(self);
+			[subject sendNext:[NSValue valueWithPointer:arg]];
+		});
+	} else if (strcmp(typeEncoding, @encode(void)) == 0) {
+		wrapImp = imp_implementationWithBlock(^(id self) {
+			((void (*)(id, SEL))originalImp)(self, selector);
+
+			RACSubject *subject = subjectBlock(self);
+			[subject sendNext:RACUnit.defaultUnit];
+		});
+	}
+
+	if (wrapImp == NULL) return NO;
+
+	originalImp = method_setImplementation(originalMethod, wrapImp);
+	return YES;
+
+#undef WRAP_AND_SEND
+#undef WRAP_AND_SEND_STRUCT
+}
+
+static BOOL NSObjectRACSignalForSelectorSignalizeImplementation(id self, SEL _cmd, SEL selector, BOOL isClassMethod) {
+	static NSMutableSet *replacedClasses;
+	static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+		replacedClasses = [NSMutableSet set];
+	});
+
+	@synchronized(replacedClasses) {
+		Class class = object_getClass(self);
+		NSString *key = NSStringFromSelector(selector);
+
+		NSString *registKey = [@[NSStringFromClass(class), key] componentsJoinedByString:isClassMethod ? @"+" : @"-"];
+		if ([replacedClasses member:registKey]) {
+			return YES;
+		}
+
+		Method originalMethod = class_getInstanceMethod(class, selector);
+		NSCAssert(originalMethod != NULL, @"%@ should already be implemented on %@. %@ could not replace the none existing implementation.", NSStringFromSelector(selector), self, NSStringFromSelector(_cmd));
+		if (originalMethod == NULL) return NO;
+
+		NSMethodSignature *methodSignature = [self methodSignatureForSelector:selector];
+		BOOL methodReturnTypeIsVoid = strcmp(methodSignature.methodReturnType, @encode(void)) == 0;
+		NSCAssert(methodReturnTypeIsVoid, @"%@ should have void return type on %@.", NSStringFromSelector(selector), self);
+		if (!methodReturnTypeIsVoid) return NO;
+
+		const char *typeEncoding = (methodSignature.numberOfArguments == 2) ? @encode(void) : [methodSignature getArgumentTypeAtIndex:2];
+		BOOL success = NSObjectRACSignalForSelectorWrapImplementation(originalMethod, selector, typeEncoding);
+		NSCAssert(success, @"%@ has unknown argument type %s on %@.", NSStringFromSelector(selector), typeEncoding, self);
+		if (!success) return NO;
+
+		[replacedClasses addObject:registKey];
+		return YES;
+	}
+}
+
+static RACSignal *NSObjectRACSignalForSelectorInvocation(id self, SEL _cmd, SEL selector, BOOL isClassMethod) {
+	NSCParameterAssert([NSStringFromSelector(selector) componentsSeparatedByString:@":"].count <= 2);
+
+	@synchronized(self) {
+		NSMutableDictionary *selectorSignals = objc_getAssociatedObject(self, RACObjectSelectorInvocationSignals);
+		if (selectorSignals == nil) {
+			selectorSignals = [NSMutableDictionary dictionary];
+			objc_setAssociatedObject(self, RACObjectSelectorInvocationSignals, selectorSignals, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+		}
+
+		NSString *key = NSStringFromSelector(selector);
+		RACSubject *subject = selectorSignals[key];
+		if (subject != nil) return subject;
+
+		BOOL success = NSObjectRACSignalForSelectorSignalizeImplementation(self, _cmd, selector, isClassMethod);
+		if (!success) return nil;
+
+		subject = [RACSubject subject];
+		selectorSignals[key] = subject;
+
+		[self rac_addDeallocDisposable:[RACDisposable disposableWithBlock:^{
+			[subject sendCompleted];
+		}]];
+
+		return subject;
+	}
+}
+
+- (RACSignal *)rac_signalForSelectorInvocation:(SEL)selector {
+	return NSObjectRACSignalForSelectorInvocation(self, _cmd, selector, NO);
+}
+
++ (RACSignal *)rac_signalForSelectorInvocation:(SEL)selector {
+	return NSObjectRACSignalForSelectorInvocation(self, _cmd, selector, YES);
 }
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACSelectorSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACSelectorSignal.m
@@ -10,6 +10,7 @@
 #import "RACSubclassObject.h"
 #import "NSObject+RACSelectorSignal.h"
 #import "RACSignal.h"
+#import "RACUnit.h"
 
 SpecBegin(NSObjectRACSelectorSignal)
 
@@ -43,6 +44,134 @@ describe(@"with an instance method", ^{
 		expect(value).to.beNil();
 #endif
 	});
+
+	it(@"should swizzle an existing method", ^{
+		RACTestObject *object = [[RACTestObject alloc] init];
+		__block id value;
+		[[object rac_signalForSelectorInvocation:@selector(lifeIsGood:)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		[object lifeIsGood:@42];
+
+		expect(value).to.equal(@42);
+	});
+	
+	it(@"shouldn't swizzle a none existing method", ^{
+		RACTestObject *object = [[RACTestObject alloc] init];
+#ifndef NS_BLOCK_ASSERTIONS
+		expect(^{
+			[object rac_signalForSelectorInvocation:@selector(subscribe:)];
+		}).to.raiseAny();
+#else
+		__block id value;
+		[[object rac_signalForSelectorInvocation:@selector(subscribe:)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		[object lifeIsGood:@42];
+
+		expect(value).to.beNil();
+#endif
+	});
+
+	it(@"should swizzle an existing method only once", ^{
+		RACSubclassObject *object = [[RACSubclassObject alloc] init];
+		RACSubclassObject *object2 = [[RACSubclassObject alloc] init];
+		RACSubclassObject *object3 = [[RACSubclassObject alloc] init];
+		RACSubclassObject *object4 = [[RACSubclassObject alloc] init];
+		__block id value;
+		__block int callCount = 0;
+		[[object rac_signalForSelectorInvocation:@selector(setObjectValue:)] subscribeNext:^(id x) {
+			value = x;
+			callCount++;
+		}];
+		[[object2 rac_signalForSelectorInvocation:@selector(setObjectValue:)] subscribeNext:^(id x) {
+			value = x;
+			callCount++;
+		}];
+		[[object3 rac_signalForSelectorInvocation:@selector(lifeIsGood:)] subscribeNext:^(id x) {
+			value = x;
+			callCount++;
+		}];
+		[[object4 rac_signalForSelectorInvocation:@selector(lifeIsGood:)] subscribeNext:^(id x) {
+			value = x;
+			callCount++;
+		}];
+
+		object.objectValue = @42;
+
+		expect(value).to.equal(@42);
+		expect(object.objectValue).to.equal(@42);
+
+		object2.objectValue = @31;
+
+		expect(value).to.equal(@31);
+		expect(object2.objectValue).to.equal(@31);
+
+		[object3 lifeIsGood:@20];
+
+		expect(value).to.equal(@20);
+
+		[object4 lifeIsGood:@10];
+
+		expect(value).to.equal(@10);
+
+		expect(callCount).to.equal(4);
+	});
+
+	it(@"should work for integer", ^{
+		RACTestObject *object = [[RACTestObject alloc] init];
+		__block id value;
+		[[object rac_signalForSelectorInvocation:@selector(setIntegerValue:)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		object.integerValue = 42;
+
+		expect(value).to.equal(@42);
+		expect(object.integerValue).to.equal(42);
+	});
+
+	it(@"should work for char pointer", ^{
+		RACTestObject *object = [[RACTestObject alloc] init];
+		__block id value;
+		[[object rac_signalForSelectorInvocation:@selector(setConstCharPointerValue:)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		const char *string = "blah blah blah";
+		object.constCharPointerValue = string;
+
+		expect(value).to.equal(@"blah blah blah");
+		expect(strcmp(object.constCharPointerValue, string) == 0).to.beTruthy();
+	});
+
+	it(@"should work for CGRect", ^{
+		RACTestObject *object = [[RACTestObject alloc] init];
+		__block id value;
+		[[object rac_signalForSelectorInvocation:@selector(setRectValue:)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		CGRect rect = CGRectMake(10, 20, 30, 40);
+		object.rectValue = rect;
+
+		expect([value rectValue]).to.equal(rect);
+		expect(object.rectValue).to.equal(rect);
+	});
+
+	it(@"should work for void", ^{
+		RACTestObject *object = [[RACTestObject alloc] init];
+		__block id value;
+		[[object rac_signalForSelectorInvocation:@selector(lifeIsGood)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		[object lifeIsGood];
+
+		expect(value).to.equal(RACUnit.defaultUnit);
+	});
 });
 
 describe(@"with a class method", ^{
@@ -65,6 +194,34 @@ describe(@"with a class method", ^{
 #else
 		__block id value;
 		[[RACTestObject rac_signalForSelector:@selector(lifeIsGood:)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		[RACTestObject lifeIsGood:@42];
+
+		expect(value).to.beNil();
+#endif
+	});
+
+	it(@"should swizzle an existing method", ^{
+		__block id value;
+		[[RACTestObject rac_signalForSelectorInvocation:@selector(lifeIsGood:)] subscribeNext:^(id x) {
+			value = x;
+		}];
+
+		[RACTestObject lifeIsGood:@42];
+
+		expect(value).to.equal(@42);
+	});
+
+	it(@"shouldn't swizzle a none existing method", ^{
+#ifndef NS_BLOCK_ASSERTIONS
+		expect(^{
+			[RACTestObject rac_signalForSelectorInvocation:@selector(subscribe:)];
+		}).to.raiseAny();
+#else
+		__block id value;
+		[[RACTestObject rac_signalForSelectorInvocation:@selector(subscribe:)] subscribeNext:^(id x) {
 			value = x;
 		}];
 

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.h
@@ -34,6 +34,7 @@
 - (NSString *)combineObjectValue:(id)objectValue andSecondObjectValue:(id)secondObjectValue;
 
 - (void)lifeIsGood:(id)sender;
+- (void)lifeIsGood;
 
 + (void)lifeIsGood:(id)sender;
 

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.m
@@ -38,6 +38,10 @@
 	
 }
 
+- (void)lifeIsGood {
+
+}
+
 + (void)lifeIsGood:(id)sender {
 	
 }


### PR DESCRIPTION
Method Swizzling version of -rac_signalForSelector: .
It does not add method implementation, it replace the existing implementation for a given selector.
