### PR TITLE
Remove unnecessary imports

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACCommandSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACCommandSupport.m
@@ -10,9 +10,7 @@
 #import "EXTScope.h"
 #import "NSObject+RACPropertySubscribing.h"
 #import "RACCommand.h"
-#import "RACScheduler.h"
 #import "RACScopedDisposable.h"
-#import "RACSignal+Operations.h"
 #import <objc/runtime.h>
 
 static void *NSControlRACCommandKey = &NSControlRACCommandKey;

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSEnumerator+RACSequenceAdditions.m
@@ -8,7 +8,6 @@
 
 #import "NSEnumerator+RACSequenceAdditions.h"
 #import "RACSequence.h"
-#import "EXTScope.h"
 
 @implementation NSEnumerator (RACSequenceAdditions)
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACKVOWrapper.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACKVOWrapper.m
@@ -8,7 +8,6 @@
 
 #import "NSObject+RACKVOWrapper.h"
 #import "RACKVOTrampoline.h"
-#import <objc/runtime.h>
 
 @implementation NSObject (RACKVOWrapper)
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.m
@@ -16,7 +16,6 @@
 #import "RACReplaySubject.h"
 #import "RACSignal+Operations.h"
 #import "RACTuple.h"
-#import "RACUnit.h"
 
 static RACSignal *RACLiftAndCallBlock(id object, NSArray *args, RACSignal * (^block)(NSArray *));
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.m
@@ -14,7 +14,7 @@
 #import "RACCompoundDisposable.h"
 #import "RACDisposable.h"
 #import "RACKVOTrampoline.h"
