### PR TITLE
Fix rac_liftSelector:withSignals: documentation to nil terminate

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
@@ -27,7 +27,7 @@
 //
 // Examples
 //
-//   [button rac_liftSelector:@selector(setTitleColor:forState:) withSignals:textColorSignal, [RACSignal return:@(UIControlStateNormal)]];
+//   [button rac_liftSelector:@selector(setTitleColor:forState:) withSignals:textColorSignal, [RACSignal return:@(UIControlStateNormal)], nil];
 //
 // Returns a signal which sends the return value from each invocation of the
 // selector. If the selector returns void, it instead sends RACUnit.defaultUnit.


### PR DESCRIPTION
The method has the NS_REQUIRES_NIL_TERMINATION attr, but the example
given in the doc comment isn't nil-terminated
