### PR TITLE
Making RACEventTrampoline and RACDelegateProxy available in the iOS library

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		1EC06B18173CB04000365258 /* UIGestureRecognizer+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EC06B16173CB04000365258 /* UIGestureRecognizer+RACSignalSupport.m */; };
 		27A887D11703DC6800040001 /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A887C81703DB4F00040001 /* UIBarButtonItem+RACCommandSupport.m */; };
 		27A887D21703DDEB00040001 /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 27A887C71703DB4F00040001 /* UIBarButtonItem+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		586351E61768B717005F08DD /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A1FCC3761567DED0008C9686 /* RACDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		586351E71768B717005F08DD /* RACEventTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = A1FCC36B15673FA3008C9686 /* RACEventTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5F244771167E5EDE0062180C /* RACPropertySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F24476F167E5EDE0062180C /* RACPropertySubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5F244772167E5EDE0062180C /* RACPropertySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F24476F167E5EDE0062180C /* RACPropertySubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5F244773167E5EDE0062180C /* RACPropertySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F244770167E5EDE0062180C /* RACPropertySubject.m */; };
@@ -1362,6 +1364,8 @@
 				88302C961762EC79003633BD /* RACQueueScheduler.h in Headers */,
 				88302C9B1762EC7E003633BD /* RACQueueScheduler+Subclass.h in Headers */,
 				88302CA21762F62D003633BD /* RACTargetQueueScheduler.h in Headers */,
+				586351E61768B717005F08DD /* RACDelegateProxy.h in Headers */,
+				586351E71768B717005F08DD /* RACEventTrampoline.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
@@ -49,6 +49,8 @@
 #import <ReactiveCocoa/UITextView+RACSignalSupport.h>
 #import <ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h>
 #import <ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h>
+#import <ReactiveCocoa/RACEventTrampoline.h>
+#import <ReactiveCocoa/RACDelegateProxy.h>
 #elif TARGET_OS_MAC
 #import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import <ReactiveCocoa/NSControl+RACCommandSupport.h>


### PR DESCRIPTION
I started using RAC only recently, so I might be missing something really basic, but there was no way for me to access and use RACEventTrampoline and RACDelegateProxy. I'm pretty sure I got the whole project (build phases, dependencies, etc.) configured properly. 

This what's in the pull request, is the only way I could get it to work. The aforementioned two classes were available after making these changes.