-#import "RACReplaySubject.h"
+#import "RACSubscriber.h"
 #import "RACSignal+Operations.h"
 
 static RACSignal *signalWithoutChangesFor(Class class, NSObject *object, NSString *keyPath, NSKeyValueObservingOptions options, NSObject *observer) {

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
@@ -14,7 +14,6 @@
 #import "RACSignal+Operations.h"
 #import "RACSubject.h"
 #import "RACSubscriptingAssignmentTrampoline.h"
-#import <libkern/OSAtomic.h>
 
 @interface RACCommand () {
 	RACSubject *_errors;

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCompoundDisposable.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCompoundDisposable.m
@@ -7,7 +7,6 @@
 //
 
 #import "RACCompoundDisposable.h"
-#import "EXTScope.h"
 #import <libkern/OSAtomic.h>
 
 @interface RACCompoundDisposable () {

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACImmediateScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACImmediateScheduler.m
@@ -7,7 +7,6 @@
 //
 
 #import "RACImmediateScheduler.h"
-#import "EXTScope.h"
 #import "RACScheduler+Private.h"
 
 @implementation RACImmediateScheduler

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACObservablePropertySubject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACObservablePropertySubject.m
@@ -16,11 +16,8 @@
 #import "RACBinding.h"
 #import "RACDisposable.h"
 #import "RACKVOTrampoline.h"
-#import "RACSignal+Private.h"
 #import "RACSubject.h"
 #import "RACSubscriber+Private.h"
-#import "RACSwizzling.h"
-#import "RACTuple.h"
 
 // Name of exceptions thrown by RACKVOBinding when an object calls
 // -didChangeValueForKey: without a corresponding -willChangeValueForKey:.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.m
@@ -10,7 +10,6 @@
 #import "RACDisposable.h"
 #import "RACScheduler+Private.h"
 #import "RACQueueScheduler+Subclass.h"
-#import <libkern/OSAtomic.h>
 
 @implementation RACQueueScheduler
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACReplaySubject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACReplaySubject.m
@@ -12,7 +12,6 @@
 #import "RACSubscriber.h"
 #import "RACTuple.h"
 #import "RACCompoundDisposable.h"
-#import <libkern/OSAtomic.h>
 
 const NSUInteger RACReplaySubjectUnlimitedCapacity = 0;
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.m
@@ -13,7 +13,6 @@
 #import "RACTargetQueueScheduler.h"
 #import "RACScheduler+Private.h"
 #import "RACSubscriptionScheduler.h"
-#import <libkern/OSAtomic.h>
 
 // The key for the thread-specific current scheduler.
 NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedulerKey";

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.m
@@ -8,17 +8,14 @@
 
 #import "RACSequence.h"
 #import "RACArraySequence.h"
-#import "RACBlockTrampoline.h"
-#import "RACDisposable.h"
 #import "RACDynamicSequence.h"
 #import "RACEagerSequence.h"
 #import "RACEmptySequence.h"
 #import "RACScheduler.h"
 #import "RACSignal.h"
-#import "RACSubject.h"
+#import "RACSubscriber.h"
 #import "RACTuple.h"
 #import "RACUnarySequence.h"
-#import <libkern/OSAtomic.h>
 
 // An enumerator over sequences.
 @interface RACSequenceEnumerator : NSEnumerator

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -7,12 +7,8 @@
 //
 
 #import "RACSignal+Operations.h"
-#import "EXTScope.h"
-#import "NSArray+RACSequenceAdditions.h"
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACDescription.h"
-#import "RACBehaviorSubject.h"
-#import "RACBlockTrampoline.h"
 #import "RACCommand.h"
 #import "RACCompoundDisposable.h"
 #import "RACDisposable.h"

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
@@ -9,8 +9,6 @@
 #import "RACSignal.h"
 #import "EXTScope.h"
 #import "NSObject+RACDescription.h"
-#import "RACBehaviorSubject.h"
-#import "RACBlockTrampoline.h"
 #import "RACCompoundDisposable.h"
 #import "RACDisposable.h"
 #import "RACMulticastConnection.h"

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStringSequence.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStringSequence.m
@@ -7,7 +7,6 @@
 //
 
 #import "RACStringSequence.h"
-#import "EXTScope.h"
 
 @interface RACStringSequence ()
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubject.m
@@ -7,7 +7,6 @@
 //
 
 #import "RACSubject.h"
-#import "EXTScope.h"
 #import "RACSignal+Private.h"
 #import "RACCompoundDisposable.h"
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.m
@@ -8,7 +8,6 @@
 
 #import "RACTuple.h"
 #import "EXTKeyPathCoding.h"
-#import "NSArray+RACSequenceAdditions.h"
 #import "RACTupleSequence.h"
 
 @implementation RACTupleNil

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m
@@ -11,9 +11,7 @@
 #import <ReactiveCocoa/NSObject+RACPropertySubscribing.h>
 #import <ReactiveCocoa/RACCommand.h>
 #import <ReactiveCocoa/RACDisposable.h>
-#import <ReactiveCocoa/RACScheduler.h>
 #import <ReactiveCocoa/RACSignal+Operations.h>
-#import <ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h>
 #import <objc/runtime.h>
 
 static void *UIControlRACCommandKey = &UIControlRACCommandKey;

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIButton+RACCommandSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIButton+RACCommandSupport.m
@@ -11,9 +11,7 @@
 #import <ReactiveCocoa/NSObject+RACPropertySubscribing.h>
 #import <ReactiveCocoa/RACCommand.h>
 #import <ReactiveCocoa/RACDisposable.h>
-#import <ReactiveCocoa/RACScheduler.h>
 #import <ReactiveCocoa/RACSignal+Operations.h>
-#import <ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h>
 #import <objc/runtime.h>
 
 static void *UIButtonRACCommandKey = &UIButtonRACCommandKey;


### PR DESCRIPTION
I noticed a couple imports that were obviously not being used (`RACBehaviorSubject.h`), so I opened AppCode and ran its "Optimize Imports". It was a tad aggressive, so I pruned it to fewer removals.

I didn't know whether to bother pushing this, it's admittedly of no value. Feel free to do a blind close if it's seen as a waste of time.
