### PR TITLE
Disable Fishhook on iOS device builds

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace+Private.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace+Private.h
@@ -6,7 +6,9 @@
 //  Copyright (c) 2013 GitHub, Inc. All rights reserved.
 //
 
-#ifdef DEBUG
+// RACBacktrace is only enabled for `DEBUG` builds, and in the case of iOS, only
+// on the simulator, not on device.
+#if defined(DEBUG) && (TARGET_IPHONE_SIMULATOR || !TARGET_OS_IPHONE)
 
 extern void rac_dispatch_async(dispatch_queue_t queue, dispatch_block_t block);
 extern void rac_dispatch_barrier_async(dispatch_queue_t queue, dispatch_block_t block);

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
@@ -10,14 +10,14 @@
 #import <pthread.h>
 #import "RACBacktrace.h"
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <dlfcn.h>
-#import "fishhook.h"
-#endif
-
 #define RAC_BACKTRACE_MAX_CALL_STACK_FRAMES 128
 
 #ifdef DEBUG
+
+#if TARGET_IPHONE_SIMULATOR
+#import <dlfcn.h>
+#import "fishhook.h"
+#endif
 
 // Undefine the macros that hide the real GCD functions.
 #undef dispatch_async
@@ -27,7 +27,7 @@
 #undef dispatch_barrier_async_f
 #undef dispatch_after_f
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if TARGET_IPHONE_SIMULATOR
 static void (*orig_dispatch_async)(dispatch_queue_t queue, dispatch_block_t block);
 static void (*orig_dispatch_barrier_async)(dispatch_queue_t queue, dispatch_block_t block);
 static void (*orig_dispatch_after)(dispatch_time_t when, dispatch_queue_t queue, dispatch_block_t block);
@@ -174,7 +174,7 @@ static void RACExceptionHandler (NSException *ex) {
 + (void)load {
 	@autoreleasepool {
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if TARGET_IPHONE_SIMULATOR
 		orig_dispatch_async = dlsym(RTLD_DEFAULT, "dispatch_async");
 		orig_dispatch_barrier_async = dlsym(RTLD_DEFAULT, "dispatch_barrier_async");
 		orig_dispatch_after = dlsym(RTLD_DEFAULT, "dispatch_after");

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACBacktraceSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACBacktraceSpec.m
@@ -91,11 +91,16 @@ it(@"should trace across a RACScheduler", ^{
 	expect(previousBacktrace).willNot.beNil();
 });
 
+// For iOS builds, RACBacktrace is enabled only on the simulator, not on device.
+#if TARGET_IPHONE_SIMULATOR || !TARGET_OS_IPHONE
+
 it(@"should trace across an NSOperationQueue", ^{
 	NSOperationQueue *queue = [[NSOperationQueue alloc] init];
 	[queue addOperationWithBlock:block];
 	expect(previousBacktrace).willNot.beNil();
 });
+
+#endif
 
 SpecEnd
 


### PR DESCRIPTION
Fixes #718 

While technically fishhook's approach works on device, since Apple strips/obfuscates the symbol tables, it might not be possible in practice. I'm going to do a bit more investigation, but this fixes the problem now.
