### PR TITLE
Gitignore ignores spotlight index files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ build/*
 xcuserdata
 profile
 *.moved-aside
+.DS_STORE
 


### PR DESCRIPTION
Is there a reason why this wasn't already part of it?
