### PR TITLE
Added new -asynchronouslySubscribeNext:error:completed: test method

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.h
@@ -179,6 +179,15 @@
 // **These methods should never ship in production code.**
 @interface RACSignal (Testing)
 
+// Spins the main run loop for a short while, waiting for the receiver to complete and
+// subscribes to `next`, `error` and `completed` events.
+//
+// **Because this method executes the run loop recursively, it should only be used
+// on the main thread, and only from a unit test.**
+//
+// Returns whether the signal sent `complete` or `error` to the receiver before timing out.
+- (BOOL)asynchronouslySubscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock;
+
 // Spins the main run loop for a short while, waiting for the receiver to send a `next`.
 //
 // **Because this method executes the run loop recursively, it should only be used


### PR DESCRIPTION
I wanted to test a signal that's supposed to send multiple next events and I felt that this method was missing, especially in projects that don't use expecta and the easy `will` and `willNot`, or when testing the successive `next` values sent by a signal.
