### PR TITLE
Fix UIKit test host build settings for on device testing

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -2349,6 +2349,7 @@
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"\n\n//:configuration",
 				);
 				INFOPLIST_FILE = "ReactiveCocoaTests/UIKit/UIKitTests/ReactiveCocoa-iOS-UIKitTestHostTests-Info.plist";
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
@@ -2377,6 +2378,7 @@
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"\n\n//:configuration",
 				);
 				INFOPLIST_FILE = "ReactiveCocoaTests/UIKit/UIKitTests/ReactiveCocoa-iOS-UIKitTestHostTests-Info.plist";
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";


### PR DESCRIPTION
This enables `ONLY_ACTIVE_ARCH` for `Debug` and `Test` builds of the UIKit tests, to match the build settings of specta and expecta. This is necessary to get successful linking of the UIKit test host. The linker error is due to specta/expecta not building for all the architectures, which the UIKit tests are currently building for.
