### PR TITLE
Document that -rac_signalForDelegateMethod: requires the delegate to be set to nil before -dealloc

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.h
@@ -14,6 +14,10 @@
 
 // Creates and returns a signal that sends the sender of the delegate method
 // whenever it is triggered.
+//
+// If you use this method, you **must** set the text view's `delegate` to nil before
+// the text view itself is released. This can usually be done from the -dealloc
+// method of the text view's owner (view or view controller).
 - (RACSignal *)rac_signalForDelegateMethod:(SEL)method;
 
 // Creates and returns a signal for the text of the field. It always starts with


### PR DESCRIPTION
Completes #744.
