### PR TITLE
Remove nil termination from -rac_liftSelector:withSignals:

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
@@ -26,12 +26,12 @@
 //
 // Examples
 //
-//   [button rac_liftSelector:@selector(setTitleColor:forState:) withSignals:textColorSignal, [RACSignal return:@(UIControlStateNormal)], nil];
+//   [button rac_liftSelector:@selector(setTitleColor:forState:) withSignals:textColorSignal, [RACSignal return:@(UIControlStateNormal)]];
 //
 // Returns a signal which sends the return value from each invocation of the
 // selector. If the selector returns void, it instead sends RACUnit.defaultUnit.
 // It completes only after all the signal arguments complete.
-- (RACSignal *)rac_liftSelector:(SEL)selector withSignals:(RACSignal *)firstSignal, ... NS_REQUIRES_NIL_TERMINATION;
+- (RACSignal *)rac_liftSelector:(SEL)selector withSignals:(RACSignal *)firstSignal, ...;
 
 // Like -rac_liftSelector:withSignals:, but accepts an array instead of
 // a variadic list of arguments.

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.m
@@ -49,11 +49,15 @@
 - (RACSignal *)rac_liftSelector:(SEL)selector withSignals:(RACSignal *)firstSignal, ... {
 	NSCParameterAssert(firstSignal != nil);
 
-	NSMutableArray *signals = [NSMutableArray array];
+	NSMethodSignature *signature = [self methodSignatureForSelector:selector];
+	NSUInteger numberOfArguments = signature.numberOfArguments - 2;
+	NSMutableArray *signals = [NSMutableArray arrayWithCapacity:numberOfArguments];
+	[signals addObject:firstSignal];
 
 	va_list args;
 	va_start(args, firstSignal);
-	for (id currentSignal = firstSignal; currentSignal != nil; currentSignal = va_arg(args, id)) {
+	for (NSUInteger i = 1; i < numberOfArguments; ++i) {
+		RACSignal *currentSignal = va_arg(args, RACSignal *);
 		NSCAssert([currentSignal isKindOfClass:RACSignal.class], @"Argument %@ is not a RACSignal", currentSignal);
 
 		[signals addObject:currentSignal];

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIControl+RACSignalSupportPrivate.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIControl+RACSignalSupportPrivate.m
@@ -35,7 +35,7 @@
 			ignoreValues]
 			catchTo:RACSignal.empty]];
 	[[self
-		rac_liftSelector:@selector(valueForKey:) withSignals:eventSignal, nil]
+		rac_liftSelector:@selector(valueForKey:) withSignals:eventSignal]
 		subscribe:channel.followingTerminal];
 
 	RACSignal *valuesSignal = [channel.followingTerminal

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACLiftingSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/NSObjectRACLiftingSpec.m
@@ -28,7 +28,7 @@ describe(@"-rac_liftSelector:withSignals:", ^{
 
 	it(@"should call the selector with the value of the signal", ^{
 		RACSubject *subject = [RACSubject subject];
-		[object rac_liftSelector:@selector(setObjectValue:) withSignals:subject, nil];
+		[object rac_liftSelector:@selector(setObjectValue:) withSignals:subject];
 
 		expect(object.objectValue).to.beNil();
 


### PR DESCRIPTION
This doesn't break compatibility, it can still be called with a `nil` terminator, but no longer required.
