### PR TITLE
Remove support for lifting char * args and return values

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.h
@@ -13,8 +13,8 @@
 // Sets the argument for the invocation at the given index by unboxing the given
 // object based on the type signature of the argument.
 //
-// This does not support C array, union, or struct types other than CGRect,
-// CGSize, CGPoint, and NSRange.
+// This does not support C strings, arrays, unions, or structs other than
+// CGRect, CGSize, CGPoint, and NSRange.
 //
 // object - The object to unbox and set as the argument.
 // index  - The index of the argument to set.
@@ -24,8 +24,8 @@
 // invocation's method signature. The value is then wrapped in the appropriate
 // object type.
 //
-// This does not support C array, union, or struct types other than CGRect,
-// CGSize, CGPoint, and NSRange.
+// This does not support C strings, arrays, unions, or structs other than
+// CGRect, CGSize, CGPoint, and NSRange.
 //
 // index  - The index of the argument to get.
 //
@@ -35,8 +35,8 @@
 // Gets the return value from the invocation based on the invocation's method
 // signature. The value is then wrapped in the appropriate object type.
 //
-// This does not support C array, union, or struct types other than CGRect,
-// CGSize, CGPoint, and NSRange.
+// This does not support C strings, arrays, unions, or structs other than
+// CGRect, CGSize, CGPoint, and NSRange.
 //
 // Returns the return value of the invocation, wrapped in an object. Voids are
 // returned as `RACUnit.defaultUnit`.

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.m
@@ -58,8 +58,6 @@
 		PULL_AND_SET(float, floatValue);
 	} else if (strcmp(argType, "d") == 0) {
 		PULL_AND_SET(double, doubleValue);
-	} else if (strcmp(argType, "*") == 0) {
-		PULL_AND_SET(const char *, UTF8String);
 	} else if (argType[0] == '^') {
 		PULL_AND_SET(void *, pointerValue);
 	} else if (strcmp(argType, @encode(CGRect)) == 0) {
@@ -71,7 +69,7 @@
 	} else if (strcmp(argType, @encode(NSRange)) == 0) {
 		PULL_AND_SET_STRUCT(NSRange);
 	} else {
-		NSCAssert(NO, @"Unknown argument type %s", argType);
+		NSCAssert(NO, @"Unsupported argument type %s", argType);
 	}
 
 #undef PULL_AND_SET
@@ -127,8 +125,6 @@
 		WRAP_AND_RETURN(float);
 	} else if (strcmp(typeSignature, "d") == 0) {
 		WRAP_AND_RETURN(double);
-	} else if (strcmp(typeSignature, "*") == 0) {
-		WRAP_AND_RETURN(const char *);
 	} else if (typeSignature[0] == '^') {
 		const void *pointer = NULL;
 		[self getArgument:&pointer atIndex:(NSInteger)index];
@@ -142,7 +138,7 @@
 	} else if (strcmp(typeSignature, @encode(NSRange)) == 0) {
 		WRAP_AND_RETURN_STRUCT(NSRange);
 	} else {
-		NSCAssert(NO, @"Unknown return type signature %s", typeSignature);
+		NSCAssert(NO, @"Unsupported return type signature %s", typeSignature);
 	}
 
 	return nil;
@@ -200,8 +196,6 @@
 		WRAP_AND_RETURN(float);
 	} else if (strcmp(typeSignature, "d") == 0) {
 		WRAP_AND_RETURN(double);
-	} else if (strcmp(typeSignature, "*") == 0) {
-		WRAP_AND_RETURN(const char *);
 	} else if (strcmp(typeSignature, "v") == 0) {
 		return RACUnit.defaultUnit;
 	} else if (typeSignature[0] == '^') {
@@ -217,7 +211,7 @@
 	} else if (strcmp(typeSignature, @encode(NSRange)) == 0) {
 		WRAP_AND_RETURN_STRUCT(NSRange);
 	} else {
-		NSCAssert(NO, @"Unknown return type signature %s", typeSignature);
+		NSCAssert(NO, @"Unsupported return type signature %s", typeSignature);
 	}
 
 	return nil;

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
@@ -16,8 +16,8 @@
 //
 // It will replay the most recently sent value to new subscribers.
 //
