### PR TITLE
Fix RACSignalSupport to reset delegate after dynamically adding methods

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/UIActionSheet+RACSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIActionSheet+RACSignalSupport.m
@@ -34,15 +34,17 @@ static void RACUseDelegateProxy(UIActionSheet *self) {
 }
 
 - (RACSignal *)rac_buttonClickedSignal {
-	RACUseDelegateProxy(self);
-
-	return [[[[self.rac_delegateProxy
+	RACSignal *signal = [[[[self.rac_delegateProxy
 		signalForSelector:@selector(actionSheet:clickedButtonAtIndex:)]
 		reduceEach:^(UIActionSheet *actionSheet, NSNumber *buttonIndex) {
 			return buttonIndex;
 		}]
 		takeUntil:self.rac_willDeallocSignal]
 		setNameWithFormat:@"%@ -rac_buttonClickedSignal", [self rac_description]];
+
+	RACUseDelegateProxy(self);
+
+	return signal;
 }
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIAlertView+RACSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIAlertView+RACSignalSupport.m
@@ -34,15 +34,17 @@ static void RACUseDelegateProxy(UIAlertView *self) {
 }
 
 - (RACSignal *)rac_buttonClickedSignal {
-	RACUseDelegateProxy(self);
-
-	return [[[[self.rac_delegateProxy
+	RACSignal *signal = [[[[self.rac_delegateProxy
 		signalForSelector:@selector(alertView:clickedButtonAtIndex:)]
 		reduceEach:^(UIAlertView *alertView, NSNumber *buttonIndex) {
 			return buttonIndex;
 		}]
 		takeUntil:self.rac_willDeallocSignal]
 		setNameWithFormat:@"%@ -rac_buttonClickedSignal", [self rac_description]];
+
+	RACUseDelegateProxy(self);
+
+	return signal;
 }
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.m
@@ -35,10 +35,8 @@ static void RACUseDelegateProxy(UITextView *self) {
 }
 
 - (RACSignal *)rac_textSignal {
-	RACUseDelegateProxy(self);
-
 	@weakify(self);
-	return [[[[[RACSignal
+	RACSignal *signal = [[[[[RACSignal
 		defer:^{
 			@strongify(self);
 			return [RACSignal return:RACTuplePack(self)];
@@ -49,6 +47,10 @@ static void RACUseDelegateProxy(UITextView *self) {
 		}]
 		takeUntil:self.rac_willDeallocSignal]
 		setNameWithFormat:@"%@ -rac_textSignal", [self rac_description]];
+
+	RACUseDelegateProxy(self);
+
+	return signal;
 }
 
 @end


### PR DESCRIPTION
I used the following code for to present an action sheet:

``` objective-c
UIActionSheet *sheet = [[UIActionSheet alloc] initWithTitle:@"Sheet"
    delegate:nil
    cancelButtonTitle:@"Cancel"
    destructiveButtonTitle:@"Destroy"
    otherButtonTitles:nil];
[sheet.rac_buttonClickedSignal subscribeNext:^(NSNumber *idx) {
    NSLog(@"button %@ clicked", idx);
}];

[sheet showInView:myView]
```

When I click on a button, the log message is never printed.

I tracked the issue down to the way delegates were handled in the rac_buttonClickedSignal method.  When you set the delegate of a UIKit class, the delegate gets asked if it responds to each of the optional methods in the delegate protocol.  The UIKit class caches these responses in instance variables, so the delegate is asked only once (at the time it is set as the delegate) whether or not it implements optional protocol methods.

The issue is that the actionSheet:clickedButtonAtIndex: method is added to the delegate proxy by ReactiveCocoa _after_ the sheet's delegate has been set to a RACDelegateProxy.  When I click on a button on the action sheet, it checks its previously cached list of what optional methods the delegate responds to, sees that the delegate doesn't (didn't at the time of setting) implement actionSheet:clickedButtonAtIndex:, and never calls the method on the delegate.

I've fixed this by reordering so that the method is now added to the delegate proxy _before_ the proxy is set as the sheet's delegate.  This fix also applies to UIAlertView and UITextView.
