### PR TITLE
Avoid retain cycles between RACDelegateProxy and RACEventTrampoline

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACDelegateProxy.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACDelegateProxy.m
@@ -58,7 +58,7 @@
 - (void)forwardInvocation:(NSInvocation *)invocation {
 	SEL selector = invocation.selector;
 	for (NSValue *trampolineValue in self.trampolines) {
-		RACEventTrampoline *trampoline = [trampolineValue nonretainedObjectValue];
+		RACEventTrampoline *trampoline = trampolineValue.nonretainedObjectValue;
 		[trampoline didGetDelegateEvent:selector sender:self.delegator];
 	}
 
@@ -79,7 +79,7 @@
 
 - (BOOL)trampolinesRespondToSelector:(SEL)selector {
 	for (NSValue *trampolineValue in self.trampolines) {
-		RACEventTrampoline *trampoline = [trampolineValue nonretainedObjectValue];
+		RACEventTrampoline *trampoline = trampolineValue.nonretainedObjectValue;
 		if (trampoline.delegateMethod == selector) {
 			return YES;
 		}


### PR DESCRIPTION
Trampolines will always have a strong reference to their delegate proxy
for its lifetime, so we can safely have a non-retained back reference,
breaking the cycle.

Fixes #743.
