### PR TITLE
Add support for lifting methods with no arguments.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACLiftingSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACLiftingSpec.m
@@ -93,6 +93,16 @@ describe(@"-rac_liftSelector:withSignalsFromArray:", ^{
 		expect(object.integerValue).to.equal(42);
 	});
 
+	it(@"should work with no arguments", ^{
+		RACSubject *subject = [RACSubject subject];
+		[object rac_liftSelector:@selector(setIntegerValueTo5) withSignalsFromArray:@[ subject ]];
+
+		expect(object.integerValue).to.equal(0);
+
+		[subject sendNext:RACUnit.defaultUnit];
+		expect(object.integerValue).to.equal(5);
+	});
+
 	it(@"should work with signals that immediately start with a value", ^{
 		RACSubject *subject = [RACSubject subject];
 		[object rac_liftSelector:@selector(setObjectValue:) withSignalsFromArray:@[ [subject startWith:@42] ]];

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.h
@@ -53,4 +53,6 @@
 
 - (NSRange)returnRangeValueWithObjectValue:(id)objectValue andIntegerValue:(NSInteger)integerValue;
 
+- (void)setIntegerValueTo5;
+
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.m
@@ -56,4 +56,8 @@
 	return testObject;
 }
 
+- (void)setIntegerValueTo5 {
+	self.integerValue = 5;
+}
+
 @end


### PR DESCRIPTION
Since lifting supports `void` return methods by sending `RACUnit.defaultUnit` I thought it would make sense to support methods with no arguments by having one signal that sends `RACUnit.defaultUnit` (although it actually ignores the values the signal sends completely).

Details aside, I think not being able to lift methods with no arguments is a pretty big feature hole.
