### PR TITLE
Add quick setup guide to CONTRIBUTING notes for developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ topic), send a pull request!
 All code contributions should match our [coding
 conventions](https://github.com/github/objective-c-conventions).
 
-# Setting up your ReactiveCocoa development environment
+## Development environment setup
 
 After cloning your fork, you'll need to do the following:
 


### PR DESCRIPTION
When I cloned my fork to work on #751, I opened the Xcode project, hit build and watched it fail completely.

It was only digging through the README that I found the reference to `script/bootstrap`, hidden away in the "Importing ReactiveCocoa" section.

It would be clearer to have some quick setup steps for new contributors in the CONTRIBUTING.md file as this is the first place I looked.