-// This does not support C array, union, or struct types other than CGRect,
-// CGSize, and CGPoint.
+// This does not support C strings, arrays, unions, or structs other than
+// CGRect, CGSize, CGPoint, and NSRange.
 //
 // If it is not given any signal arguments, it will immediately invoke the
 // selector with the arguments.

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACLiftingSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACLiftingSpec.m
@@ -239,28 +239,6 @@ describe(@"-rac_liftSelector:withObjects:", ^{
 
 	itShouldBehaveLike(@"RACLifting", @{ kRACLiftingTestRigClass : RACLiftingSelectorTestRig.class });
 
-	it(@"should work for char pointer", ^{
-		RACSubject *subject = [RACSubject subject];
-		[object rac_liftSelector:@selector(setCharPointerValue:) withObjects:subject];
-
-		expect(object.charPointerValue).to.equal(NULL);
-
-		NSString *string = @"blah blah blah";
-		[subject sendNext:string];
-		expect(@(object.charPointerValue)).to.equal(string);
-	});
-
-	it(@"should work for const char pointer", ^{
-		RACSubject *subject = [RACSubject subject];
-		[object rac_liftSelector:@selector(setConstCharPointerValue:) withObjects:subject];
-
-		expect(object.constCharPointerValue).to.equal(NULL);
-
-		NSString *string = @"blah blah blah";
-		[subject sendNext:string];
-		expect(@(object.constCharPointerValue)).to.equal(string);
-	});
-
 	it(@"should work for CGRect", ^{
 		RACSubject *subject = [RACSubject subject];
 		[object rac_liftSelector:@selector(setRectValue:) withObjects:subject];
@@ -434,28 +412,6 @@ describe(@"-rac_liftSelector:withObjectsFromArray:", ^{
 
 		[subject sendNext:self.class];
 		expect(object.objectValue).to.equal(self.class);
-	});
-
-	it(@"should work for char pointer", ^{
-		RACSubject *subject = [RACSubject subject];
-		[object rac_liftSelector:@selector(setCharPointerValue:) withObjectsFromArray:@[ subject ]];
-
-		expect(object.charPointerValue).to.equal(NULL);
-
-		NSString *string = @"blah blah blah";
-		[subject sendNext:string];
-		expect(@(object.charPointerValue)).to.equal(string);
-	});
-
-	it(@"should work for const char pointer", ^{
-		RACSubject *subject = [RACSubject subject];
-		[object rac_liftSelector:@selector(setConstCharPointerValue:) withObjectsFromArray:@[ subject ]];
-
-		expect(object.constCharPointerValue).to.equal(NULL);
-
-		NSString *string = @"blah blah blah";
-		[subject sendNext:string];
-		expect(@(object.constCharPointerValue)).to.equal(string);
 	});
 
 	it(@"should work for CGRect", ^{

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.h
@@ -13,8 +13,6 @@
 @property (nonatomic, strong) id objectValue;
 @property (nonatomic, strong) id secondObjectValue;
 @property (nonatomic, assign) NSInteger integerValue;
-@property (nonatomic, assign) char *charPointerValue;
-@property (nonatomic, assign) const char *constCharPointerValue;
 @property (nonatomic, assign) CGRect rectValue;
 @property (nonatomic, assign) CGSize sizeValue;
 @property (nonatomic, assign) CGPoint pointValue;


### PR DESCRIPTION
We were seeing relatively frequent race conditions in the lifting tests for `char *` and `const char *`, perhaps hinting at some deeper problem. The memory management of C strings is also complex and error-prone, so it's better to encourage the use of `NSString` instead.

Targeting 2.0 with this, since it is a breaking change.
