### PR TITLE
oneOf: operator to merge differently typed signals

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -178,6 +178,16 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 // the returned signal sends `error` immediately.
 + (RACSignal *)merge:(id<NSFastEnumeration>)signals;
 
+// Sends an RACTuple containing the latest `next` from any of the signals as its
+// Nth element, where the originating signal is the Nth in the given collection.
+//
+// Each tuple sent by the returned signal contains at most one non-nil value.
+// If one of the input signals sends nil, then an all-nil tuple is sent.
+//
+// The returned signal sends `completed` when all input signals complete. If any
+// signal sends an error, then the returned signal sends `error` imemdiately.
++ (RACSignal *)oneOf:(id<NSFastEnumeration>)signals;
+
 // Merges the signals sent by the receiver into a flattened signal, but only
 // subscribes to `maxConcurrent` number of signals at a time. New signals are
 // queued and subscribed to as other signals complete.


### PR DESCRIPTION
Suppose I want to derive a signal of arrays from a signal of insertions (`addedObjects`) and a signal of deletions (`removedObjectIndexes`), which are applied to an empty array in the order they are sent.

This seems like it should be a merge followed by a scan. But while scanning through the merged signal of insertions and deletions, I need to distinguish between the two kinds of values, not least because one is `NSNumber` and the other can be any `NSObject` type.

Here's a broken approach:

```
[[[RACSignal
 merge:@[addedObjects, removedObjectIndexes]]
 scanWithStart:@[]
 reduce:^(NSArray *running, id next) {
     if ([next isKindOfClass:[NSNumber class]])
         return [running arrayByRemovingObjectAtIndex:[next unsignedIntegerValue]];
     else
         return [running arrayByAddingObject:next];
 }]
 startWith:@[]];
```

Here's what I'd like to be able to do instead:

```
[[[RACSignal
  oneOf:@[addedObjects, removedObjectIndexes]]
  scanWithStart:@[]
  reduce:^(NSArray *running, RACTuple *next) {
      RACTupleUnpack(id addedObject, NSNumber *removedObjectIndex) = next;
      if (removedObjectIndex)
          return [running arrayByRemovingObjectAtIndex:
                  removedObjectIndex.unsignedIntegerValue];
      else if (addedObject)
          return [running arrayByAddingObject:addedObject];
      else
          return running;
  }]
 startWith:@[]];
```

So, if `merge:` is `[Signal a] -> Signal a`, then `oneOf:` is like `Signal a -> Signal b -> Signal (Either a b)`, except that it accepts any number of input signals and uses `RACTuple` as a make-believe `Either`.

Is there a better solution to this case? Is `oneOf:` really needed?
