### PR TITLE
import UIAlertView+RACSignalSupport.h in ReactiveCocoa.h

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
@@ -46,6 +46,7 @@
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
 	#import "RACDelegateProxy.h"
 	#import "UIActionSheet+RACSignalSupport.h"
+	#import "UIAlertView+RACSignalSupport.h"
 	#import "UIBarButtonItem+RACCommandSupport.h"
 	#import "UIButton+RACCommandSupport.h"
 	#import "UIControl+RACSignalSupport.h"


### PR DESCRIPTION
I think that this is more convenient. 
