### PR TITLE
Fixed default value in -asynchronousFirstOrDefault:success:error:

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
@@ -507,7 +507,7 @@ static const NSTimeInterval RACSignalAsynchronousWaitTimeout = 10;
 - (id)asynchronousFirstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error {
 	NSCAssert([NSThread isMainThread], @"%s should only be used from the main thread", __func__);
 
-	__block id result = nil;
+	__block id result = defaultValue;
 	__block BOOL done = NO;
 
 	// Ensures that we don't pass values across thread boundaries by reference.

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -431,6 +431,27 @@ describe(@"querying", ^{
 		expect(error).to.beNil();
 	});
 
+	it(@"should return a default value from -asynchronousFirstOrDefault:success:error:", ^{
+		RACSignal *signal = [[RACSignal error:RACSignalTestError] delay:0.01];
+
+		__block BOOL scheduledBlockRan = NO;
+		[RACScheduler.mainThreadScheduler schedule:^{
+			scheduledBlockRan = YES;
+		}];
+
+		expect(scheduledBlockRan).to.beFalsy();
+
+		BOOL success = NO;
+		NSError *error = nil;
+		id value = [signal asynchronousFirstOrDefault:RACUnit.defaultUnit success:&success error:&error];
+
+		expect(scheduledBlockRan).to.beTruthy();
+
+		expect(value).to.equal(RACUnit.defaultUnit);
+		expect(success).to.beFalsy();
+		expect(error).to.equal(RACSignalTestError);
+	});
+
 	it(@"should return a delayed error from -asynchronousFirstOrDefault:success:error:", ^{
 		RACSignal *signal = [[RACSignal
 			createSignal:^(id<RACSubscriber> subscriber) {


### PR DESCRIPTION
It's a one liner.
