### PR TITLE
Adding a link to Escape from Callback Hell

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ some more resources for learning about FRP:
 
 * [What is FRP? - Elm Language](http://elm-lang.org/learn/What-is-FRP.elm)
 * [What is Functional Reactive Programming - Stack Overflow](http://stackoverflow.com/questions/1028250/what-is-functional-reactive-programming/1030631#1030631)
-* [Escape from Callback Hell - goto : structured programming :: callbacks : reactive programming](http://elm-lang.org/learn/Escape-from-Callback-Hell.elm)
+* [Escape from Callback Hell](http://elm-lang.org/learn/Escape-from-Callback-Hell.elm)
 
 [Basic Operators]: Documentation/BasicOperators.md
 [Documentation]: Documentation


### PR DESCRIPTION
I thought this article explained the dangers of callback misuse and how FRP addresses these issue. Developers are starting to see how callbacks can [make code unreadable](http://callbackhell.com). Cocoa developers especially are starting to [run into these issue](https://twitter.com/marcoarment/statuses/365683181069942784) with APIs that use blocks.
