### PR TITLE
Find appropriate selector without NSString allocation

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBlockTrampoline.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBlockTrampoline.m
@@ -56,6 +56,7 @@
 	NSCParameterAssert(count > 0);
 
 	switch (count) {
+		case  0: return NULL;
 		case  1: return @selector(performWith:);
 		case  2: return @selector(performWith::);
 		case  3: return @selector(performWith:::);


### PR DESCRIPTION
I think this patch can avoid unnecessary string allocation on each invocation of RACBlockTrampoline.
