### PR TITLE
Fix C string lifting test.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACTestObject.m
@@ -86,12 +86,13 @@
 	size_t doubledSize = strlen(string) * 2 + 1;
 	char *doubledString = malloc(sizeof(char) * doubledSize);
 
-	// Create an autoreleasing NSData to free the buffer eventually
-	__autoreleasing NSData *data __attribute__((unused)) = [NSData dataWithBytesNoCopy:doubledString length:doubledSize freeWhenDone:YES];
-
 	doubledString[0] = '\0';
 	strlcat(doubledString, string, doubledSize);
 	strlcat(doubledString, string, doubledSize);
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		free(doubledString);
+	});
 
 	return doubledString;
 }


### PR DESCRIPTION
I guess you can be clever, or ARC can be clever, but not both.

According to http://stackoverflow.com/questions/14186336/how-to-autorelease-a-non-returned-object-under-arc the autoreleasing `NSData` trick won't work in ARC. I guess it breaks on `Release` because the optimizer checks if you actually use the reference or not. There are some tricks posted on how to make it work anyway, by using a helper function, but I think this is clearer.
