### PR TITLE
nil out the previous backtrace when a backtrace is deallocated

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
@@ -195,6 +195,11 @@ static void RACExceptionHandler (NSException *ex) {
 
 #pragma mark NSObject
 
+- (void)dealloc
+{
+	_previousThreadBacktrace = nil;
+}
+
 - (NSString *)description {
 	NSString *str = [NSString stringWithFormat:@"%@", self.callStackSymbols];
 	if (self.previousThreadBacktrace != nil) {

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACBacktraceSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACBacktraceSpec.m
@@ -8,6 +8,9 @@
 
 #import "RACBacktrace.h"
 #import "RACScheduler.h"
+#import "RACSequence.h"
+#import "NSArray+RACSequenceAdditions.h"
+#import "RACSignal.h"
 
 #ifdef DEBUG
 
@@ -89,6 +92,20 @@ describe(@"with a GCD queue", ^{
 it(@"should trace across a RACScheduler", ^{
 	[[RACScheduler scheduler] schedule:block];
 	expect(previousBacktrace).willNot.beNil();
+});
+
+it(@"shouldn't go bonkers with RACScheduler", ^{
+	NSMutableArray *a = [NSMutableArray array];
+	for (NSUInteger i = 0; i < 5000; i++) {
+		[a addObject:@(i)];
+	}
+
+	[[a.rac_sequence signalWithScheduler:[RACScheduler scheduler]]
+	 subscribeNext:^(id x) {
+
+	 } completed:^{
+
+	 }];
 });
 
 // Tracing across NSOperationQueue only works on OS X because it depends on


### PR DESCRIPTION
This fixes #726

I was able to boil it down to the following sample:

```
    NSMutableArray *a = [NSMutableArray array];
    for (NSUInteger i = 0; i < 5000; i++) {
        [a addObject:@(i)];
    }

    [[a.rac_sequence signalWithScheduler:[RACScheduler scheduler]]
     subscribeNext:^(id x) {

     } completed:^{
         NSLog(@"Great success");
     }];
```

Which will cause the crash mentioned in #726 once it completes, even with the proper DYLD_INSERT_LIBRARIES set, contrary to what I said in that ticket.

Now, I'm not 100% sure what's actually causing this but I'm seeing in both the xcode4&5 compiler versions and I think it may be related to when the queue specific context calls its deallocator and when ARC does its thing. Because if I introduce a leak by removing the deallocator argument to `dispatch_set_specific` in `RACBacktraceBlock` (and without the patch below) the crash doesn't occur. Also interestingly I wasn't able to create a sample app that crashes by just calling the `rac_dispatch_async()` function directly, it has to be wrapped in something like the above sequence signal.

Would love to hear someone else's take on this
