### PR TITLE
Clarify -sequenceNext:'s documentation and implementation

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -160,7 +160,8 @@ extern const NSInteger RACSignalErrorTimedOut;
 //                 signals.
 - (RACSignal *)flatten:(NSUInteger)maxConcurrent;
 
-// Gets a new signal to subscribe to after the receiver completes.
+// Ignores all `next`s from the receiver, and after the receiver completes, gets
+// a new signal to subscribe to.
 - (RACSignal *)sequenceNext:(RACSignal * (^)(void))block;
 
 // Concats the inner signals of a signal of signals.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -641,21 +641,10 @@ static RACDisposable *concatPopNextSignal(NSMutableArray *signals, BOOL *outerDo
 - (RACSignal *)sequenceNext:(RACSignal * (^)(void))block {
 	NSCParameterAssert(block != nil);
 
-	return [[[self materialize] flattenMap:^(RACEvent *event) {
-		switch (event.eventType) {
-			case RACEventTypeCompleted:
-				return block();
-
-			case RACEventTypeError:
-				return [RACSignal error:event.error];
-
-			case RACEventTypeNext:
-				return [RACSignal empty];
-
-			default:
-				NSCAssert(NO, @"Unrecognized event type: %i", (int)event.eventType);
-		}
-	}] setNameWithFormat:@"[%@] -sequenceNext:", self.name];
+	return [[[self
+		ignoreElements]
+		concat:[RACSignal defer:block]]
+		setNameWithFormat:@"[%@] -sequenceNext:", self.name];
 }
 
 - (RACSignal *)concat {


### PR DESCRIPTION
The documentation for `-sequenceNext:` does not mention that it ignore's the `next`'s sent from the current signal. I had thought it was a variant of `-concat:`, because I didn't look at its implementation closely enough.

After getting clarification in [#493](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/493#issuecomment-17965362), I figured the docs could use an addition mentioning that `next`'s are ignored.

Also in [#493](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/493#issuecomment-17965362), it was explained that `-sequenceNext:` is a composition of `-ignoreElements`, `-concat:`, and `+defer:`. I've changed the implementation of to be built on those, which is in my eyes a simplification. Are there any performance or semantic issues to be concerned about? There are only a couple of `-sequenceNext:` tests, and they still pass.

If the doc change is acceptable but not the implementation change, I'll back it out.
