### PR TITLE
Quote header search path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ To add RAC to your application:
     * **On OS X**, add `ReactiveCocoa.framework`. RAC must also be added to any
       "Copy Frameworks" build phase. If you don't already have one, simply add
       a "Copy Files" build phase and target the "Frameworks" destination.
- 1. Add `$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include
+ 1. Add `"$(BUILD_ROOT)/../IntermediateBuildFilesPath/UninstalledProducts/include"
     $(inherited)` to the "Header Search Paths" build setting (this is only
     necessary for archive builds, but it has no negative effect otherwise).
  1. **For iOS targets**, add `-ObjC` to the "Other Linker Flags" build setting.


### PR DESCRIPTION
Paths that include environment variables should be quoted; documenting that here will help new users get started.
