### PR TITLE
Mapping with key paths

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/extobjc/EXTKeyPathCoding.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/extobjc/EXTKeyPathCoding.h
@@ -44,6 +44,15 @@ NSString *lowercaseStringPath = @keypath(NSString.new, lowercaseString);
 #define keypath2(OBJ, PATH) \
     (((void)(NO && ((void)OBJ.PATH, NO)), # PATH))
 
+#define mapKeypath(...) \
+    metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__))(mapKeypath1(__VA_ARGS__))(mapKeypath2(__VA_ARGS__))
+
+#define mapKeypath1(PATH) \
+    ^(id x) { return [x valueForKeyPath:@keypath(PATH)]; }
+
+#define mapKeypath2(OBJ, PATH) \
+    ^(id x) { return [x valueForKeyPath:@keypath(OBJ, PATH)]; }
+
 /**
  * \@collectionKeypath allows compile-time verification of key paths across collections NSArray/NSSet etc. Given a real object
  * receiver, collection object receiver and related keypaths:

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACStreamExamples.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACStreamExamples.m
@@ -238,7 +238,7 @@ sharedExamplesFor(RACStreamExamples, ^(NSDictionary *data) {
 			RACTuplePack([streamClass return:@1]),
 			RACTuplePack([streamClass return:@2]),
 		]);
-		RACStream *stream = [baseStream flattenMap:RACMapToKeyPath(@keypath(RACTuple.new, first))];
+		RACStream *stream = [baseStream flattenMap:mapKeypath(RACTuple.new, first)];
 
 		verifyValues(stream, @[ @0, @1, @2 ]);
 	});


### PR DESCRIPTION
I once thought about streams having `-valueForKeyPath:`, as a map operation, but I didn't think it would garner much interest. However, if it's stream aware, it seems a bit more interesting.

While working on some code that looked like this:

``` objc
RAC(self, propertyName) = [[RACObserve(self, currentFoo)
    flattenMap:^(Foo *foo) {
        return [foo bar]; // returns a signal
    }]
    map:^(Bar *bar) {
        return bar.name;
    }];
```

I thought that this might be a nice point to discuss mapping by key path. For example:

``` objc
[RACObserve(self, otherProperty) mapToValueForKeyPath:@"bar.name"];
```

Unfortunately, `@keypath` can't be used because Objective-C typing.

I can see arguments both for and against this. Figured I'd just throw it up an e-note to see what people thought. A name more indicative of it being stream aware would be good too.

@dannygreg 
