### PR TITLE
Use Test configuration for Test scheme

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa.xcscheme
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa.xcscheme
@@ -40,7 +40,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Test">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
I noticed the Test scheme was using the Debug configuration. Pretty minor, the Test scheme additionally unsets `CODE_SIGN_ENTITLEMENTS`.
