### PR TITLE
Autorelease the backtrace instead of precise lifetiming it

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
@@ -61,7 +61,7 @@ static dispatch_block_t RACBacktraceBlock (dispatch_queue_t queue, dispatch_bloc
 	RACBacktrace *backtrace = [RACBacktrace backtrace];
 
 	return [^{
-		RACBacktrace *backtraceKeptAlive __attribute__((objc_precise_lifetime)) = backtrace;
+		__autoreleasing RACBacktrace *backtraceKeptAlive = backtrace;
 
 		dispatch_queue_set_specific(queue, (void *)pthread_self(), (__bridge void *)backtraceKeptAlive, NULL);
 		block();


### PR DESCRIPTION
This avoids overflowing the stack when there are a ton of backtraces to deallocate.

Fixes #753.

@brow
