### PR TITLE
Reimplement -switchToLatest using existing operators

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -723,6 +723,8 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 
 		NSCAssert([x isKindOfClass:RACSignal.class], @"-switchToLatest requires that the source signal (%@) send signals. Instead we got: %@", self, x);
 
+		// -concat:[RACSignal never] prevents completion of the receiver from
+		// prematurely terminating the inner signal.
 		return [x takeUntil:[multicastedSelf concat:[RACSignal never]]];
 	}] setNameWithFormat:@"[%@] -switchToLatest", self.name];
 }


### PR DESCRIPTION
From this [stackoverflow question](http://stackoverflow.com/questions/18291805/scanning-over-a-merge-of-differently-typed-signals), I was helped to realize that `-switchToLatest` could be implemented using `-flattenMap:` and `-takeUntil:`. This makes its implementation more succinct, and I reason the semantics are the same, but I haven't considered performance. I thought it was worth bringing it up.
