### PR TITLE
Add an extra slash to header documentation comments

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSArray+RACSequenceAdditions.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSArray+RACSequenceAdditions.h
@@ -12,9 +12,9 @@
 
 @interface NSArray (RACSequenceAdditions)
 
-// Creates and returns a sequence corresponding to the receiver.
-//
-// Mutating the receiver will not affect the sequence after it's been created.
+/// Creates and returns a sequence corresponding to the receiver.
+///
+/// Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACCommandSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACCommandSupport.h
@@ -12,11 +12,11 @@
 
 @interface NSControl (RACCommandSupport)
 
-// Sets the control's command. When the control is clicked, the command is
-// executed with the sender of the event. The control's enabledness is bound
-// to the command's `canExecute`.
-//
-// Note: this will reset the control's target and action.
+/// Sets the control's command. When the control is clicked, the command is
+/// executed with the sender of the event. The control's enabledness is bound
+/// to the command's `canExecute`.
+///
+/// Note: this will reset the control's target and action.
 @property (nonatomic, strong) RACCommand *rac_command;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACTextSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACTextSignalSupport.h
@@ -12,13 +12,13 @@
 
 @interface NSControl (RACTextSignalSupport)
 
-// Observes a text-based control for changes.
-//
-// Using this method on a control without editable text is considered undefined
-// behavior.
-//
-// Returns a signal which sends the current string value of the receiver, then
-// the new value any time it changes.
+/// Observes a text-based control for changes.
+///
+/// Using this method on a control without editable text is considered undefined
+/// behavior.
+///
+/// Returns a signal which sends the current string value of the receiver, then
+/// the new value any time it changes.
 - (RACSignal *)rac_textSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSDictionary+RACSequenceAdditions.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSDictionary+RACSequenceAdditions.h
@@ -12,20 +12,20 @@
 
 @interface NSDictionary (RACSequenceAdditions)
 
-// Creates and returns a sequence of RACTuple key/value pairs. The key will be
-// the first element in the tuple, and the value will be the second.
-//
-// Mutating the receiver will not affect the sequence after it's been created.
+/// Creates and returns a sequence of RACTuple key/value pairs. The key will be
+/// the first element in the tuple, and the value will be the second.
+///
+/// Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
-// Creates and returns a sequence corresponding to the keys in the receiver.
-//
-// Mutating the receiver will not affect the sequence after it's been created.
+/// Creates and returns a sequence corresponding to the keys in the receiver.
+///
+/// Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_keySequence;
 
-// Creates and returns a sequence corresponding to the values in the receiver.
-//
-// Mutating the receiver will not affect the sequence after it's been created.
+/// Creates and returns a sequence corresponding to the values in the receiver.
+///
+/// Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_valueSequence;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSEnumerator+RACSequenceAdditions.h
@@ -12,9 +12,9 @@
 
 @interface NSEnumerator (RACSequenceAdditions)
 
-// Creates and returns a sequence corresponding to the receiver.
-//
-// The receiver is exhausted lazily as the sequence is enumerated.
+/// Creates and returns a sequence corresponding to the receiver.
+///
+/// The receiver is exhausted lazily as the sequence is enumerated.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSInvocation+RACTypeParsing.h
@@ -12,44 +12,44 @@
 
 @interface NSInvocation (RACTypeParsing)
 
-// Sets the argument for the invocation at the given index by unboxing the given
-// object based on the type signature of the argument.
-//
-// This does not support C arrays or unions.
-//
-// Note that calling this on a char * or const char * argument can cause all
-// arguments to be retained.
-//
-// object - The object to unbox and set as the argument.
-// index  - The index of the argument to set.
+/// Sets the argument for the invocation at the given index by unboxing the given
+/// object based on the type signature of the argument.
+///
+/// This does not support C arrays or unions.
+///
+/// Note that calling this on a char * or const char * argument can cause all
+/// arguments to be retained.
+///
+/// object - The object to unbox and set as the argument.
+/// index  - The index of the argument to set.
 - (void)rac_setArgument:(id)object atIndex:(NSUInteger)index;
 
-// Gets the argument for the invocation at the given index based on the
-// invocation's method signature. The value is then wrapped in the appropriate
-// object type.
-//
-// This does not support C arrays or unions.
-//
-// index  - The index of the argument to get.
-//
-// Returns the argument of the invocation, wrapped in an object.
+/// Gets the argument for the invocation at the given index based on the
+/// invocation's method signature. The value is then wrapped in the appropriate
+/// object type.
+///
+/// This does not support C arrays or unions.
+///
+/// index  - The index of the argument to get.
+///
+/// Returns the argument of the invocation, wrapped in an object.
 - (id)rac_argumentAtIndex:(NSUInteger)index;
 
-// Arguments tuple for the invocation.
-//
-// The arguments tuple excludes implicit variables `self` and `_cmd`.
-//
-// See -rac_argumentAtIndex: and -rac_setArgumentAtIndex: for further
-// description of the underlying behavior.
+/// Arguments tuple for the invocation.
+///
+/// The arguments tuple excludes implicit variables `self` and `_cmd`.
+///
+/// See -rac_argumentAtIndex: and -rac_setArgumentAtIndex: for further
+/// description of the underlying behavior.
 @property (nonatomic, copy) RACTuple *rac_argumentsTuple;
 
-// Gets the return value from the invocation based on the invocation's method
-// signature. The value is then wrapped in the appropriate object type.
-//
-// This does not support C arrays or unions.
-//
-// Returns the return value of the invocation, wrapped in an object. Voids are
-// returned as `RACUnit.defaultUnit`.
+/// Gets the return value from the invocation based on the invocation's method
+/// signature. The value is then wrapped in the appropriate object type.
+///
+/// This does not support C arrays or unions.
+///
+/// Returns the return value of the invocation, wrapped in an object. Voids are
+/// returned as `RACUnit.defaultUnit`.
 - (id)rac_returnValue;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACAppKitBindings.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACAppKitBindings.h
@@ -12,20 +12,20 @@
 
 @interface NSObject (RACAppKitBindings)
 
-// Invokes -rac_channelToBinding:options: without any options.
+/// Invokes -rac_channelToBinding:options: without any options.
 - (RACChannelTerminal *)rac_channelToBinding:(NSString *)binding;
 
-// Applies a Cocoa binding to the receiver, then exposes a RACChannel-based
-// interface for manipulating it.
-//
-// Creating two of the same bindings on the same object will result in undefined
-// behavior.
-//
-// binding - The name of the binding. This must not be nil.
-// options - Any options to pass to Cocoa Bindings. This may be nil.
-//
-// Returns a RACChannelTerminal which will send future values from the receiver,
-// and update the receiver when values are sent to the terminal.
+/// Applies a Cocoa binding to the receiver, then exposes a RACChannel-based
+/// interface for manipulating it.
+///
+/// Creating two of the same bindings on the same object will result in undefined
+/// behavior.
+///
+/// binding - The name of the binding. This must not be nil.
+/// options - Any options to pass to Cocoa Bindings. This may be nil.
+///
+/// Returns a RACChannelTerminal which will send future values from the receiver,
+/// and update the receiver when values are sent to the terminal.
 - (RACChannelTerminal *)rac_channelToBinding:(NSString *)binding options:(NSDictionary *)options;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACDeallocating.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACDeallocating.h
@@ -14,11 +14,11 @@
 
 @interface NSObject (RACDeallocating)
 
-// The compound disposable which will be disposed of when the receiver is
-// deallocated.
+/// The compound disposable which will be disposed of when the receiver is
+/// deallocated.
 @property (atomic, readonly, strong) RACCompoundDisposable *rac_deallocDisposable;
 
-// Returns a signal that will complete immediately before the receiver is fully deallocated.
+/// Returns a signal that will complete immediately before the receiver is fully deallocated.
 - (RACSignal *)rac_willDeallocSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACDescription.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACDescription.h
@@ -10,11 +10,11 @@
 
 @interface NSObject (RACDescription)
 
-// A simplified description of the receiver for Debug builds, which does not
-// invoke -description (and thus should be much faster in many cases).
-//
-// This method will return a constant string in Release builds, skipping any
-// work.
+/// A simplified description of the receiver for Debug builds, which does not
+/// invoke -description (and thus should be much faster in many cases).
+///
+/// This method will return a constant string in Release builds, skipping any
+/// work.
 - (NSString *)rac_description;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACKVOWrapper.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACKVOWrapper.h
@@ -9,39 +9,39 @@
 #import <Foundation/Foundation.h>
 
 
-// RAC-specific KVO change dictionary key: Will be @YES if the change was caused
-// by the value at the key path or an intermediate value deallocating, @NO
-// otherwise.
+/// RAC-specific KVO change dictionary key: Will be @YES if the change was caused
+/// by the value at the key path or an intermediate value deallocating, @NO
+/// otherwise.
 extern NSString * const RACKeyValueChangeCausedByDeallocationKey;
 
-// RAC-specific KVO change dictionary key: Will be @YES if the change only
-// affected the value of the last key path component leaving the values of the
-// intermediate key path components unaltered, @NO otherwise.
+/// RAC-specific KVO change dictionary key: Will be @YES if the change only
+/// affected the value of the last key path component leaving the values of the
+/// intermediate key path components unaltered, @NO otherwise.
 extern NSString * const RACKeyValueChangeAffectedOnlyLastComponentKey;
 
 @class RACDisposable, RACKVOTrampoline;
 
 @interface NSObject (RACKVOWrapper)
 
-// Adds the given block as the callbacks for when the key path changes.
-//
-// Unlike direct KVO observation, this handles deallocation of `weak` properties
-// by generating an appropriate notification. This will only occur if there is
-// an `@property` declaration visible in the observed class, with the `weak`
-// memory management attribute.
-//
-// The observation does not need to be explicitly removed. It will be removed
-// when the observer or the receiver deallocate.
-//
-// keyPath  - The key path to observe. Must not be nil.
-// options  - The KVO observation options.
-// observer - The object that requested the observation. May be nil.
-// block    - The block called when the value at the key path changes. It is
-//            passed the current value of the key path and the extended KVO
-//            change dictionary including RAC-specific keys and values. Must not
-//            be nil.
-//
-// Returns a disposable that can be used to stop the observation.
+/// Adds the given block as the callbacks for when the key path changes.
+///
+/// Unlike direct KVO observation, this handles deallocation of `weak` properties
+/// by generating an appropriate notification. This will only occur if there is
+/// an `@property` declaration visible in the observed class, with the `weak`
+/// memory management attribute.
+///
+/// The observation does not need to be explicitly removed. It will be removed
+/// when the observer or the receiver deallocate.
+///
+/// keyPath  - The key path to observe. Must not be nil.
+/// options  - The KVO observation options.
+/// observer - The object that requested the observation. May be nil.
+/// block    - The block called when the value at the key path changes. It is
+///            passed the current value of the key path and the extended KVO
+///            change dictionary including RAC-specific keys and values. Must not
+///            be nil.
+///
+/// Returns a disposable that can be used to stop the observation.
 - (RACDisposable *)rac_observeKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer block:(void (^)(id value, NSDictionary *change))block;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
@@ -10,31 +10,31 @@
 
 @interface NSObject (RACLifting)
 
-// Lifts the selector on the receiver into the reactive world. The selector will
-// be invoked whenever any signal argument sends a value, but only after each
-// signal has sent an initial value.
-//
-// It will replay the most recently sent value to new subscribers.
-//
-// This does not support C arrays or unions.
-//
-// selector    - The selector on self to invoke.
-// firstSignal - The signal corresponding to the first method argument. This
-//               must not be nil.
-// ...         - A list of RACSignals corresponding to the remaining arguments.
-//               There must be a non-nil signal for each method argument.
-//
-// Examples
-//
-//   [button rac_liftSelector:@selector(setTitleColor:forState:) withSignals:textColorSignal, [RACSignal return:@(UIControlStateNormal)], nil];
-//
-// Returns a signal which sends the return value from each invocation of the
-// selector. If the selector returns void, it instead sends RACUnit.defaultUnit.
-// It completes only after all the signal arguments complete.
+/// Lifts the selector on the receiver into the reactive world. The selector will
+/// be invoked whenever any signal argument sends a value, but only after each
+/// signal has sent an initial value.
+///
+/// It will replay the most recently sent value to new subscribers.
+///
+/// This does not support C arrays or unions.
+///
+/// selector    - The selector on self to invoke.
+/// firstSignal - The signal corresponding to the first method argument. This
+///               must not be nil.
+/// ...         - A list of RACSignals corresponding to the remaining arguments.
+///               There must be a non-nil signal for each method argument.
+///
+/// Examples
+///
+///   [button rac_liftSelector:@selector(setTitleColor:forState:) withSignals:textColorSignal, [RACSignal return:@(UIControlStateNormal)], nil];
+///
+/// Returns a signal which sends the return value from each invocation of the
+/// selector. If the selector returns void, it instead sends RACUnit.defaultUnit.
+/// It completes only after all the signal arguments complete.
 - (RACSignal *)rac_liftSelector:(SEL)selector withSignals:(RACSignal *)firstSignal, ... NS_REQUIRES_NIL_TERMINATION;
 
-// Like -rac_liftSelector:withSignals:, but accepts an array instead of
-// a variadic list of arguments.
+/// Like -rac_liftSelector:withSignals:, but accepts an array instead of
+/// a variadic list of arguments.
 - (RACSignal *)rac_liftSelector:(SEL)selector withSignalsFromArray:(NSArray *)signals;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.h
@@ -10,42 +10,42 @@
 #import "EXTKeyPathCoding.h"
 #import "metamacros.h"
 
-// Creates a signal which observes `KEYPATH` on `TARGET` for changes.
-//
-// In either case, the observation continues until `TARGET` _or self_ is
-// deallocated. If any intermediate object is deallocated instead, it will be
-// assumed to have been set to nil.
-//
-// Make sure to `@strongify(self)` when using this macro within a block! The
-// macro will _always_ reference `self`, which can silently introduce a retain
-// cycle within a block. As a result, you should make sure that `self` is a weak
-// reference (e.g., created by `@weakify` and `@strongify`) before the
-// expression that uses `RACObserve`.
-//
-// Examples
-//
-//    // Observes self, and doesn't stop until self is deallocated.
-//    RACSignal *selfSignal = RACObserve(self, arrayController.items);
-//
-//    // Observes the array controller, and stops when self _or_ the array
-//    // controller is deallocated.
-//    RACSignal *arrayControllerSignal = RACObserve(self.arrayController, items);
-//
-//    // Observes obj.arrayController, and stops when self _or_ the array
-//    // controller is deallocated.
-//    RACSignal *signal2 = RACObserve(obj.arrayController, items);
-//
-//    @weakify(self);
-//    RACSignal *signal3 = [anotherSignal flattenMap:^(NSArrayController *arrayController) {
-//        // Avoids a retain cycle because of RACObserve implicitly referencing
-//        // self.
-//        @strongify(self);
-//        return RACObserve(arrayController, items);
-//    }];
-//
-// Returns a signal which sends the current value of the key path on
-// subscription, then sends the new value every time it changes, and sends
-// completed if self or observer is deallocated.
+/// Creates a signal which observes `KEYPATH` on `TARGET` for changes.
+///
+/// In either case, the observation continues until `TARGET` _or self_ is
+/// deallocated. If any intermediate object is deallocated instead, it will be
+/// assumed to have been set to nil.
+///
+/// Make sure to `@strongify(self)` when using this macro within a block! The
+/// macro will _always_ reference `self`, which can silently introduce a retain
+/// cycle within a block. As a result, you should make sure that `self` is a weak
+/// reference (e.g., created by `@weakify` and `@strongify`) before the
+/// expression that uses `RACObserve`.
+///
+/// Examples
+///
+///    // Observes self, and doesn't stop until self is deallocated.
+///    RACSignal *selfSignal = RACObserve(self, arrayController.items);
+///
+///    // Observes the array controller, and stops when self _or_ the array
+///    // controller is deallocated.
+///    RACSignal *arrayControllerSignal = RACObserve(self.arrayController, items);
+///
+///    // Observes obj.arrayController, and stops when self _or_ the array
+///    // controller is deallocated.
+///    RACSignal *signal2 = RACObserve(obj.arrayController, items);
+///
+///    @weakify(self);
+///    RACSignal *signal3 = [anotherSignal flattenMap:^(NSArrayController *arrayController) {
+///        // Avoids a retain cycle because of RACObserve implicitly referencing
+///        // self.
+///        @strongify(self);
+///        return RACObserve(arrayController, items);
+///    }];
+///
+/// Returns a signal which sends the current value of the key path on
+/// subscription, then sends the new value every time it changes, and sends
+/// completed if self or observer is deallocated.
 #define RACObserve(TARGET, KEYPATH) \
     [(TARGET) rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]
 
@@ -54,24 +54,24 @@
 
 @interface NSObject (RACPropertySubscribing)
 
-// Creates a signal to observe the value at the given key path.
-//
-// The initial value is sent on subscription, the subsequent values are sent
-// from whichever thread the change occured on, even if it doesn't have a valid
-// scheduler.
-//
-// Returns a signal that immediately sends the receiver's current value at the
-// given keypath, then any changes thereafter.
+/// Creates a signal to observe the value at the given key path.
+///
+/// The initial value is sent on subscription, the subsequent values are sent
+/// from whichever thread the change occured on, even if it doesn't have a valid
+/// scheduler.
+///
+/// Returns a signal that immediately sends the receiver's current value at the
+/// given keypath, then any changes thereafter.
 - (RACSignal *)rac_valuesForKeyPath:(NSString *)keyPath observer:(NSObject *)observer;
 
-// Creates a signal to observe the changes of the given key path.
-//
-// The initial value is sent on subscription, the subsequent values are sent
-// from whichever thread the change occured on, even if it doesn't have a valid
-// scheduler.
-//
-// Returns a signal that sends tuples containing the current value at the key
-// path and the change dictionary for each KVO callback.
+/// Creates a signal to observe the changes of the given key path.
+///
+/// The initial value is sent on subscription, the subsequent values are sent
+/// from whichever thread the change occured on, even if it doesn't have a valid
+/// scheduler.
+///
+/// Returns a signal that sends tuples containing the current value at the key
+/// path and the change dictionary for each KVO callback.
 - (RACSignal *)rac_valuesAndChangesForKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACSelectorSignal.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACSelectorSignal.h
@@ -10,70 +10,70 @@
 
 @class RACSignal;
 
-// The domain for any errors originating from -rac_signalForSelector:.
+/// The domain for any errors originating from -rac_signalForSelector:.
 extern NSString * const RACSelectorSignalErrorDomain;
 
-// -rac_signalForSelector: was going to add a new method implementation for
-// `selector`, but another thread added an implementation before it was able to.
-//
-// This will _not_ occur for cases where a method implementation exists before
-// -rac_signalForSelector: is invoked.
+/// -rac_signalForSelector: was going to add a new method implementation for
+/// `selector`, but another thread added an implementation before it was able to.
+///
+/// This will _not_ occur for cases where a method implementation exists before
+/// -rac_signalForSelector: is invoked.
 extern const NSInteger RACSelectorSignalErrorMethodSwizzlingRace;
 
 @interface NSObject (RACSelectorSignal)
 
-// Creates a signal associated with the receiver, which will send a tuple of the
-// method's arguments each time the given selector is invoked.
-//
-// If the selector is already implemented on the receiver, the existing
-// implementation will be invoked _before_ the signal fires.
-//
-// If the selector is not yet implemented on the receiver, the injected
-// implementation will have a `void` return type and accept only object
-// arguments. Invoking the added implementation with non-object values, or
-// expecting a return value, will result in undefined behavior.
-//
-// This is useful for changing an event or delegate callback into a signal. For
-// example, on an NSView:
-//
-//     [[view rac_signalForSelector:@selector(mouseDown:)] subscribeNext:^(RACTuple *args) {
-//         NSEvent *event = args.first;
-//         NSLog(@"mouse button pressed: %@", event);
-//     }];
-//
-// selector - The selector for whose invocations are to be observed. If it
-//            doesn't exist, it will be implemented to accept object arguments
-//            and return void. This cannot have C arrays or unions as arguments
-//            or C arrays, unions, structs, complex or vector types as return
-//            type.
-//
-// Returns a signal which will send a tuple of arguments upon each invocation of
-// the selector, then completes when the receiver is deallocated. `next` events
-// will be sent synchronously from the thread that invoked the method. If
-// a runtime call fails, the signal will send an error in the
-// RACSelectorSignalErrorDomain.
+/// Creates a signal associated with the receiver, which will send a tuple of the
+/// method's arguments each time the given selector is invoked.
+///
+/// If the selector is already implemented on the receiver, the existing
+/// implementation will be invoked _before_ the signal fires.
+///
+/// If the selector is not yet implemented on the receiver, the injected
+/// implementation will have a `void` return type and accept only object
+/// arguments. Invoking the added implementation with non-object values, or
+/// expecting a return value, will result in undefined behavior.
+///
+/// This is useful for changing an event or delegate callback into a signal. For
+/// example, on an NSView:
+///
+///     [[view rac_signalForSelector:@selector(mouseDown:)] subscribeNext:^(RACTuple *args) {
+///         NSEvent *event = args.first;
+///         NSLog(@"mouse button pressed: %@", event);
+///     }];
+///
+/// selector - The selector for whose invocations are to be observed. If it
+///            doesn't exist, it will be implemented to accept object arguments
+///            and return void. This cannot have C arrays or unions as arguments
+///            or C arrays, unions, structs, complex or vector types as return
+///            type.
+///
+/// Returns a signal which will send a tuple of arguments upon each invocation of
+/// the selector, then completes when the receiver is deallocated. `next` events
+/// will be sent synchronously from the thread that invoked the method. If
+/// a runtime call fails, the signal will send an error in the
+/// RACSelectorSignalErrorDomain.
 - (RACSignal *)rac_signalForSelector:(SEL)selector;
 
-// Behaves like -rac_signalForSelector:, but if the selector is not yet
-// implemented on the receiver, its method signature is looked up within
-// `protocol`, and may accept non-object arguments.
-//
-// If the selector is not yet implemented and has a return value, the injected
-// method will return all zero bits (equal to `nil`, `NULL`, 0, 0.0f, etc.).
-//
-// selector - The selector for whose invocations are to be observed. If it
-//            doesn't exist, it will be implemented using information from
-//            `protocol`, and may accept non-object arguments and return
-//            a value. This cannot have C arrays or unions as arguments or
-//            return type.
-// protocol - The protocol in which `selector` is declared. This will be used
-//            for type information if the selector is not already implemented on
-//            the receiver. This must not be `NULL`, and `selector` must exist
-//            in this protocol.
-//
-// Returns a signal which will send a tuple of arguments on each invocation of
-// the selector, or an error in RACSelectorSignalErrorDomain if a runtime
-// call fails.
+/// Behaves like -rac_signalForSelector:, but if the selector is not yet
+/// implemented on the receiver, its method signature is looked up within
+/// `protocol`, and may accept non-object arguments.
+///
+/// If the selector is not yet implemented and has a return value, the injected
+/// method will return all zero bits (equal to `nil`, `NULL`, 0, 0.0f, etc.).
+///
+/// selector - The selector for whose invocations are to be observed. If it
+///            doesn't exist, it will be implemented using information from
+///            `protocol`, and may accept non-object arguments and return
+///            a value. This cannot have C arrays or unions as arguments or
+///            return type.
+/// protocol - The protocol in which `selector` is declared. This will be used
+///            for type information if the selector is not already implemented on
+///            the receiver. This must not be `NULL`, and `selector` must exist
+///            in this protocol.
+///
+/// Returns a signal which will send a tuple of arguments on each invocation of
+/// the selector, or an error in RACSelectorSignalErrorDomain if a runtime
+/// call fails.
 - (RACSignal *)rac_signalForSelector:(SEL)selector fromProtocol:(Protocol *)protocol;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSOrderedSet+RACSequenceAdditions.h
@@ -12,9 +12,9 @@
 
 @interface NSOrderedSet (RACSequenceAdditions)
 
-// Creates and returns a sequence corresponding to the receiver.
-//
-// Mutating the receiver will not affect the sequence after it's been created.
+/// Creates and returns a sequence corresponding to the receiver.
+///
+/// Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSSet+RACSequenceAdditions.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSSet+RACSequenceAdditions.h
@@ -12,9 +12,9 @@
 
 @interface NSSet (RACSequenceAdditions)
 
-// Creates and returns a sequence corresponding to the receiver.
-//
-// Mutating the receiver will not affect the sequence after it's been created.
+/// Creates and returns a sequence corresponding to the receiver.
+///
+/// Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACKeyPathUtilities.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACKeyPathUtilities.h
@@ -10,24 +10,24 @@
 
 @interface NSString (RACKeyPathUtilities)
 
-// Returns an array of the components of the receiver.
-//
-// Calling this method on a string that isn't a key path is considered undefined
-// behavior.
+/// Returns an array of the components of the receiver.
+///
+/// Calling this method on a string that isn't a key path is considered undefined
+/// behavior.
 - (NSArray *)rac_keyPathComponents;
 
-// Returns a key path with all the components of the receiver except for the
-// last one.
-//
-// Calling this method on a string that isn't a key path is considered undefined
-// behavior.
+/// Returns a key path with all the components of the receiver except for the
+/// last one.
+///
+/// Calling this method on a string that isn't a key path is considered undefined
+/// behavior.
 - (NSString *)rac_keyPathByDeletingLastKeyPathComponent;
 
-// Returns a key path with all the components of the receiver expect for the
-// first one.
-//
-// Calling this method on a string that isn't a key path is considered undefined
-// behavior.
+/// Returns a key path with all the components of the receiver expect for the
+/// first one.
+///
+/// Calling this method on a string that isn't a key path is considered undefined
+/// behavior.
 - (NSString *)rac_keyPathByDeletingFirstKeyPathComponent;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACSequenceAdditions.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACSequenceAdditions.h
@@ -12,10 +12,10 @@
 
 @interface NSString (RACSequenceAdditions)
 
-// Creates and returns a sequence containing strings corresponding to each
-// composed character sequence in the receiver.
-//
-// Mutating the receiver will not affect the sequence after it's been created.
+/// Creates and returns a sequence containing strings corresponding to each
+/// composed character sequence in the receiver.
+///
+/// Mutating the receiver will not affect the sequence after it's been created.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/NSText+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSText+RACSignalSupport.h
@@ -12,8 +12,8 @@
 
 @interface NSText (RACSignalSupport)
 
-// Returns a signal which sends the current `string` of the receiver, then the
-// new value any time it changes.
+/// Returns a signal which sends the current `string` of the receiver, then the
+/// new value any time it changes.
 - (RACSignal *)rac_textSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACArraySequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACArraySequence.h
@@ -8,11 +8,11 @@
 
 #import "RACSequence.h"
 
-// Private class that adapts an array to the RACSequence interface.
+/// Private class that adapts an array to the RACSequence interface.
 @interface RACArraySequence : RACSequence
 
-// Returns a sequence for enumerating over the given array, starting from the
-// given offset. The array will be copied to prevent mutation.
+/// Returns a sequence for enumerating over the given array, starting from the
+/// given offset. The array will be copied to prevent mutation.
 + (instancetype)sequenceWithArray:(NSArray *)array offset:(NSUInteger)offset;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.h
@@ -22,38 +22,38 @@ extern void rac_dispatch_after_f(dispatch_time_t time, dispatch_queue_t queue, v
 #define dispatch_barrier_async_f rac_dispatch_barrier_async_f
 #define dispatch_after_f rac_dispatch_after_f
 
-// Preserves backtraces across asynchronous calls.
-//
-// On OS X, you can enable the automatic capturing of asynchronous backtraces
-// (in Debug builds) by setting the `DYLD_INSERT_LIBRARIES` environment variable
-// to `@executable_path/../Frameworks/ReactiveCocoa.framework/ReactiveCocoa` in
-// your scheme's Run action settings.
-//
-// On iOS, your project and RAC will automatically use the `rac_` GCD functions
-// (declared above) for asynchronous work. Unfortunately, unlike OS X, it's
-// impossible to capture backtraces inside NSOperationQueue or other code
-// outside of your project.
-//
-// Once backtraces are being captured, you can `po [RACBacktrace backtrace]` in
-// the debugger to print them out at any time. You can even set up an alias in
-// ~/.lldbinit to do so:
-//
-//    command alias racbt po [RACBacktrace backtrace]
-// 
+/// Preserves backtraces across asynchronous calls.
+///
+/// On OS X, you can enable the automatic capturing of asynchronous backtraces
+/// (in Debug builds) by setting the `DYLD_INSERT_LIBRARIES` environment variable
+/// to `@executable_path/../Frameworks/ReactiveCocoa.framework/ReactiveCocoa` in
+/// your scheme's Run action settings.
+///
+/// On iOS, your project and RAC will automatically use the `rac_` GCD functions
+/// (declared above) for asynchronous work. Unfortunately, unlike OS X, it's
+/// impossible to capture backtraces inside NSOperationQueue or other code
+/// outside of your project.
+///
+/// Once backtraces are being captured, you can `po [RACBacktrace backtrace]` in
+/// the debugger to print them out at any time. You can even set up an alias in
+/// ~/.lldbinit to do so:
+///
+///    command alias racbt po [RACBacktrace backtrace]
+/// 
 @interface RACBacktrace : NSObject
 
-// The backtrace from any previous thread.
+/// The backtrace from any previous thread.
 @property (nonatomic, strong, readonly) RACBacktrace *previousThreadBacktrace;
 
-// The call stack of this backtrace's thread.
+/// The call stack of this backtrace's thread.
 @property (nonatomic, copy, readonly) NSArray *callStackSymbols;
 
-// Captures the current thread's backtrace, appending it to any backtrace from
-// a previous thread.
+/// Captures the current thread's backtrace, appending it to any backtrace from
+/// a previous thread.
 + (instancetype)backtrace;
 
-// Same as +backtrace, but omits the specified number of frames at the
-// top of the stack (in addition to this method itself).
+/// Same as +backtrace, but omits the specified number of frames at the
+/// top of the stack (in addition to this method itself).
 + (instancetype)backtraceIgnoringFrames:(NSUInteger)ignoreCount;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBehaviorSubject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBehaviorSubject.h
@@ -9,11 +9,11 @@
 #import "RACSubject.h"
 
 
-// A behavior subject sends the last value it received when it is subscribed to.
+/// A behavior subject sends the last value it received when it is subscribed to.
 @interface RACBehaviorSubject : RACSubject
 
-// Creates a new behavior subject with a default value. If it hasn't received
-// any values when it gets subscribed to, it sends the default value.
+/// Creates a new behavior subject with a default value. If it hasn't received
+/// any values when it gets subscribed to, it sends the default value.
 + (instancetype)behaviorSubjectWithDefaultValue:(id)value;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBlockTrampoline.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBlockTrampoline.h
@@ -10,21 +10,21 @@
 
 @class RACTuple;
 
-// Allows a limited type of dynamic block invocation.
+/// Allows a limited type of dynamic block invocation.
 @interface RACBlockTrampoline : NSObject
 
-// Invokes the given block with the given arguments. All of the block's
-// argument types must be objects and it must be typed to return an object.
-//
-// At this time, it only supports blocks that take up to 15 arguments. Any more
-// is just cray.
-//
-// block     - The block to invoke. Must accept as many arguments as are given in
-//             the arguments array. Cannot be nil.
-// arguments - The arguments with which to invoke the block. `RACTupleNil`s will
-//             be passed as nils.
-//
-// Returns the return value of invoking the block.
+/// Invokes the given block with the given arguments. All of the block's
+/// argument types must be objects and it must be typed to return an object.
+///
+/// At this time, it only supports blocks that take up to 15 arguments. Any more
+/// is just cray.
+///
+/// block     - The block to invoke. Must accept as many arguments as are given in
+///             the arguments array. Cannot be nil.
+/// arguments - The arguments with which to invoke the block. `RACTupleNil`s will
+///             be passed as nils.
+///
+/// Returns the return value of invoking the block.
 + (id)invokeBlock:(id)block withArguments:(RACTuple *)arguments;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACChannel.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACChannel.h
@@ -11,58 +11,58 @@
 
 @class RACChannelTerminal;
 
-// A two-way channel.
-//
-// Conceptually, RACChannel can be thought of as a bidirectional connection,
-// composed of two controllable signals that work in parallel.
-//
-// For example, when connecting between a view and a model:
-//
-//        Model                      View
-//  `leadingTerminal` ------> `followingTerminal`
-//  `leadingTerminal` <------ `followingTerminal`
-//
-// The initial value of the model and all future changes to it are _sent on_ the
-// `leadingTerminal`, and _received by_ subscribers of the `followingTerminal`.
-//
-// Likewise, whenever the user changes the value of the view, that value is sent
-// on the `followingTerminal`, and received in the model from the
-// `leadingTerminal`. However, the initial value of the view is not received
-// from the `leadingTerminal` (only future changes).
+/// A two-way channel.
+///
+/// Conceptually, RACChannel can be thought of as a bidirectional connection,
+/// composed of two controllable signals that work in parallel.
+///
+/// For example, when connecting between a view and a model:
+///
+///        Model                      View
+///  `leadingTerminal` ------> `followingTerminal`
+///  `leadingTerminal` <------ `followingTerminal`
+///
+/// The initial value of the model and all future changes to it are _sent on_ the
+/// `leadingTerminal`, and _received by_ subscribers of the `followingTerminal`.
+///
+/// Likewise, whenever the user changes the value of the view, that value is sent
+/// on the `followingTerminal`, and received in the model from the
+/// `leadingTerminal`. However, the initial value of the view is not received
+/// from the `leadingTerminal` (only future changes).
 @interface RACChannel : NSObject
 
-// The terminal which "leads" the channel, by sending its latest value
-// immediately to new subscribers of the `followingTerminal`.
-//
-// New subscribers to this terminal will not receive a starting value, but will
-// receive all future values that are sent to the `followingTerminal`.
+/// The terminal which "leads" the channel, by sending its latest value
+/// immediately to new subscribers of the `followingTerminal`.
+///
+/// New subscribers to this terminal will not receive a starting value, but will
+/// receive all future values that are sent to the `followingTerminal`.
 @property (nonatomic, strong, readonly) RACChannelTerminal *leadingTerminal;
 
-// The terminal which "follows" the lead of the other terminal, only sending
-// _future_ values to the subscribers of the `leadingTerminal`.
-//
-// The latest value sent to the `leadingTerminal` (if any) will be sent
-// immediately to new subscribers of this terminal, and then all future values
-// as well.
+/// The terminal which "follows" the lead of the other terminal, only sending
+/// _future_ values to the subscribers of the `leadingTerminal`.
+///
+/// The latest value sent to the `leadingTerminal` (if any) will be sent
+/// immediately to new subscribers of this terminal, and then all future values
+/// as well.
 @property (nonatomic, strong, readonly) RACChannelTerminal *followingTerminal;
 
 @end
 
-// Represents one end of a RACChannel.
-//
-// An terminal is similar to a socket or pipe -- it represents one end of
-// a connection (the RACChannel, in this case). Values sent to this terminal
-// will _not_ be received by its subscribers. Instead, the values will be sent
-// to the subscribers of the RACChannel's _other_ terminal.
-//
-// For example, when using the `followingTerminal`, _sent_ values can only be
-// _received_ from the `leadingTerminal`, and vice versa.
-//
-// To make it easy to terminate a RACChannel, `error` and `completed` events
-// sent to either terminal will be received by the subscribers of _both_
-// terminals.
-//
-// Do not instantiate this class directly. Create a RACChannel instead.
+/// Represents one end of a RACChannel.
+///
+/// An terminal is similar to a socket or pipe -- it represents one end of
+/// a connection (the RACChannel, in this case). Values sent to this terminal
+/// will _not_ be received by its subscribers. Instead, the values will be sent
+/// to the subscribers of the RACChannel's _other_ terminal.
+///
+/// For example, when using the `followingTerminal`, _sent_ values can only be
+/// _received_ from the `leadingTerminal`, and vice versa.
+///
+/// To make it easy to terminate a RACChannel, `error` and `completed` events
+/// sent to either terminal will be received by the subscribers of _both_
+/// terminals.
+///
+/// Do not instantiate this class directly. Create a RACChannel instead.
 @interface RACChannelTerminal : RACSignal <RACSubscriber>
 
 - (id)init __attribute__((unavailable("Instantiate a RACChannel instead")));

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.h
@@ -10,103 +10,103 @@
 
 @class RACSignal;
 
-// The domain for errors originating within `RACCommand`.
+/// The domain for errors originating within `RACCommand`.
 extern NSString * const RACCommandErrorDomain;
 
-// -execute: was invoked while the command was disabled.
+/// -execute: was invoked while the command was disabled.
 extern const NSInteger RACCommandErrorNotEnabled;
 
-// A `userInfo` key for an error, associated with the `RACCommand` that the
-// error originated from.
-//
-// This is included only when the error code is `RACCommandErrorNotEnabled`.
+/// A `userInfo` key for an error, associated with the `RACCommand` that the
+/// error originated from.
+///
+/// This is included only when the error code is `RACCommandErrorNotEnabled`.
 extern NSString * const RACUnderlyingCommandErrorKey;
 
-// A command is a signal triggered in response to some action, typically
-// UI-related.
+/// A command is a signal triggered in response to some action, typically
+/// UI-related.
 @interface RACCommand : NSObject
 
-// A signal of the signals returned by successful invocations of -execute:
-// (i.e., while the receiver is `enabled`).
-//
-// Errors will be automatically caught upon the inner signals, and sent upon
-// `errors` instead. If you _want_ to receive inner errors, use -execute: or
-// -[RACSignal materialize].
-// 
-// Only executions that begin _after_ subscription will be sent upon this
-// signal. All inner signals will arrive upon the main thread.
+/// A signal of the signals returned by successful invocations of -execute:
+/// (i.e., while the receiver is `enabled`).
+///
+/// Errors will be automatically caught upon the inner signals, and sent upon
+/// `errors` instead. If you _want_ to receive inner errors, use -execute: or
+/// -[RACSignal materialize].
+/// 
+/// Only executions that begin _after_ subscription will be sent upon this
+/// signal. All inner signals will arrive upon the main thread.
 @property (nonatomic, strong, readonly) RACSignal *executionSignals;
 
-// A signal of whether this command is currently executing.
-//
-// This will send YES whenever -execute: is invoked and the created signal has
-// not yet terminated. Once all executions have terminated, `executing` will
-// send NO.
-//
-// This signal will send its current value upon subscription, and then all
-// future values on the main thread.
+/// A signal of whether this command is currently executing.
+///
+/// This will send YES whenever -execute: is invoked and the created signal has
+/// not yet terminated. Once all executions have terminated, `executing` will
+/// send NO.
+///
+/// This signal will send its current value upon subscription, and then all
+/// future values on the main thread.
 @property (nonatomic, strong, readonly) RACSignal *executing;
 
-// A signal of whether this command is able to execute.
-//
-// This will send NO if:
-//
-//  - The command was created with an `enabledSignal`, and NO is sent upon that
-//    signal, or
-//  - `allowsConcurrentExecution` is NO and the command has started executing.
-//
-// Once the above conditions are no longer met, the signal will send YES.
-//
-// This signal will send its current value upon subscription, and then all
-// future values on the main thread.
+/// A signal of whether this command is able to execute.
+///
+/// This will send NO if:
+///
+///  - The command was created with an `enabledSignal`, and NO is sent upon that
+///    signal, or
+///  - `allowsConcurrentExecution` is NO and the command has started executing.
+///
+/// Once the above conditions are no longer met, the signal will send YES.
+///
+/// This signal will send its current value upon subscription, and then all
+/// future values on the main thread.
 @property (nonatomic, strong, readonly) RACSignal *enabled;
 
-// Forwards any errors that occur within signals returned by -execute:.
-//
-// When an error occurs on a signal returned from -execute:, this signal will
-// send the associated NSError value as a `next` event (since an `error` event
-// would terminate the stream).
-//
-// After subscription, this signal will send all future errors on the main
-// thread.
+/// Forwards any errors that occur within signals returned by -execute:.
+///
+/// When an error occurs on a signal returned from -execute:, this signal will
+/// send the associated NSError value as a `next` event (since an `error` event
+/// would terminate the stream).
+///
+/// After subscription, this signal will send all future errors on the main
+/// thread.
 @property (nonatomic, strong, readonly) RACSignal *errors;
 
-// Whether the command allows multiple executions to proceed concurrently.
-//
-// The default value for this property is NO.
+/// Whether the command allows multiple executions to proceed concurrently.
+///
+/// The default value for this property is NO.
 @property (atomic, assign) BOOL allowsConcurrentExecution;
 
-// Invokes -initWithSignalBlock:enabled: with a nil `enabledSignal`.
+/// Invokes -initWithSignalBlock:enabled: with a nil `enabledSignal`.
 - (id)initWithSignalBlock:(RACSignal * (^)(id input))signalBlock;
 
-// Initializes a command that is conditionally enabled.
-//
-// This is the designated initializer for this class.
-//
-// enabledSignal - A signal of BOOLs which indicate whether the command should
-//                 be enabled. `enabled` will be based on the latest value sent
-//                 from this signal. Before any values are sent, `enabled` will
-//                 default to YES. This argument may be nil.
-// signalBlock   - A block which will map each input value (passed to -execute:)
-//                 to a signal of work. The returned signal will be multicasted
-//                 to a replay subject, sent on `executionSignals`, then
-//                 subscribed to synchronously. Neither the block nor the
-//                 returned signal may be nil.
+/// Initializes a command that is conditionally enabled.
+///
+/// This is the designated initializer for this class.
+///
+/// enabledSignal - A signal of BOOLs which indicate whether the command should
+///                 be enabled. `enabled` will be based on the latest value sent
+///                 from this signal. Before any values are sent, `enabled` will
+///                 default to YES. This argument may be nil.
+/// signalBlock   - A block which will map each input value (passed to -execute:)
+///                 to a signal of work. The returned signal will be multicasted
+///                 to a replay subject, sent on `executionSignals`, then
+///                 subscribed to synchronously. Neither the block nor the
+///                 returned signal may be nil.
 - (id)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(id input))signalBlock;
 
-// If the receiver is enabled, this method will:
-//
-//  1. Invoke the `signalBlock` given at the time of initialization.
-//  2. Multicast the returned signal to a RACReplaySubject.
-//  3. Send the multicasted signal on `executionSignals`.
-//  4. Subscribe (connect) to the original signal on the main thread.
-//
-// input - The input value to pass to the receiver's `signalBlock`. This may be
-//         nil.
-//
-// Returns the multicasted signal, after subscription. If the receiver is not
-// enabled, returns a signal that will send an error with code
-// RACCommandErrorNotEnabled.
+/// If the receiver is enabled, this method will:
+///
+///  1. Invoke the `signalBlock` given at the time of initialization.
+///  2. Multicast the returned signal to a RACReplaySubject.
+///  3. Send the multicasted signal on `executionSignals`.
+///  4. Subscribe (connect) to the original signal on the main thread.
+///
+/// input - The input value to pass to the receiver's `signalBlock`. This may be
+///         nil.
+///
+/// Returns the multicasted signal, after subscription. If the receiver is not
+/// enabled, returns a signal that will send an error with code
+/// RACCommandErrorNotEnabled.
 - (RACSignal *)execute:(id)input;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCompoundDisposable.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCompoundDisposable.h
@@ -8,40 +8,40 @@
 
 #import "RACDisposable.h"
 
-// A disposable of disposables. When it is disposed, it disposes of all its
-// contained disposables.
-//
-// If -addDisposable: is called after the compound disposable has been disposed
-// of, the given disposable is immediately disposed. This allows a compound
-// disposable to act as a stand-in for a disposable that will be delivered
-// asynchronously.
+/// A disposable of disposables. When it is disposed, it disposes of all its
+/// contained disposables.
+///
+/// If -addDisposable: is called after the compound disposable has been disposed
+/// of, the given disposable is immediately disposed. This allows a compound
+/// disposable to act as a stand-in for a disposable that will be delivered
+/// asynchronously.
 @interface RACCompoundDisposable : RACDisposable
 
-// Creates and returns a new compound disposable.
+/// Creates and returns a new compound disposable.
 + (instancetype)compoundDisposable;
 
-// Creates and returns a new compound disposable containing the given
-// disposables.
+/// Creates and returns a new compound disposable containing the given
+/// disposables.
 + (instancetype)compoundDisposableWithDisposables:(NSArray *)disposables;
 
-// Adds the given disposable. If the receiving disposable has already been
-// disposed of, the given disposable is disposed immediately.
-//
-// This method is thread-safe.
-//
-// disposable - The disposable to add. Cannot be nil.
+/// Adds the given disposable. If the receiving disposable has already been
+/// disposed of, the given disposable is disposed immediately.
+///
+/// This method is thread-safe.
+///
+/// disposable - The disposable to add. Cannot be nil.
 - (void)addDisposable:(RACDisposable *)disposable;
 
-// Removes the specified disposable from the compound disposable (regardless of
-// its disposed status), or does nothing if it's not in the compound disposable.
-//
-// This is mainly useful for limiting the memory usage of the compound
-// disposable for long-running operations.
-//
-// This method is thread-safe.
-//
-// disposable - The disposable to remove. This argument may be nil (to make the
-//              use of weak references easier).
+/// Removes the specified disposable from the compound disposable (regardless of
+/// its disposed status), or does nothing if it's not in the compound disposable.
+///
+/// This is mainly useful for limiting the memory usage of the compound
+/// disposable for long-running operations.
+///
+/// This method is thread-safe.
+///
+/// disposable - The disposable to remove. This argument may be nil (to make the
+///              use of weak references easier).
 - (void)removeDisposable:(RACDisposable *)disposable;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACDelegateProxy.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACDelegateProxy.h
@@ -10,19 +10,19 @@
 
 @class RACSignal;
 
-// A delegate object suitable for using -rac_signalForSelector:fromProtocol:
-// upon.
+/// A delegate object suitable for using -rac_signalForSelector:fromProtocol:
+/// upon.
 @interface RACDelegateProxy : NSObject
 
-// The delegate to which messages should be forwarded if not handled by
-// any -signalForSelector: applications.
+/// The delegate to which messages should be forwarded if not handled by
+/// any -signalForSelector: applications.
 @property (nonatomic, unsafe_unretained) id rac_proxiedDelegate;
 
-// Creates a delegate proxy capable of responding to selectors from `protocol`.
+/// Creates a delegate proxy capable of responding to selectors from `protocol`.
 - (instancetype)initWithProtocol:(Protocol *)protocol;
 
-// Calls -rac_signalForSelector:fromProtocol: using the `protocol` specified
-// during initialization.
+/// Calls -rac_signalForSelector:fromProtocol: using the `protocol` specified
+/// during initialization.
 - (RACSignal *)signalForSelector:(SEL)selector;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACDisposable.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACDisposable.h
@@ -11,26 +11,26 @@
 @class RACScopedDisposable;
 
 
-// A disposable encapsulates the work necessary to tear down and cleanup a
-// subscription.
+/// A disposable encapsulates the work necessary to tear down and cleanup a
+/// subscription.
 @interface RACDisposable : NSObject
 
-// Whether the receiver has been disposed.
-//
-// Use of this property is discouraged, since it may be set to `YES`
-// concurrently at any time.
-//
-// This property is not KVO-compliant.
+/// Whether the receiver has been disposed.
+///
+/// Use of this property is discouraged, since it may be set to `YES`
+/// concurrently at any time.
+///
+/// This property is not KVO-compliant.
 @property (atomic, assign, getter = isDisposed, readonly) BOOL disposed;
 
 + (instancetype)disposableWithBlock:(void (^)(void))block;
 
-// Performs the disposal work. Can be called multiple times, though sebsequent
-// calls won't do anything.
+/// Performs the disposal work. Can be called multiple times, though sebsequent
+/// calls won't do anything.
 - (void)dispose;
 
-// Returns a new disposable which will dispose of this disposable when it gets
-// dealloc'd.
+/// Returns a new disposable which will dispose of this disposable when it gets
+/// dealloc'd.
 - (RACScopedDisposable *)asScopedDisposable;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACDynamicSequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACDynamicSequence.h
@@ -8,13 +8,13 @@
 
 #import "RACSequence.h"
 
-// Private class that implements a sequence dynamically using blocks.
+/// Private class that implements a sequence dynamically using blocks.
 @interface RACDynamicSequence : RACSequence
 
-// Returns a sequence which evaluates `dependencyBlock` only once, the first
-// time either `headBlock` or `tailBlock` is evaluated. The result of
-// `dependencyBlock` will be passed into `headBlock` and `tailBlock` when
-// invoked.
+/// Returns a sequence which evaluates `dependencyBlock` only once, the first
+/// time either `headBlock` or `tailBlock` is evaluated. The result of
+/// `dependencyBlock` will be passed into `headBlock` and `tailBlock` when
+/// invoked.
 + (RACSequence *)sequenceWithLazyDependency:(id (^)(void))dependencyBlock headBlock:(id (^)(id dependency))headBlock tailBlock:(RACSequence *(^)(id dependency))tailBlock;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACEagerSequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACEagerSequence.h
@@ -8,7 +8,7 @@
 
 #import "RACArraySequence.h"
 
-// Private class that implements an eager sequence.
+/// Private class that implements an eager sequence.
 @interface RACEagerSequence : RACArraySequence
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACEmptySequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACEmptySequence.h
@@ -8,6 +8,6 @@
 
 #import "RACSequence.h"
 
-// Private class representing an empty sequence.
+/// Private class representing an empty sequence.
 @interface RACEmptySequence : RACSequence
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACEvent.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACEvent.h
@@ -8,44 +8,44 @@
 
 #import <Foundation/Foundation.h>
 
-// Describes the type of a RACEvent.
-//
-// RACEventTypeCompleted - A `completed` event.
-// RACEventTypeError     - An `error` event.
-// RACEventTypeNext      - A `next` event.
+/// Describes the type of a RACEvent.
+///
+/// RACEventTypeCompleted - A `completed` event.
+/// RACEventTypeError     - An `error` event.
+/// RACEventTypeNext      - A `next` event.
 typedef enum : NSUInteger {
     RACEventTypeCompleted,
     RACEventTypeError,
     RACEventTypeNext
 } RACEventType;
 
-// Represents an event sent by a RACSignal.
-//
-// This corresponds to the `Notification` class in Rx.
+/// Represents an event sent by a RACSignal.
+///
+/// This corresponds to the `Notification` class in Rx.
 @interface RACEvent : NSObject <NSCopying>
 
-// Returns a singleton RACEvent representing the `completed` event.
+/// Returns a singleton RACEvent representing the `completed` event.
 + (instancetype)completedEvent;
 
-// Returns a new event of type RACEventTypeError, containing the given error.
+/// Returns a new event of type RACEventTypeError, containing the given error.
 + (instancetype)eventWithError:(NSError *)error;
 
-// Returns a new event of type RACEventTypeNext, containing the given value.
+/// Returns a new event of type RACEventTypeNext, containing the given value.
 + (instancetype)eventWithValue:(id)value;
 
-// The type of event represented by the receiver.
+/// The type of event represented by the receiver.
 @property (nonatomic, assign, readonly) RACEventType eventType;
 
-// Returns whether the receiver is of type RACEventTypeCompleted or
-// RACEventTypeError.
+/// Returns whether the receiver is of type RACEventTypeCompleted or
+/// RACEventTypeError.
 @property (nonatomic, getter = isFinished, assign, readonly) BOOL finished;
 
-// The error associated with an event of type RACEventTypeError. This will be
-// nil for all other event types.
+/// The error associated with an event of type RACEventTypeError. This will be
+/// nil for all other event types.
 @property (nonatomic, strong, readonly) NSError *error;
 
-// The value associated with an event of type RACEventTypeNext. This will be
-// nil for all other event types.
+/// The value associated with an event of type RACEventTypeNext. This will be
+/// nil for all other event types.
 @property (nonatomic, strong, readonly) id value;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACGroupedSignal.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACGroupedSignal.h
@@ -9,10 +9,10 @@
 #import "RACSubject.h"
 
 
-// A grouped signal is used by -[RACSignal groupBy:transform:].
+/// A grouped signal is used by -[RACSignal groupBy:transform:].
 @interface RACGroupedSignal : RACSubject
 
-// The key shared by the group.
+/// The key shared by the group.
 @property (nonatomic, readonly, copy) id<NSCopying> key;
 
 + (instancetype)signalWithKey:(id<NSCopying>)key;

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACImmediateScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACImmediateScheduler.h
@@ -8,7 +8,7 @@
 
 #import "RACScheduler.h"
 
-// A scheduler which immediately executes its scheduled blocks.
+/// A scheduler which immediately executes its scheduled blocks.
 @interface RACImmediateScheduler : RACScheduler
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACKVOChannel.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACKVOChannel.h
@@ -10,85 +10,85 @@
 #import "EXTKeyPathCoding.h"
 #import "metamacros.h"
 
-// Creates a RACKVOChannel to the given key path. When the targeted object
-// deallocates, the channel will complete.
-//
-// If RACChannelTo() is used as an expression, it returns a RACChannelTerminal that
-// can be used to watch the specified property for changes, and set new values
-// for it. The terminal will start with the property's current value upon
-// subscription.
-//
-// If RACChannelTo() is used on the left-hand side of an assignment, there must a
-// RACChannelTerminal on the right-hand side of the assignment. The two will be
-// subscribed to one another: the property's value is immediately set to the
-// value of the channel terminal on the right-hand side, and subsequent changes
-// to either terminal will be reflected on the other.
-//
-// There are two different versions of this macro:
-//
-//  - RACChannelTo(TARGET, KEYPATH, NILVALUE) will create a channel to the `KEYPATH`
-//    of `TARGET`. If the terminal is ever sent a `nil` value, the property will
-//    be set to `NILVALUE` instead. `NILVALUE` may itself be `nil` for object
-//    properties, but an NSValue should be used for primitive properties, to
-//    avoid an exception if `nil` is sent (which might occur if an intermediate
-//    object is set to `nil`).
-//  - RACChannelTo(TARGET, KEYPATH) is the same as the above, but `NILVALUE` defaults to
-//    `nil`.
-//
-// Examples
-//
-//  RACChannelTerminal *integerChannel = RACChannelTo(self, integerProperty, @42);
-//
-//  // Sets self.integerProperty to 5.
-//  [integerChannel sendNext:@5];
-//
-//  // Logs the current value of self.integerProperty, and all future changes.
-//  [integerChannel subscribeNext:^(id value) {
-//      NSLog(@"value: %@", value);
-//  }];
-//
-//  // Binds properties to each other, taking the initial value from the right
-//  side.
-//  RACChannelTo(view, objectProperty) = RACChannelTo(model, objectProperty);
-//  RACChannelTo(view, integerProperty, @2) = RACChannelTo(model, integerProperty, @10);
+/// Creates a RACKVOChannel to the given key path. When the targeted object
+/// deallocates, the channel will complete.
+///
+/// If RACChannelTo() is used as an expression, it returns a RACChannelTerminal that
+/// can be used to watch the specified property for changes, and set new values
+/// for it. The terminal will start with the property's current value upon
+/// subscription.
+///
+/// If RACChannelTo() is used on the left-hand side of an assignment, there must a
+/// RACChannelTerminal on the right-hand side of the assignment. The two will be
+/// subscribed to one another: the property's value is immediately set to the
+/// value of the channel terminal on the right-hand side, and subsequent changes
+/// to either terminal will be reflected on the other.
+///
+/// There are two different versions of this macro:
+///
+///  - RACChannelTo(TARGET, KEYPATH, NILVALUE) will create a channel to the `KEYPATH`
+///    of `TARGET`. If the terminal is ever sent a `nil` value, the property will
+///    be set to `NILVALUE` instead. `NILVALUE` may itself be `nil` for object
+///    properties, but an NSValue should be used for primitive properties, to
+///    avoid an exception if `nil` is sent (which might occur if an intermediate
+///    object is set to `nil`).
+///  - RACChannelTo(TARGET, KEYPATH) is the same as the above, but `NILVALUE` defaults to
+///    `nil`.
+///
+/// Examples
+///
+///  RACChannelTerminal *integerChannel = RACChannelTo(self, integerProperty, @42);
+///
+///  // Sets self.integerProperty to 5.
+///  [integerChannel sendNext:@5];
+///
+///  // Logs the current value of self.integerProperty, and all future changes.
+///  [integerChannel subscribeNext:^(id value) {
+///      NSLog(@"value: %@", value);
+///  }];
+///
+///  // Binds properties to each other, taking the initial value from the right
+///  side.
+///  RACChannelTo(view, objectProperty) = RACChannelTo(model, objectProperty);
+///  RACChannelTo(view, integerProperty, @2) = RACChannelTo(model, integerProperty, @10);
 #define RACChannelTo(TARGET, ...) \
     metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__)) \
         (RACChannelTo_(TARGET, __VA_ARGS__, nil)) \
         (RACChannelTo_(TARGET, __VA_ARGS__))
 
-// Do not use this directly. Use the RACChannelTo macro above.
+/// Do not use this directly. Use the RACChannelTo macro above.
 #define RACChannelTo_(TARGET, KEYPATH, NILVALUE) \
     [[RACKVOChannel alloc] initWithTarget:(TARGET) keyPath:@keypath(TARGET, KEYPATH) nilValue:(NILVALUE)][@keypath(RACKVOChannel.new, followingTerminal)]
 
-// A RACChannel that observes a KVO-compliant key path for changes.
+/// A RACChannel that observes a KVO-compliant key path for changes.
 @interface RACKVOChannel : RACChannel
 
-// Initializes a channel that will observe the given object and key path.
-//
-// The current value of the key path, and future KVO notifications for the given
-// key path, will be sent to subscribers of the channel's `followingTerminal`.
-// Values sent to the `followingTerminal` will be set at the given key path using
-// key-value coding.
-//
-// When the target object deallocates, the channel will complete. Signal errors
-// are considered undefined behavior.
-//
-// This is the designated initializer for this class.
-//
-// target   - The object to bind to.
-// keyPath  - The key path to observe and set the value of.
-// nilValue - The value to set at the key path whenever a `nil` value is
-//            received. This may be nil when connecting to object properties, but
-//            an NSValue should be used for primitive properties, to avoid an
-//            exception if `nil` is received (which might occur if an intermediate
-//            object is set to `nil`).
+/// Initializes a channel that will observe the given object and key path.
+///
+/// The current value of the key path, and future KVO notifications for the given
+/// key path, will be sent to subscribers of the channel's `followingTerminal`.
+/// Values sent to the `followingTerminal` will be set at the given key path using
+/// key-value coding.
+///
+/// When the target object deallocates, the channel will complete. Signal errors
+/// are considered undefined behavior.
+///
+/// This is the designated initializer for this class.
+///
+/// target   - The object to bind to.
+/// keyPath  - The key path to observe and set the value of.
+/// nilValue - The value to set at the key path whenever a `nil` value is
+///            received. This may be nil when connecting to object properties, but
+///            an NSValue should be used for primitive properties, to avoid an
+///            exception if `nil` is received (which might occur if an intermediate
+///            object is set to `nil`).
 - (id)initWithTarget:(NSObject *)target keyPath:(NSString *)keyPath nilValue:(id)nilValue;
 
 - (id)init __attribute__((unavailable("Use -initWithTarget:keyPath:nilValue: instead")));
 
 @end
 
-// Methods needed for the convenience macro. Do not call explicitly.
+/// Methods needed for the convenience macro. Do not call explicitly.
 @interface RACKVOChannel (RACChannelTo)
 
 - (RACChannelTerminal *)objectForKeyedSubscript:(NSString *)key;

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACKVOTrampoline.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACKVOTrampoline.h
@@ -10,22 +10,22 @@
 #import "NSObject+RACKVOWrapper.h"
 #import "RACDisposable.h"
 
-// The KVO trampoline object. Represents a KVO observation.
-//
-// Disposing of the trampoline will stop observation.
+/// The KVO trampoline object. Represents a KVO observation.
+///
+/// Disposing of the trampoline will stop observation.
 @interface RACKVOTrampoline : RACDisposable
 
-// Initializes the receiver with the given parameters.
-//
-// target   - The object whose key path should be observed. Cannot be nil.
-// observer - The object that gets notified when the value at the key path
-//            changes. Can be nil.
-// keyPath  - The key path on `target` to observe. Cannot be nil.
-// options  - Any key value observing options to use in the observation.
-// block    - The block to call when the value at the observed key path changes.
-//            Cannot be nil.
-//
-// Returns the initialized object.
+/// Initializes the receiver with the given parameters.
+///
+/// target   - The object whose key path should be observed. Cannot be nil.
+/// observer - The object that gets notified when the value at the key path
+///            changes. Can be nil.
+/// keyPath  - The key path on `target` to observe. Cannot be nil.
+/// options  - Any key value observing options to use in the observation.
+/// block    - The block to call when the value at the observed key path changes.
+///            Cannot be nil.
+///
+/// Returns the initialized object.
 - (id)initWithTarget:(NSObject *)target observer:(NSObject *)observer keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACMulticastConnection.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACMulticastConnection.h
@@ -9,38 +9,38 @@
 @class RACSignal;
 @class RACDisposable;
 
-// A multicast connection encapsulates the idea of sharing one subscription to a
-// signal to many subscribers. This is most often needed if the subscription to
-// the underlying signal involves side-effects or shouldn't be called more than
-// once.
-//
-// The multicasted signal is only subscribed to when
-// -[RACMulticastConnection connect] is called. Until that happens, no values
-// will be sent on `signal`. See -[RACMulticastConnection autoconnect] for how
-// -[RACMulticastConnection connect] can be called automatically.
-//
-// Note that you shouldn't create RACMulticastConnection manually. Instead use
-// -[RACSignal publish] or -[RACSignal multicast:].
+/// A multicast connection encapsulates the idea of sharing one subscription to a
+/// signal to many subscribers. This is most often needed if the subscription to
+/// the underlying signal involves side-effects or shouldn't be called more than
+/// once.
+///
+/// The multicasted signal is only subscribed to when
+/// -[RACMulticastConnection connect] is called. Until that happens, no values
+/// will be sent on `signal`. See -[RACMulticastConnection autoconnect] for how
+/// -[RACMulticastConnection connect] can be called automatically.
+///
+/// Note that you shouldn't create RACMulticastConnection manually. Instead use
+/// -[RACSignal publish] or -[RACSignal multicast:].
 @interface RACMulticastConnection : NSObject
 
-// The multicasted signal.
+/// The multicasted signal.
 @property (nonatomic, strong, readonly) RACSignal *signal;
 
-// Connect to the underlying signal by subscribing to it. Calling this multiple
-// times does nothing but return the existing connection's disposable.
-//
-// Returns the disposable for the subscription to the multicasted signal.
+/// Connect to the underlying signal by subscribing to it. Calling this multiple
+/// times does nothing but return the existing connection's disposable.
+///
+/// Returns the disposable for the subscription to the multicasted signal.
 - (RACDisposable *)connect;
 
-// Connects to the underlying signal when the returned signal is first
-// subscribed to, and disposes of the subscription to the multicasted signal
-// when the returned signal has no subscribers.
-//
-// If new subscribers show up after being disposed, they'll subscribe and then
-// be immediately disposed of. The returned signal will never re-connect to the
-// multicasted signal.
-//
-// Returns the autoconnecting signal.
+/// Connects to the underlying signal when the returned signal is first
+/// subscribed to, and disposes of the subscription to the multicasted signal
+/// when the returned signal has no subscribers.
+///
+/// If new subscribers show up after being disposed, they'll subscribe and then
+/// be immediately disposed of. The returned signal will never re-connect to the
+/// multicasted signal.
+///
+/// Returns the autoconnecting signal.
 - (RACSignal *)autoconnect;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACObjCRuntime.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACObjCRuntime.h
@@ -10,7 +10,7 @@
 
 @interface RACObjCRuntime : NSObject
 
-// Invokes objc_allocateClassPair(). Can be called from ARC code.
+/// Invokes objc_allocateClassPair(). Can be called from ARC code.
 + (Class)createClass:(const char *)className inheritingFromClass:(Class)superclass;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACPassthroughSubscriber.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACPassthroughSubscriber.h
@@ -9,16 +9,16 @@
 #import <Foundation/Foundation.h>
 #import "RACSubscriber.h"
 
-// Passes through all events to another subscriber while not disposed.
+/// Passes through all events to another subscriber while not disposed.
 @interface RACPassthroughSubscriber : NSObject <RACSubscriber>
 
-// Initializes the receiver to pass through events until disposed.
-//
-// subscriber - The subscriber to forward events to. This must not be nil.
-// disposable - When this disposable is disposed, no more events will be
-//              forwarded. This must not be nil.
-//
-// Returns an initialized passthrough subscriber.
+/// Initializes the receiver to pass through events until disposed.
+///
+/// subscriber - The subscriber to forward events to. This must not be nil.
+/// disposable - When this disposable is disposed, no more events will be
+///              forwarded. This must not be nil.
+///
+/// Returns an initialized passthrough subscriber.
 - (instancetype)initWithSubscriber:(id<RACSubscriber>)subscriber disposable:(RACDisposable *)disposable;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler+Subclass.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler+Subclass.h
@@ -8,39 +8,39 @@
 
 #import "RACQueueScheduler.h"
 
-// An interface for use by subclasses.
-//
-// Subclasses should use `-performAsCurrentScheduler:` to do the actual block
-// invocation so that +[RACScheduler currentScheduler] behaves as expected.
-//
-// **Note that RACSchedulers are expected to be serial**. Subclasses must honor
-// that contract. See `RACTargetQueueScheduler` for a queue-based scheduler
-// which will enforce the serialization guarantee.
+/// An interface for use by subclasses.
+///
+/// Subclasses should use `-performAsCurrentScheduler:` to do the actual block
+/// invocation so that +[RACScheduler currentScheduler] behaves as expected.
+///
+/// **Note that RACSchedulers are expected to be serial**. Subclasses must honor
+/// that contract. See `RACTargetQueueScheduler` for a queue-based scheduler
+/// which will enforce the serialization guarantee.
 @interface RACQueueScheduler ()
 
-// The queue on which blocks are enqueued.
+/// The queue on which blocks are enqueued.
 @property (nonatomic, readonly) dispatch_queue_t queue;
 
-// Initializes the receiver with the name of the scheduler and the queue which
-// the scheduler should use.
-//
-// name  - The name of the scheduler. If nil, a default name will be used.
-// queue - The queue upon which the receiver should enqueue scheduled blocks.
-//         This argument must not be NULL.
-//
-// Returns the initialized object.
+/// Initializes the receiver with the name of the scheduler and the queue which
+/// the scheduler should use.
+///
+/// name  - The name of the scheduler. If nil, a default name will be used.
+/// queue - The queue upon which the receiver should enqueue scheduled blocks.
+///         This argument must not be NULL.
+///
+/// Returns the initialized object.
 - (id)initWithName:(NSString *)name queue:(dispatch_queue_t)queue;
 
-// Performs the given block with the receiver as the current scheduler for
-// `queue`. This should only be called by subclasses to perform scheduled blocks
-// on their queue.
-//
-// block - The block to execute. Cannot be NULL.
+/// Performs the given block with the receiver as the current scheduler for
+/// `queue`. This should only be called by subclasses to perform scheduled blocks
+/// on their queue.
+///
+/// block - The block to execute. Cannot be NULL.
 - (void)performAsCurrentScheduler:(void (^)(void))block;
 
-// Converts a date into a GCD time using dispatch_walltime().
-//
-// date - The date to convert. This must not be nil.
+/// Converts a date into a GCD time using dispatch_walltime().
+///
+/// date - The date to convert. This must not be nil.
 + (dispatch_time_t)wallTimeWithDate:(NSDate *)date;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.h
@@ -8,11 +8,11 @@
 
 #import "RACScheduler.h"
 
-// An abstract scheduler which asynchronously enqueues all its work to a Grand
-// Central Dispatch queue.
-//
-// Because RACQueueScheduler is abstract, it should not be instantiated
-// directly. Create a subclass using the `RACQueueScheduler+Subclass.h`
-// interface and use that instead.
+/// An abstract scheduler which asynchronously enqueues all its work to a Grand
+/// Central Dispatch queue.
+///
+/// Because RACQueueScheduler is abstract, it should not be instantiated
+/// directly. Create a subclass using the `RACQueueScheduler+Subclass.h`
+/// interface and use that instead.
 @interface RACQueueScheduler : RACScheduler
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACReplaySubject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACReplaySubject.h
@@ -11,13 +11,13 @@
 extern const NSUInteger RACReplaySubjectUnlimitedCapacity;
 
 
-// A replay subject saves the values it is sent (up to its defined capacity)
-// and resends those to new subscribers. It will also replay an error or
-// completion.
+/// A replay subject saves the values it is sent (up to its defined capacity)
+/// and resends those to new subscribers. It will also replay an error or
+/// completion.
 @interface RACReplaySubject : RACSubject
 
-// Creates a new replay subject with the given capacity. A capacity of
-// RACReplaySubjectUnlimitedCapacity means values are never trimmed.
+/// Creates a new replay subject with the given capacity. A capacity of
+/// RACReplaySubjectUnlimitedCapacity means values are never trimmed.
 + (instancetype)replaySubjectWithCapacity:(NSUInteger)capacity;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler+Private.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler+Private.h
@@ -8,27 +8,27 @@
 
 #import "RACScheduler.h"
 
-// The thread-specific current scheduler key.
+/// The thread-specific current scheduler key.
 extern NSString * const RACSchedulerCurrentSchedulerKey;
 
-// A private interface for internal RAC use only.
+/// A private interface for internal RAC use only.
 @interface RACScheduler ()
 
-// A dedicated scheduler that fills two requirements:
-// 
-//   1. By the time subscription happens, we need a valid +currentScheduler.
-//   2. Subscription should happen as soon as possible.
-// 
-// To fulfill those two, if we already have a valid +currentScheduler, it
-// immediately executes scheduled blocks. If we don't, it will execute scheduled
-// blocks with a private background scheduler.
+/// A dedicated scheduler that fills two requirements:
+/// 
+///   1. By the time subscription happens, we need a valid +currentScheduler.
+///   2. Subscription should happen as soon as possible.
+/// 
+/// To fulfill those two, if we already have a valid +currentScheduler, it
+/// immediately executes scheduled blocks. If we don't, it will execute scheduled
+/// blocks with a private background scheduler.
 + (instancetype)subscriptionScheduler;
 
-// Initializes the receiver with the given name.
-//
-// name - The name of the scheduler. If nil, a default name will be used.
-//
-// Returns the initialized object.
+/// Initializes the receiver with the given name.
+///
+/// name - The name of the scheduler. If nil, a default name will be used.
+///
+/// Returns the initialized object.
 - (id)initWithName:(NSString *)name;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.h
@@ -8,12 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
-// The priority for the scheduler.
-//
-// RACSchedulerPriorityHigh       - High priority.
-// RACSchedulerPriorityDefault    - Default priority.
-// RACSchedulerPriorityLow        - Low priority.
-// RACSchedulerPriorityBackground - Background priority.
+/// The priority for the scheduler.
+///
+/// RACSchedulerPriorityHigh       - High priority.
+/// RACSchedulerPriorityDefault    - Default priority.
+/// RACSchedulerPriorityLow        - Low priority.
+/// RACSchedulerPriorityBackground - Background priority.
 typedef enum : long {
 	RACSchedulerPriorityHigh = DISPATCH_QUEUE_PRIORITY_HIGH,
 	RACSchedulerPriorityDefault = DISPATCH_QUEUE_PRIORITY_DEFAULT,
@@ -21,122 +21,122 @@ typedef enum : long {
 	RACSchedulerPriorityBackground = DISPATCH_QUEUE_PRIORITY_BACKGROUND,
 } RACSchedulerPriority;
 
-// Scheduled with -scheduleRecursiveBlock:, this type of block is passed a block
-// with which it can call itself recursively.
+/// Scheduled with -scheduleRecursiveBlock:, this type of block is passed a block
+/// with which it can call itself recursively.
 typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 
 @class RACDisposable;
 
-// Schedulers are used to control when and where work is performed.
+/// Schedulers are used to control when and where work is performed.
 @interface RACScheduler : NSObject
 
-// A singleton scheduler that immediately executes the blocks it is given.
-//
-// **Note:** Unlike most other schedulers, this does not set the current
-// scheduler. There may still be a valid +currentScheduler if this is used
-// within a block scheduled on a different scheduler.
+/// A singleton scheduler that immediately executes the blocks it is given.
+///
+/// **Note:** Unlike most other schedulers, this does not set the current
+/// scheduler. There may still be a valid +currentScheduler if this is used
+/// within a block scheduled on a different scheduler.
 + (RACScheduler *)immediateScheduler;
 
-// A singleton scheduler that executes blocks in the main thread.
+/// A singleton scheduler that executes blocks in the main thread.
 + (RACScheduler *)mainThreadScheduler;
 
-// Creates and returns a new background scheduler with the given priority and
-// name. The name is for debug and instrumentation purposes only.
-//
-// Scheduler creation is cheap. It's unnecessary to save the result of this
-// method call unless you want to serialize some actions on the same background
-// scheduler.
+/// Creates and returns a new background scheduler with the given priority and
+/// name. The name is for debug and instrumentation purposes only.
+///
+/// Scheduler creation is cheap. It's unnecessary to save the result of this
+/// method call unless you want to serialize some actions on the same background
+/// scheduler.
 + (RACScheduler *)schedulerWithPriority:(RACSchedulerPriority)priority name:(NSString *)name;
 
-// Invokes +schedulerWithPriority:name: with a default name.
+/// Invokes +schedulerWithPriority:name: with a default name.
 + (RACScheduler *)schedulerWithPriority:(RACSchedulerPriority)priority;
 
-// Invokes +schedulerWithPriority: with RACSchedulerPriorityDefault.
+/// Invokes +schedulerWithPriority: with RACSchedulerPriorityDefault.
 + (RACScheduler *)scheduler;
 
-// The current scheduler. This will only be valid when used from within a
-// -[RACScheduler schedule:] block or when on the main thread.
+/// The current scheduler. This will only be valid when used from within a
+/// -[RACScheduler schedule:] block or when on the main thread.
 + (RACScheduler *)currentScheduler;
 
-// Schedule the given block for execution on the scheduler.
-//
-// Scheduled blocks will be executed in the order in which they were scheduled.
-//
-// block - The block to schedule for execution. Cannot be nil.
-//
-// Returns a disposable which can be used to cancel the scheduled block before
-// it begins executing, or nil if cancellation is not supported.
+/// Schedule the given block for execution on the scheduler.
+///
+/// Scheduled blocks will be executed in the order in which they were scheduled.
+///
+/// block - The block to schedule for execution. Cannot be nil.
+///
+/// Returns a disposable which can be used to cancel the scheduled block before
+/// it begins executing, or nil if cancellation is not supported.
 - (RACDisposable *)schedule:(void (^)(void))block;
 
-// Schedule the given block for execution on the scheduler at or after
-// a specific time.
-//
-// Note that blocks scheduled for a certain time will not preempt any other
-// scheduled work that is executing at the time.
-//
-// When invoked on the +immediateScheduler, the calling thread **will block**
-// until the specified time.
-//
-// date  - The earliest time at which `block` should begin executing. The block
-//         may not execute immediately at this time, whether due to system load
-//         or another block on the scheduler currently being run. Cannot be nil.
-// block - The block to schedule for execution. Cannot be nil.
-//
-// Returns a disposable which can be used to cancel the scheduled block before
-// it begins executing, or nil if cancellation is not supported.
+/// Schedule the given block for execution on the scheduler at or after
+/// a specific time.
+///
+/// Note that blocks scheduled for a certain time will not preempt any other
+/// scheduled work that is executing at the time.
+///
+/// When invoked on the +immediateScheduler, the calling thread **will block**
+/// until the specified time.
+///
+/// date  - The earliest time at which `block` should begin executing. The block
+///         may not execute immediately at this time, whether due to system load
+///         or another block on the scheduler currently being run. Cannot be nil.
+/// block - The block to schedule for execution. Cannot be nil.
+///
+/// Returns a disposable which can be used to cancel the scheduled block before
+/// it begins executing, or nil if cancellation is not supported.
 - (RACDisposable *)after:(NSDate *)date schedule:(void (^)(void))block;
 
-// Schedule the given block for execution on the scheduler after the delay.
-//
-// Converts the delay into an NSDate, then invokes `-after:schedule:`.
+/// Schedule the given block for execution on the scheduler after the delay.
+///
+/// Converts the delay into an NSDate, then invokes `-after:schedule:`.
 - (RACDisposable *)afterDelay:(NSTimeInterval)delay schedule:(void (^)(void))block;
 
-// Reschedule the given block at a particular interval, starting at a specific
-// time, and with a given leeway for deferral.
-//
-// Note that blocks scheduled for a certain time will not preempt any other
-// scheduled work that is executing at the time.
-//
-// Regardless of the value of `leeway`, the given block may not execute exactly
-// at `when` or exactly on successive intervals, whether due to system load or
-// because another block is currently being run on the scheduler.
-//
-// It is considered undefined behavior to invoke this method on the
-// +immediateScheduler.
-//
-// date     - The earliest time at which `block` should begin executing. The
-//            block may not execute immediately at this time, whether due to
-//            system load or another block on the scheduler currently being
-//            run. Cannot be nil.
-// interval - The interval at which the block should be rescheduled, starting
-//            from `date`. This will use the system wall clock, to avoid
-//            skew when the computer goes to sleep.
-// leeway   - A hint to the system indicating the number of seconds that each
-//            scheduling can be deferred. Note that this is just a hint, and
-//            there may be some additional latency no matter what.
-// block    - The block to repeatedly schedule for execution. Cannot be nil.
-//
-// Returns a disposable which can be used to cancel the automatic scheduling and
-// rescheduling, or nil if cancellation is not supported.
+/// Reschedule the given block at a particular interval, starting at a specific
+/// time, and with a given leeway for deferral.
+///
+/// Note that blocks scheduled for a certain time will not preempt any other
+/// scheduled work that is executing at the time.
+///
+/// Regardless of the value of `leeway`, the given block may not execute exactly
+/// at `when` or exactly on successive intervals, whether due to system load or
+/// because another block is currently being run on the scheduler.
+///
+/// It is considered undefined behavior to invoke this method on the
+/// +immediateScheduler.
+///
+/// date     - The earliest time at which `block` should begin executing. The
+///            block may not execute immediately at this time, whether due to
+///            system load or another block on the scheduler currently being
+///            run. Cannot be nil.
+/// interval - The interval at which the block should be rescheduled, starting
+///            from `date`. This will use the system wall clock, to avoid
+///            skew when the computer goes to sleep.
+/// leeway   - A hint to the system indicating the number of seconds that each
+///            scheduling can be deferred. Note that this is just a hint, and
+///            there may be some additional latency no matter what.
+/// block    - The block to repeatedly schedule for execution. Cannot be nil.
+///
+/// Returns a disposable which can be used to cancel the automatic scheduling and
+/// rescheduling, or nil if cancellation is not supported.
 - (RACDisposable *)after:(NSDate *)date repeatingEvery:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway schedule:(void (^)(void))block;
 
-// Schedule the given recursive block for execution on the scheduler. The
-// scheduler will automatically flatten any recursive scheduling into iteration
-// instead, so this can be used without issue for blocks that may keep invoking
-// themselves forever.
-//
-// Scheduled blocks will be executed in the order in which they were scheduled.
-//
-// recursiveBlock - The block to schedule for execution. When invoked, the
-//                  recursive block will be passed a `void (^)(void)` block
-//                  which will reschedule the recursive block at the end of the
-//                  receiver's queue. This passed-in block will automatically
-//                  skip scheduling if the scheduling of the `recursiveBlock`
-//                  was disposed in the meantime.
-//
-// Returns a disposable which can be used to cancel the scheduled block before
-// it begins executing, or to stop it from rescheduling if it's already begun
-// execution.
+/// Schedule the given recursive block for execution on the scheduler. The
+/// scheduler will automatically flatten any recursive scheduling into iteration
+/// instead, so this can be used without issue for blocks that may keep invoking
+/// themselves forever.
+///
+/// Scheduled blocks will be executed in the order in which they were scheduled.
+///
+/// recursiveBlock - The block to schedule for execution. When invoked, the
+///                  recursive block will be passed a `void (^)(void)` block
+///                  which will reschedule the recursive block at the end of the
+///                  receiver's queue. This passed-in block will automatically
+///                  skip scheduling if the scheduling of the `recursiveBlock`
+///                  was disposed in the meantime.
+///
+/// Returns a disposable which can be used to cancel the scheduled block before
+/// it begins executing, or to stop it from rescheduling if it's already begun
+/// execution.
 - (RACDisposable *)scheduleRecursiveBlock:(RACSchedulerRecursiveBlock)recursiveBlock;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScopedDisposable.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScopedDisposable.h
@@ -9,11 +9,11 @@
 #import "RACDisposable.h"
 
 
-// A disposable that calls its own -dispose when it is dealloc'd.
+/// A disposable that calls its own -dispose when it is dealloc'd.
 @interface RACScopedDisposable : RACDisposable
 
-// Creates a new scoped disposable that will also dispose of the given
-// disposable when it is dealloc'd.
+/// Creates a new scoped disposable that will also dispose of the given
+/// disposable when it is dealloc'd.
 + (instancetype)scopedDisposableWithDisposable:(RACDisposable *)disposable;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSequence.h
@@ -12,136 +12,136 @@
 @class RACScheduler;
 @class RACSignal;
 
-// Represents an immutable sequence of values. Unless otherwise specified, the
-// sequences' values are evaluated lazily on demand. Like Cocoa collections,
-// sequences cannot contain nil.
-//
-// Most inherited RACStream methods that accept a block will execute the block
-// _at most_ once for each value that is evaluated in the returned sequence.
-// Side effects are subject to the behavior described in
-// +sequenceWithHeadBlock:tailBlock:.
-//
-// Implemented as a class cluster. A minimal implementation for a subclass
-// consists simply of -head and -tail.
+/// Represents an immutable sequence of values. Unless otherwise specified, the
+/// sequences' values are evaluated lazily on demand. Like Cocoa collections,
+/// sequences cannot contain nil.
+///
+/// Most inherited RACStream methods that accept a block will execute the block
+/// _at most_ once for each value that is evaluated in the returned sequence.
+/// Side effects are subject to the behavior described in
+/// +sequenceWithHeadBlock:tailBlock:.
+///
+/// Implemented as a class cluster. A minimal implementation for a subclass
+/// consists simply of -head and -tail.
 @interface RACSequence : RACStream <NSCoding, NSCopying, NSFastEnumeration>
 
-// The first object in the sequence, or nil if the sequence is empty.
-//
-// Subclasses must provide an implementation of this method.
+/// The first object in the sequence, or nil if the sequence is empty.
+///
+/// Subclasses must provide an implementation of this method.
 @property (nonatomic, strong, readonly) id head;
 
-// All but the first object in the sequence, or nil if the sequence is empty.
-//
-// Subclasses must provide an implementation of this method.
+/// All but the first object in the sequence, or nil if the sequence is empty.
+///
+/// Subclasses must provide an implementation of this method.
 @property (nonatomic, strong, readonly) RACSequence *tail;
 
-// Evaluates the full sequence to produce an equivalently-sized array.
+/// Evaluates the full sequence to produce an equivalently-sized array.
 @property (nonatomic, copy, readonly) NSArray *array;
 
-// Returns an enumerator of all objects in the sequence.
+/// Returns an enumerator of all objects in the sequence.
 @property (nonatomic, copy, readonly) NSEnumerator *objectEnumerator;
 
-// Converts a sequence into an eager sequence.
-//
-// An eager sequence fully evaluates all of its values immediately. Sequences
-// derived from an eager sequence will also be eager.
-//
-// Returns a new eager sequence, or the receiver if the sequence is already
-// eager.
+/// Converts a sequence into an eager sequence.
+///
+/// An eager sequence fully evaluates all of its values immediately. Sequences
+/// derived from an eager sequence will also be eager.
+///
+/// Returns a new eager sequence, or the receiver if the sequence is already
+/// eager.
 @property (nonatomic, copy, readonly) RACSequence *eagerSequence;
 
-// Converts a sequence into a lazy sequence.
-//
-// A lazy sequence evaluates its values on demand, as they are accessed.
-// Sequences derived from a lazy sequence will also be lazy.
-//
-// Returns a new lazy sequence, or the receiver if the sequence is already lazy.
+/// Converts a sequence into a lazy sequence.
+///
+/// A lazy sequence evaluates its values on demand, as they are accessed.
+/// Sequences derived from a lazy sequence will also be lazy.
+///
+/// Returns a new lazy sequence, or the receiver if the sequence is already lazy.
 @property (nonatomic, copy, readonly) RACSequence *lazySequence;
 
-// Invokes -signalWithScheduler: with a new RACScheduler.
+/// Invokes -signalWithScheduler: with a new RACScheduler.
 - (RACSignal *)signal;
 
-// Evaluates the full sequence on the given scheduler.
-//
-// Each item is evaluated in its own scheduled block, such that control of the
-// scheduler is yielded between each value.
-//
-// Returns a signal which sends the receiver's values on the given scheduler as
-// they're evaluated.
+/// Evaluates the full sequence on the given scheduler.
+///
+/// Each item is evaluated in its own scheduled block, such that control of the
+/// scheduler is yielded between each value.
+///
+/// Returns a signal which sends the receiver's values on the given scheduler as
+/// they're evaluated.
 - (RACSignal *)signalWithScheduler:(RACScheduler *)scheduler;
 
-// Applies a left fold to the sequence.
-//
-// This is the same as iterating the sequence along with a provided start value.
-// This uses a constant amount of memory. A left fold is left-associative so in
-// the sequence [1,2,3] the block would applied in the following order:
-//  reduce(reduce(reduce(start, 1), 2), 3)
-//
-// start  - The starting value for the fold. Used as `accumulator` for the
-//          first fold.
-// reduce - The block used to combine the accumulated value and the next value.
-//          Cannot be nil.
-//
-// Returns a reduced value.
+/// Applies a left fold to the sequence.
+///
+/// This is the same as iterating the sequence along with a provided start value.
+/// This uses a constant amount of memory. A left fold is left-associative so in
+/// the sequence [1,2,3] the block would applied in the following order:
+///  reduce(reduce(reduce(start, 1), 2), 3)
+///
+/// start  - The starting value for the fold. Used as `accumulator` for the
+///          first fold.
+/// reduce - The block used to combine the accumulated value and the next value.
+///          Cannot be nil.
+///
+/// Returns a reduced value.
 - (id)foldLeftWithStart:(id)start reduce:(id (^)(id accumulator, id value))reduce;
 
-// Applies a right fold to the sequence.
-//
-// A right fold is equivalent to recursion on the list. The block is evaluated
-// from the right to the left in list. It is right associative so it's applied
-// to the rightmost elements first. For example, in the sequence [1,2,3] the
-// block is applied in the order:
-//   reduce(1, reduce(2, reduce(3, start)))
-//
-// start  - The starting value for the fold.
-// reduce - The block used to combine the accumulated value and the next head.
-//          The block is given the accumulated value and the value of the rest
-//          of the computation (result of the recursion). This is computed when
-//          you retrieve its value using `rest.head`. This allows you to
-//          prevent unnecessary computation by not accessing `rest.head` if you
-//          don't need to.
-//
-// Returns a reduced value.
+/// Applies a right fold to the sequence.
+///
+/// A right fold is equivalent to recursion on the list. The block is evaluated
+/// from the right to the left in list. It is right associative so it's applied
+/// to the rightmost elements first. For example, in the sequence [1,2,3] the
+/// block is applied in the order:
+///   reduce(1, reduce(2, reduce(3, start)))
+///
+/// start  - The starting value for the fold.
+/// reduce - The block used to combine the accumulated value and the next head.
+///          The block is given the accumulated value and the value of the rest
+///          of the computation (result of the recursion). This is computed when
+///          you retrieve its value using `rest.head`. This allows you to
+///          prevent unnecessary computation by not accessing `rest.head` if you
+///          don't need to.
+///
+/// Returns a reduced value.
 - (id)foldRightWithStart:(id)start reduce:(id (^)(id first, RACSequence *rest))reduce;
 
-// Check if any value in sequence passes the block.
-//
-// block - The block predicate used to check each item. Cannot be nil.
-//
-// Returns a boolean indiciating if any value in the sequence passed.
+/// Check if any value in sequence passes the block.
+///
+/// block - The block predicate used to check each item. Cannot be nil.
+///
+/// Returns a boolean indiciating if any value in the sequence passed.
 - (BOOL)any:(BOOL (^)(id value))block;
 
-// Check if all values in the sequence pass the block.
-//
-// block - The block predicate used to check each item. Cannot be nil.
-//
-// Returns a boolean indicating if all values in the sequence passed.
+/// Check if all values in the sequence pass the block.
+///
+/// block - The block predicate used to check each item. Cannot be nil.
+///
+/// Returns a boolean indicating if all values in the sequence passed.
 - (BOOL)all:(BOOL (^)(id value))block;
 
-// Returns the first object that passes the block.
-//
-// block - The block predicate used to check each item. Cannot be nil.
-//
-// Returns an object that passes the block or nil if no objects passed.
+/// Returns the first object that passes the block.
+///
+/// block - The block predicate used to check each item. Cannot be nil.
+///
+/// Returns an object that passes the block or nil if no objects passed.
 - (id)objectPassingTest:(BOOL (^)(id value))block;
 
-// Creates a sequence that dynamically generates its values.
-//
-// headBlock - Invoked the first time -head is accessed.
-// tailBlock - Invoked the first time -tail is accessed.
-//
-// The results from each block are memoized, so each block will be invoked at
-// most once, no matter how many times the head and tail properties of the
-// sequence are accessed.
-//
-// Any side effects in `headBlock` or `tailBlock` should be thread-safe, since
-// the sequence may be evaluated at any time from any thread. Not only that, but
-// -tail may be accessed before -head, or both may be accessed simultaneously.
-// As noted above, side effects will only be triggered the _first_ time -head or
-// -tail is invoked.
-//
-// Returns a sequence that lazily invokes the given blocks to provide head and
-// tail. `headBlock` must not be nil.
+/// Creates a sequence that dynamically generates its values.
+///
+/// headBlock - Invoked the first time -head is accessed.
+/// tailBlock - Invoked the first time -tail is accessed.
+///
+/// The results from each block are memoized, so each block will be invoked at
+/// most once, no matter how many times the head and tail properties of the
+/// sequence are accessed.
+///
+/// Any side effects in `headBlock` or `tailBlock` should be thread-safe, since
+/// the sequence may be evaluated at any time from any thread. Not only that, but
+/// -tail may be accessed before -head, or both may be accessed simultaneously.
+/// As noted above, side effects will only be triggered the _first_ time -head or
+/// -tail is invoked.
+///
+/// Returns a sequence that lazily invokes the given blocks to provide head and
+/// tail. `headBlock` must not be nil.
 + (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence *(^)(void))tailBlock;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.h
@@ -8,36 +8,36 @@
 
 #import "RACDisposable.h"
 
-// A disposable that contains exactly one other disposable and allows it to be
-// swapped out atomically.
+/// A disposable that contains exactly one other disposable and allows it to be
+/// swapped out atomically.
 @interface RACSerialDisposable : RACDisposable
 
-// The inner disposable managed by the serial disposable.
-//
-// This property is thread-safe for reading and writing. However, if you want to
-// read the current value _and_ write a new one atomically, use
-// -swapInDisposable: instead.
-//
-// Disposing of the receiver will also dispose of the current disposable set for
-// this property, then set the property to nil. If any new disposable is set
-// after the receiver is disposed, it will be disposed immediately and this
-// property will remain set to nil.
+/// The inner disposable managed by the serial disposable.
+///
+/// This property is thread-safe for reading and writing. However, if you want to
+/// read the current value _and_ write a new one atomically, use
+/// -swapInDisposable: instead.
+///
+/// Disposing of the receiver will also dispose of the current disposable set for
+/// this property, then set the property to nil. If any new disposable is set
+/// after the receiver is disposed, it will be disposed immediately and this
+/// property will remain set to nil.
 @property (atomic, strong) RACDisposable *disposable;
 
-// Creates a serial disposable which will wrap the given disposable.
-//
-// disposable - The value to set for `disposable`. This may be nil.
-//
-// Returns a RACSerialDisposable, or nil if an error occurs.
+/// Creates a serial disposable which will wrap the given disposable.
+///
+/// disposable - The value to set for `disposable`. This may be nil.
+///
+/// Returns a RACSerialDisposable, or nil if an error occurs.
 + (instancetype)serialDisposableWithDisposable:(RACDisposable *)disposable;
 
-// Atomically swaps the receiver's `disposable` for `newDisposable`.
-//
-// newDisposable - The new value for `disposable`. If the receiver has already
-//                 been disposed, this disposable will be too, and `disposable`
-//                 will remain set to nil. This argument may be nil.
-//
-// Returns the previous value for the `disposable` property.
+/// Atomically swaps the receiver's `disposable` for `newDisposable`.
+///
+/// newDisposable - The new value for `disposable`. If the receiver has already
+///                 been disposed, this disposable will be too, and `disposable`
+///                 will remain set to nil. This argument may be nil.
+///
+/// Returns the previous value for the `disposable` property.
 - (RACDisposable *)swapInDisposable:(RACDisposable *)newDisposable;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -9,14 +9,14 @@
 #import <Foundation/Foundation.h>
 #import "RACSignal.h"
 
-// The domain for errors originating in RACSignal operations.
+/// The domain for errors originating in RACSignal operations.
 extern NSString * const RACSignalErrorDomain;
 
-// The error code used with -timeout:.
+/// The error code used with -timeout:.
 extern const NSInteger RACSignalErrorTimedOut;
 
-// The error code used when a value passed into +switch:cases:default: does not
-// match any of the cases, and no default was given.
+/// The error code used when a value passed into +switch:cases:default: does not
+/// match any of the cases, and no default was given.
 extern const NSInteger RACSignalErrorNoMatchingCase;
 
 @class RACMulticastConnection;
@@ -30,490 +30,490 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 @interface RACSignal (Operations)
 
-// Do the given block on `next`. This should be used to inject side effects into
-// the signal.
+/// Do the given block on `next`. This should be used to inject side effects into
+/// the signal.
 - (RACSignal *)doNext:(void (^)(id x))block;
 
-// Do the given block on `error`. This should be used to inject side effects
-// into the signal.
+/// Do the given block on `error`. This should be used to inject side effects
+/// into the signal.
 - (RACSignal *)doError:(void (^)(NSError *error))block;
 
-// Do the given block on `completed`. This should be used to inject side effects
-// into the signal.
+/// Do the given block on `completed`. This should be used to inject side effects
+/// into the signal.
 - (RACSignal *)doCompleted:(void (^)(void))block;
 
-// Send `next`s only if we don't receive another `next` in `interval` seconds.
-//
-// If a `next` is received, and then another `next` is received before
-// `interval` seconds have passed, the first value is discarded.
-//
-// After `interval` seconds have passed since the most recent `next` was sent,
-// the most recent `next` is forwarded on the scheduler that the value was
-// originally received on. If +[RACScheduler currentScheduler] was nil at the
-// time, a private background scheduler is used.
-//
-// Returns a signal which sends throttled and delayed `next` events. Completion
-// and errors are always forwarded immediately.
+/// Send `next`s only if we don't receive another `next` in `interval` seconds.
+///
+/// If a `next` is received, and then another `next` is received before
+/// `interval` seconds have passed, the first value is discarded.
+///
+/// After `interval` seconds have passed since the most recent `next` was sent,
+/// the most recent `next` is forwarded on the scheduler that the value was
+/// originally received on. If +[RACScheduler currentScheduler] was nil at the
+/// time, a private background scheduler is used.
+///
+/// Returns a signal which sends throttled and delayed `next` events. Completion
+/// and errors are always forwarded immediately.
 - (RACSignal *)throttle:(NSTimeInterval)interval;
 
-// Throttles `next`s for which `predicate` returns YES.
-//
-// When `predicate` returns YES for a `next`:
-//
-//  1. If another `next` is received before `interval` seconds have passed, the
-//     prior value is discarded. This happens regardless of whether the new
-//     value will be throttled.
-//  2. After `interval` seconds have passed since the value was originally
-//     received, it will be forwarded on the scheduler that it was received
-//     upon. If +[RACScheduler currentScheduler] was nil at the time, a private
-//     background scheduler is used.
-//
-// When `predicate` returns NO for a `next`, it is forwarded immediately,
-// without any throttling.
-//
-// interval  - The number of seconds for which to buffer the latest value that
-//             passes `predicate`.
-// predicate - Passed each `next` from the receiver, this block returns
-//             whether the given value should be throttled. This argument must
-//             not be nil.
-//
-// Returns a signal which sends `next` events, throttled when `predicate`
-// returns YES. Completion and errors are always forwarded immediately.
+/// Throttles `next`s for which `predicate` returns YES.
+///
+/// When `predicate` returns YES for a `next`:
+///
+///  1. If another `next` is received before `interval` seconds have passed, the
+///     prior value is discarded. This happens regardless of whether the new
+///     value will be throttled.
+///  2. After `interval` seconds have passed since the value was originally
+///     received, it will be forwarded on the scheduler that it was received
+///     upon. If +[RACScheduler currentScheduler] was nil at the time, a private
+///     background scheduler is used.
+///
+/// When `predicate` returns NO for a `next`, it is forwarded immediately,
+/// without any throttling.
+///
+/// interval  - The number of seconds for which to buffer the latest value that
+///             passes `predicate`.
+/// predicate - Passed each `next` from the receiver, this block returns
+///             whether the given value should be throttled. This argument must
+///             not be nil.
+///
+/// Returns a signal which sends `next` events, throttled when `predicate`
+/// returns YES. Completion and errors are always forwarded immediately.
 - (RACSignal *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id next))predicate;
 
-// Forwards `next` and `completed` events after delaying for `interval` seconds
-// on the current scheduler (on which the events were delivered).
-//
-// If +[RACScheduler currentScheduler] is nil when `next` or `completed` is
-// received, a private background scheduler is used.
-//
-// Returns a signal which sends delayed `next` and `completed` events. Errors
-// are always forwarded immediately.
+/// Forwards `next` and `completed` events after delaying for `interval` seconds
+/// on the current scheduler (on which the events were delivered).
+///
+/// If +[RACScheduler currentScheduler] is nil when `next` or `completed` is
+/// received, a private background scheduler is used.
+///
+/// Returns a signal which sends delayed `next` and `completed` events. Errors
+/// are always forwarded immediately.
 - (RACSignal *)delay:(NSTimeInterval)interval;
 
-// Resubscribes when the signal completes.
+/// Resubscribes when the signal completes.
 - (RACSignal *)repeat;
 
-// Execute the given block each time a subscription is created.
+/// Execute the given block each time a subscription is created.
 - (RACSignal *)initially:(void (^)(void))block;
 
-// Execute the given block when the signal completes or errors.
+/// Execute the given block when the signal completes or errors.
 - (RACSignal *)finally:(void (^)(void))block;
 
-// Divides the receiver's `next`s into buffers which deliver every `interval`
-// seconds.
-//
-// interval  - The interval in which values are grouped into one buffer.
-// scheduler - The scheduler upon which the returned signal will deliver its
-//             values. This must not be nil or +[RACScheduler
-//             immediateScheduler].
-//
-// Returns a signal which sends RACTuples of the buffered values at each
-// interval on `scheduler`. When the receiver completes, any currently-buffered
-// values will be sent immediately.
+/// Divides the receiver's `next`s into buffers which deliver every `interval`
+/// seconds.
+///
+/// interval  - The interval in which values are grouped into one buffer.
+/// scheduler - The scheduler upon which the returned signal will deliver its
+///             values. This must not be nil or +[RACScheduler
+///             immediateScheduler].
+///
+/// Returns a signal which sends RACTuples of the buffered values at each
+/// interval on `scheduler`. When the receiver completes, any currently-buffered
+/// values will be sent immediately.
 - (RACSignal *)bufferWithTime:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
 
-// Collect all receiver's `next`s into a NSArray. nil values will be converted
-// to NSNull.
-//
-// This corresponds to the `ToArray` method in Rx.
-//
-// Returns a signal which sends a single NSArray when the receiver completes
-// successfully.
+/// Collect all receiver's `next`s into a NSArray. nil values will be converted
+/// to NSNull.
+///
+/// This corresponds to the `ToArray` method in Rx.
+///
+/// Returns a signal which sends a single NSArray when the receiver completes
+/// successfully.
 - (RACSignal *)collect;
 
-// Takes the last `count` `next`s after the receiving signal completes.
+/// Takes the last `count` `next`s after the receiving signal completes.
 - (RACSignal *)takeLast:(NSUInteger)count;
 
-// Combines the latest values from the receiver and the given signal into
-// RACTuples, once both have sent at least one `next`.
-//
-// Any additional `next`s will result in a new RACTuple with the latest values
-// from both signals.
-//
-// signal - The signal to combine with. This argument must not be nil.
-//
-// Returns a signal which sends RACTuples of the combined values, forwards any
-// `error` events, and completes when both input signals complete.
+/// Combines the latest values from the receiver and the given signal into
+/// RACTuples, once both have sent at least one `next`.
+///
+/// Any additional `next`s will result in a new RACTuple with the latest values
+/// from both signals.
+///
+/// signal - The signal to combine with. This argument must not be nil.
+///
+/// Returns a signal which sends RACTuples of the combined values, forwards any
+/// `error` events, and completes when both input signals complete.
 - (RACSignal *)combineLatestWith:(RACSignal *)signal;
 
-// Combines the latest values from the given signals into RACTuples, once all
-// the signals have sent at least one `next`.
-//
-// Any additional `next`s will result in a new RACTuple with the latest values
-// from all signals.
-//
-// signals - The signals to combine. If this collection is empty, the returned
-//           signal will immediately complete upon subscription.
-//
-// Returns a signal which sends RACTuples of the combined values, forwards any
-// `error` events, and completes when all input signals complete.
+/// Combines the latest values from the given signals into RACTuples, once all
+/// the signals have sent at least one `next`.
+///
+/// Any additional `next`s will result in a new RACTuple with the latest values
+/// from all signals.
+///
+/// signals - The signals to combine. If this collection is empty, the returned
+///           signal will immediately complete upon subscription.
+///
+/// Returns a signal which sends RACTuples of the combined values, forwards any
+/// `error` events, and completes when all input signals complete.
 + (RACSignal *)combineLatest:(id<NSFastEnumeration>)signals;
 
-// Combines signals using +combineLatest:, then reduces the resulting tuples
-// into a single value using -reduceEach:.
-//
-// signals     - The signals to combine. If this collection is empty, the
-//               returned signal will immediately complete upon subscription.
-// reduceBlock - The block which reduces the latest values from all the
-//               signals into one value. It must take as many arguments as the
-//               number of signals given. Each argument will be an object
-//               argument. The return value must be an object. This argument
-//               must not be nil.
-//
-// Example:
-//
-//   [RACSignal combineLatest:@[ stringSignal, intSignal ] reduce:^(NSString *string, NSNumber *number) {
-//       return [NSString stringWithFormat:@"%@: %@", string, number];
-//   }];
-//
-// Returns a signal which sends the results from each invocation of
-// `reduceBlock`.
+/// Combines signals using +combineLatest:, then reduces the resulting tuples
+/// into a single value using -reduceEach:.
+///
+/// signals     - The signals to combine. If this collection is empty, the
+///               returned signal will immediately complete upon subscription.
+/// reduceBlock - The block which reduces the latest values from all the
+///               signals into one value. It must take as many arguments as the
+///               number of signals given. Each argument will be an object
+///               argument. The return value must be an object. This argument
+///               must not be nil.
+///
+/// Example:
+///
+///   [RACSignal combineLatest:@[ stringSignal, intSignal ] reduce:^(NSString *string, NSNumber *number) {
+///       return [NSString stringWithFormat:@"%@: %@", string, number];
+///   }];
+///
+/// Returns a signal which sends the results from each invocation of
+/// `reduceBlock`.
 + (RACSignal *)combineLatest:(id<NSFastEnumeration>)signals reduce:(id (^)())reduceBlock;
 
-// Sends the latest `next` from any of the signals.
-//
-// Returns a signal that passes through values from each of the given signals,
-// and sends `completed` when all of them complete. If any signal sends an error,
-// the returned signal sends `error` immediately.
+/// Sends the latest `next` from any of the signals.
+///
+/// Returns a signal that passes through values from each of the given signals,
+/// and sends `completed` when all of them complete. If any signal sends an error,
+/// the returned signal sends `error` immediately.
 + (RACSignal *)merge:(id<NSFastEnumeration>)signals;
 
-// Merges the signals sent by the receiver into a flattened signal, but only
-// subscribes to `maxConcurrent` number of signals at a time. New signals are
-// queued and subscribed to as other signals complete.
-//
-// If an error occurs on any of the signals, it is sent on the returned signal.
-// It completes only after the receiver and all sent signals have completed.
-//
-// This corresponds to `Merge<TSource>(IObservable<IObservable<TSource>>, Int32)`
-// in Rx.
-//
-// maxConcurrent - the maximum number of signals to subscribe to at a
-//                 time. If 0, it subscribes to an unlimited number of
-//                 signals.
+/// Merges the signals sent by the receiver into a flattened signal, but only
+/// subscribes to `maxConcurrent` number of signals at a time. New signals are
+/// queued and subscribed to as other signals complete.
+///
+/// If an error occurs on any of the signals, it is sent on the returned signal.
+/// It completes only after the receiver and all sent signals have completed.
+///
+/// This corresponds to `Merge<TSource>(IObservable<IObservable<TSource>>, Int32)`
+/// in Rx.
+///
+/// maxConcurrent - the maximum number of signals to subscribe to at a
+///                 time. If 0, it subscribes to an unlimited number of
+///                 signals.
 - (RACSignal *)flatten:(NSUInteger)maxConcurrent;
 
-// Ignores all `next`s from the receiver, waits for the receiver to complete,
-// then subscribes to a new signal.
-//
-// block - A block which will create or obtain a new signal to subscribe to,
-//         executed only after the receiver completes. This block must not be
-//         nil, and it must not return a nil signal.
-//
-// Returns a signal which will pass through the events of the signal created in
-// `block`. If the receiver errors out, the returned signal will error as well.
+/// Ignores all `next`s from the receiver, waits for the receiver to complete,
+/// then subscribes to a new signal.
+///
+/// block - A block which will create or obtain a new signal to subscribe to,
+///         executed only after the receiver completes. This block must not be
+///         nil, and it must not return a nil signal.
+///
+/// Returns a signal which will pass through the events of the signal created in
+/// `block`. If the receiver errors out, the returned signal will error as well.
 - (RACSignal *)then:(RACSignal * (^)(void))block;
 
-// Concats the inner signals of a signal of signals.
+/// Concats the inner signals of a signal of signals.
 - (RACSignal *)concat;
 
-// Aggregate `next`s with the given start and combination.
+/// Aggregate `next`s with the given start and combination.
 - (RACSignal *)aggregateWithStart:(id)start reduce:(id (^)(id running, id next))reduceBlock;
 
-// Aggregate `next`s with the given start and combination. The start factory 
-// block is called to get a new start object for each subscription.
+/// Aggregate `next`s with the given start and combination. The start factory 
+/// block is called to get a new start object for each subscription.
 - (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory reduce:(id (^)(id running, id next))reduceBlock;
 
-// Invokes -setKeyPath:onObject:nilValue: with `nil` for the nil value.
+/// Invokes -setKeyPath:onObject:nilValue: with `nil` for the nil value.
 - (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object;
 
-// Binds the receiver to an object, automatically setting the given key path on
-// every `next`. When the signal completes, the binding is automatically
-// disposed of.
-//
-// Sending an error on the signal is considered undefined behavior, and will
-// generate an assertion failure in Debug builds.
-//
-// A given key on an object should only have one active signal bound to it at any
-// given time. Binding more than one signal to the same property is considered
-// undefined behavior.
-//
-// keyPath  - The key path to update with `next`s from the receiver.
-// object   - The object that `keyPath` is relative to.
-// nilValue - The value to set at the key path whenever `nil` is sent by the
-//            receiver. This may be nil when binding to object properties, but
-//            an NSValue should be used for primitive properties, to avoid an
-//            exception if `nil` is sent (which might occur if an intermediate
-//            object is set to `nil`).
-//
-// Returns a disposable which can be used to terminate the binding.
+/// Binds the receiver to an object, automatically setting the given key path on
+/// every `next`. When the signal completes, the binding is automatically
+/// disposed of.
+///
+/// Sending an error on the signal is considered undefined behavior, and will
+/// generate an assertion failure in Debug builds.
+///
+/// A given key on an object should only have one active signal bound to it at any
+/// given time. Binding more than one signal to the same property is considered
+/// undefined behavior.
+///
+/// keyPath  - The key path to update with `next`s from the receiver.
+/// object   - The object that `keyPath` is relative to.
+/// nilValue - The value to set at the key path whenever `nil` is sent by the
+///            receiver. This may be nil when binding to object properties, but
+///            an NSValue should be used for primitive properties, to avoid an
+///            exception if `nil` is sent (which might occur if an intermediate
+///            object is set to `nil`).
+///
+/// Returns a disposable which can be used to terminate the binding.
 - (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object nilValue:(id)nilValue;
 
-// Sends NSDate.date every `interval` seconds.
-//
-// interval  - The time interval in seconds at which the current time is sent.
-// scheduler - The scheduler upon which the current NSDate should be sent. This
-//             must not be nil or +[RACScheduler immediateScheduler].
-//
-// Returns a signal that sends the current date/time every `interval` on
-// `scheduler`.
+/// Sends NSDate.date every `interval` seconds.
+///
+/// interval  - The time interval in seconds at which the current time is sent.
+/// scheduler - The scheduler upon which the current NSDate should be sent. This
+///             must not be nil or +[RACScheduler immediateScheduler].
+///
+/// Returns a signal that sends the current date/time every `interval` on
+/// `scheduler`.
 + (RACSignal *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
 
-// Sends NSDate.date at intervals of at least `interval` seconds, up to
-// approximately `interval` + `leeway` seconds.
-//
-// The created signal will defer sending each `next` for at least `interval`
-// seconds, and for an additional amount of time up to `leeway` seconds in the
-// interest of performance or power consumption. Note that some additional
-// latency is to be expected, even when specifying a `leeway` of 0.
-//
-// interval  - The base interval between `next`s.
-// scheduler - The scheduler upon which the current NSDate should be sent. This
-//             must not be nil or +[RACScheduler immediateScheduler].
-// leeway    - The maximum amount of additional time the `next` can be deferred.
-//
-// Returns a signal that sends the current date/time at intervals of at least
-// `interval seconds` up to approximately `interval` + `leeway` seconds on
-// `scheduler`.
+/// Sends NSDate.date at intervals of at least `interval` seconds, up to
+/// approximately `interval` + `leeway` seconds.
+///
+/// The created signal will defer sending each `next` for at least `interval`
+/// seconds, and for an additional amount of time up to `leeway` seconds in the
+/// interest of performance or power consumption. Note that some additional
+/// latency is to be expected, even when specifying a `leeway` of 0.
+///
+/// interval  - The base interval between `next`s.
+/// scheduler - The scheduler upon which the current NSDate should be sent. This
+///             must not be nil or +[RACScheduler immediateScheduler].
+/// leeway    - The maximum amount of additional time the `next` can be deferred.
+///
+/// Returns a signal that sends the current date/time at intervals of at least
+/// `interval seconds` up to approximately `interval` + `leeway` seconds on
+/// `scheduler`.
 + (RACSignal *)interval:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler withLeeway:(NSTimeInterval)leeway;
 
-// Take `next`s until the `signalTrigger` sends `next` or `completed`.
-//
-// Returns a signal which passes through all events from the receiver until
-// `signalTrigger` sends `next` or `completed`, at which point the returned signal
-// will send `completed`.
+/// Take `next`s until the `signalTrigger` sends `next` or `completed`.
+///
+/// Returns a signal which passes through all events from the receiver until
+/// `signalTrigger` sends `next` or `completed`, at which point the returned signal
+/// will send `completed`.
 - (RACSignal *)takeUntil:(RACSignal *)signalTrigger;
 
-// Subscribe to the returned signal when an error occurs.
+/// Subscribe to the returned signal when an error occurs.
 - (RACSignal *)catch:(RACSignal * (^)(NSError *error))catchBlock;
 
-// Subscribe to the given signal when an error occurs.
+/// Subscribe to the given signal when an error occurs.
 - (RACSignal *)catchTo:(RACSignal *)signal;
 
-// Returns the first `next`. Note that this is a blocking call.
+/// Returns the first `next`. Note that this is a blocking call.
 - (id)first;
 
-// Returns the first `next` or `defaultValue` if the signal completes or errors
-// without sending a `next`. Note that this is a blocking call.
+/// Returns the first `next` or `defaultValue` if the signal completes or errors
+/// without sending a `next`. Note that this is a blocking call.
 - (id)firstOrDefault:(id)defaultValue;
 
-// Returns the first `next` or `defaultValue` if the signal completes or errors
-// without sending a `next`. If an error occurs success will be NO and error
-// will be populated. Note that this is a blocking call.
-//
-// Both success and error may be NULL.
+/// Returns the first `next` or `defaultValue` if the signal completes or errors
+/// without sending a `next`. If an error occurs success will be NO and error
+/// will be populated. Note that this is a blocking call.
+///
+/// Both success and error may be NULL.
 - (id)firstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error;
 
-// Blocks the caller and waits for the signal to complete.
-//
-// error - If not NULL, set to any error that occurs.
-//
-// Returns whether the signal completed successfully. If NO, `error` will be set
-// to the error that occurred.
+/// Blocks the caller and waits for the signal to complete.
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns whether the signal completed successfully. If NO, `error` will be set
+/// to the error that occurred.
 - (BOOL)waitUntilCompleted:(NSError **)error;
 
-// Defer creation of a signal until the signal's actually subscribed to.
-//
-// This can be used to effectively turn a hot signal into a cold signal.
+/// Defer creation of a signal until the signal's actually subscribed to.
+///
+/// This can be used to effectively turn a hot signal into a cold signal.
 + (RACSignal *)defer:(RACSignal * (^)(void))block;
 
-// Send only `next`s for which -isEqual: returns NO when compared to the
-// previous `next`.
+/// Send only `next`s for which -isEqual: returns NO when compared to the
+/// previous `next`.
 - (RACSignal *)distinctUntilChanged;
 
-// Every time the receiver sends a new RACSignal, subscribes and sends `next`s and
-// `error`s only for that signal.
-//
-// The receiver must be a signal of signals.
-//
-// Returns a signal which passes through `next`s and `error`s from the latest
-// signal sent by the receiver, and sends `completed` when both the receiver and
-// the last sent signal complete.
+/// Every time the receiver sends a new RACSignal, subscribes and sends `next`s and
+/// `error`s only for that signal.
+///
+/// The receiver must be a signal of signals.
+///
+/// Returns a signal which passes through `next`s and `error`s from the latest
+/// signal sent by the receiver, and sends `completed` when both the receiver and
+/// the last sent signal complete.
 - (RACSignal *)switchToLatest;
 
-// Switches between the signals in `cases` as well as `defaultSignal` based on
-// the latest value sent by `signal`.
-//
-// signal        - A signal of objects used as keys in the `cases` dictionary.
-//                 This argument must not be nil.
-// cases         - A dictionary that has signals as values. This argument must
-//                 not be nil. A RACTupleNil key in this dictionary will match
-//                 nil `next` events that are received on `signal`.
-// defaultSignal - The signal to pass through after `signal` sends a value for
-//                 which `cases` does not contain a signal. If nil, any
-//                 unmatched values will result in
-//                 a RACSignalErrorNoMatchingCase error.
-//
-// Returns a signal which passes through `next`s and `error`s from one of the
-// the signals in `cases` or `defaultSignal`, and sends `completed` when both
-// `signal` and the last used signal complete. If no `defaultSignal` is given,
-// an unmatched `next` will result in an error on the returned signal.
+/// Switches between the signals in `cases` as well as `defaultSignal` based on
+/// the latest value sent by `signal`.
+///
+/// signal        - A signal of objects used as keys in the `cases` dictionary.
+///                 This argument must not be nil.
+/// cases         - A dictionary that has signals as values. This argument must
+///                 not be nil. A RACTupleNil key in this dictionary will match
+///                 nil `next` events that are received on `signal`.
+/// defaultSignal - The signal to pass through after `signal` sends a value for
+///                 which `cases` does not contain a signal. If nil, any
+///                 unmatched values will result in
+///                 a RACSignalErrorNoMatchingCase error.
+///
+/// Returns a signal which passes through `next`s and `error`s from one of the
+/// the signals in `cases` or `defaultSignal`, and sends `completed` when both
+/// `signal` and the last used signal complete. If no `defaultSignal` is given,
+/// an unmatched `next` will result in an error on the returned signal.
 + (RACSignal *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(RACSignal *)defaultSignal;
 
-// Switches between `trueSignal` and `falseSignal` based on the latest value
-// sent by `boolSignal`.
-//
-// boolSignal  - A signal of BOOLs determining whether `trueSignal` or
-//               `falseSignal` should be active. This argument must not be nil.
-// trueSignal  - The signal to pass through after `boolSignal` has sent YES.
-//               This argument must not be nil.
-// falseSignal - The signal to pass through after `boolSignal` has sent NO. This
-//               argument must not be nil.
-//
-// Returns a signal which passes through `next`s and `error`s from `trueSignal`
-// and/or `falseSignal`, and sends `completed` when both `boolSignal` and the
-// last switched signal complete.
+/// Switches between `trueSignal` and `falseSignal` based on the latest value
+/// sent by `boolSignal`.
+///
+/// boolSignal  - A signal of BOOLs determining whether `trueSignal` or
+///               `falseSignal` should be active. This argument must not be nil.
+/// trueSignal  - The signal to pass through after `boolSignal` has sent YES.
+///               This argument must not be nil.
+/// falseSignal - The signal to pass through after `boolSignal` has sent NO. This
+///               argument must not be nil.
+///
+/// Returns a signal which passes through `next`s and `error`s from `trueSignal`
+/// and/or `falseSignal`, and sends `completed` when both `boolSignal` and the
+/// last switched signal complete.
 + (RACSignal *)if:(RACSignal *)boolSignal then:(RACSignal *)trueSignal else:(RACSignal *)falseSignal;
 
-// Add every `next` to an array. Nils are represented by NSNulls. Note that this
-// is a blocking call.
-//
-// **This is not the same as the `ToArray` method in Rx.** See -collect for
-// that behavior instead.
-//
-// Returns the array of `next` values, or nil if an error occurs.
+/// Add every `next` to an array. Nils are represented by NSNulls. Note that this
+/// is a blocking call.
+///
+/// **This is not the same as the `ToArray` method in Rx.** See -collect for
+/// that behavior instead.
+///
+/// Returns the array of `next` values, or nil if an error occurs.
 - (NSArray *)toArray;
 
-// Add every `next` to a sequence. Nils are represented by NSNulls.
-//
-// This corresponds to the `ToEnumerable` method in Rx.
-//
-// Returns a sequence which provides values from the signal as they're sent.
-// Trying to retrieve a value from the sequence which has not yet been sent will
-// block.
+/// Add every `next` to a sequence. Nils are represented by NSNulls.
+///
+/// This corresponds to the `ToEnumerable` method in Rx.
+///
+/// Returns a sequence which provides values from the signal as they're sent.
+/// Trying to retrieve a value from the sequence which has not yet been sent will
+/// block.
 @property (nonatomic, strong, readonly) RACSequence *sequence;
 
-// Creates and returns a multicast connection. This allows you to share a single
-// subscription to the underlying signal.
+/// Creates and returns a multicast connection. This allows you to share a single
+/// subscription to the underlying signal.
 - (RACMulticastConnection *)publish;
 
-// Creates and returns a multicast connection that pushes values into the given
-// subject. This allows you to share a single subscription to the underlying
-// signal.
+/// Creates and returns a multicast connection that pushes values into the given
+/// subject. This allows you to share a single subscription to the underlying
+/// signal.
 - (RACMulticastConnection *)multicast:(RACSubject *)subject;
 
-// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
-// immediately connects to the resulting RACMulticastConnection.
-//
-// Returns the connected, multicasted signal.
+/// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
+/// immediately connects to the resulting RACMulticastConnection.
+///
+/// Returns the connected, multicasted signal.
 - (RACSignal *)replay;
 
-// Multicasts the signal to a RACReplaySubject of capacity 1, and immediately
-// connects to the resulting RACMulticastConnection.
-//
-// Returns the connected, multicasted signal.
+/// Multicasts the signal to a RACReplaySubject of capacity 1, and immediately
+/// connects to the resulting RACMulticastConnection.
+///
+/// Returns the connected, multicasted signal.
 - (RACSignal *)replayLast;
 
-// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
-// lazily connects to the resulting RACMulticastConnection.
-//
-// This means the returned signal will subscribe to the multicasted signal only
-// when the former receives its first subscription.
-//
-// Returns the lazily connected, multicasted signal.
+/// Multicasts the signal to a RACReplaySubject of unlimited capacity, and
+/// lazily connects to the resulting RACMulticastConnection.
+///
+/// This means the returned signal will subscribe to the multicasted signal only
+/// when the former receives its first subscription.
+///
+/// Returns the lazily connected, multicasted signal.
 - (RACSignal *)replayLazily;
 
-// Sends an error after `interval` seconds if the source doesn't complete
-// before then.
-//
-// The error will be in the RACSignalErrorDomain and have a code of
-// RACSignalErrorTimedOut.
-//
-// interval  - The number of seconds after which the signal should error out.
-// scheduler - The scheduler upon which any timeout error should be sent. This
-//             must not be nil or +[RACScheduler immediateScheduler].
-//
-// Returns a signal that passes through the receiver's events, until the stream
-// finishes or times out, at which point an error will be sent on `scheduler`.
+/// Sends an error after `interval` seconds if the source doesn't complete
+/// before then.
+///
+/// The error will be in the RACSignalErrorDomain and have a code of
+/// RACSignalErrorTimedOut.
+///
+/// interval  - The number of seconds after which the signal should error out.
+/// scheduler - The scheduler upon which any timeout error should be sent. This
+///             must not be nil or +[RACScheduler immediateScheduler].
+///
+/// Returns a signal that passes through the receiver's events, until the stream
+/// finishes or times out, at which point an error will be sent on `scheduler`.
 - (RACSignal *)timeout:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler;
 
-// Creates and returns a signal that delivers its events on the given scheduler.
-// Any side effects of the receiver will still be performed on the original
-// thread.
-//
-// This is ideal when the signal already performs its work on the desired
-// thread, but you want to handle its events elsewhere.
-//
-// This corresponds to the `ObserveOn` method in Rx.
+/// Creates and returns a signal that delivers its events on the given scheduler.
+/// Any side effects of the receiver will still be performed on the original
+/// thread.
+///
+/// This is ideal when the signal already performs its work on the desired
+/// thread, but you want to handle its events elsewhere.
+///
+/// This corresponds to the `ObserveOn` method in Rx.
 - (RACSignal *)deliverOn:(RACScheduler *)scheduler;
 
-// Creates and returns a signal that executes its side effects and delivers its
-// events on the given scheduler.
-//
-// Use of this operator should be avoided whenever possible, because the
-// receiver's side effects may not be safe to run on another thread. If you just
-// want to receive the signal's events on `scheduler`, use -deliverOn: instead.
+/// Creates and returns a signal that executes its side effects and delivers its
+/// events on the given scheduler.
+///
+/// Use of this operator should be avoided whenever possible, because the
+/// receiver's side effects may not be safe to run on another thread. If you just
+/// want to receive the signal's events on `scheduler`, use -deliverOn: instead.
 - (RACSignal *)subscribeOn:(RACScheduler *)scheduler;
 
-// Groups each received object into a group, as determined by calling `keyBlock`
-// with that object. The object sent is transformed by calling `transformBlock`
-// with the object. If `transformBlock` is nil, it sends the original object.
-//
-// The returned signal is a signal of RACGroupedSignal.
+/// Groups each received object into a group, as determined by calling `keyBlock`
+/// with that object. The object sent is transformed by calling `transformBlock`
+/// with the object. If `transformBlock` is nil, it sends the original object.
+///
+/// The returned signal is a signal of RACGroupedSignal.
 - (RACSignal *)groupBy:(id<NSCopying> (^)(id object))keyBlock transform:(id (^)(id object))transformBlock;
 
-// Calls -[RACSignal groupBy:keyBlock transform:nil].
+/// Calls -[RACSignal groupBy:keyBlock transform:nil].
 - (RACSignal *)groupBy:(id<NSCopying> (^)(id object))keyBlock;
 
-// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
-// objects.
+/// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
+/// objects.
 - (RACSignal *)any;
 
-// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
-// objects that pass `predicateBlock`.
-//
-// predicateBlock - cannot be nil.
+/// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
+/// objects that pass `predicateBlock`.
+///
+/// predicateBlock - cannot be nil.
 - (RACSignal *)any:(BOOL (^)(id object))predicateBlock;
 
-// Sends an [NSNumber numberWithBool:YES] if all the objects the receiving 
-// signal sends pass `predicateBlock`.
-//
-// predicateBlock - cannot be nil.
+/// Sends an [NSNumber numberWithBool:YES] if all the objects the receiving 
+/// signal sends pass `predicateBlock`.
+///
+/// predicateBlock - cannot be nil.
 - (RACSignal *)all:(BOOL (^)(id object))predicateBlock;
 
-// Resubscribes to the receiving signal if an error occurs, up until it has
-// retried the given number of times.
-//
-// retryCount - if 0, it keeps retrying until it completes.
+/// Resubscribes to the receiving signal if an error occurs, up until it has
+/// retried the given number of times.
+///
+/// retryCount - if 0, it keeps retrying until it completes.
 - (RACSignal *)retry:(NSInteger)retryCount;
 
-// Resubscribes to the receiving signal if an error occurs.
+/// Resubscribes to the receiving signal if an error occurs.
 - (RACSignal *)retry;
 
-// Sends the latest value from the receiver only when `sampler` sends a value.
-// The returned signal could repeat values if `sampler` fires more often than
-// the receiver.
-//
-// sampler - The signal that controls when the latest value from the receiver
-//           is sent. Cannot be nil.
+/// Sends the latest value from the receiver only when `sampler` sends a value.
+/// The returned signal could repeat values if `sampler` fires more often than
+/// the receiver.
+///
+/// sampler - The signal that controls when the latest value from the receiver
+///           is sent. Cannot be nil.
 - (RACSignal *)sample:(RACSignal *)sampler;
 
-// Ignores all `next`s from the receiver.
-//
-// Returns a signal which only passes through `error` or `completed` events from
-// the receiver.
+/// Ignores all `next`s from the receiver.
+///
+/// Returns a signal which only passes through `error` or `completed` events from
+/// the receiver.
 - (RACSignal *)ignoreValues;
 
-// Converts each of the receiver's events into a RACEvent object.
-//
-// Returns a signal which sends the receiver's events as RACEvents, and
-// completes after the receiver sends `completed` or `error`.
+/// Converts each of the receiver's events into a RACEvent object.
+///
+/// Returns a signal which sends the receiver's events as RACEvents, and
+/// completes after the receiver sends `completed` or `error`.
 - (RACSignal *)materialize;
 
-// Converts each RACEvent in the receiver back into "real" RACSignal events.
-//
-// Returns a signal which sends `next` for each value RACEvent, `error` for each
-// error RACEvent, and `completed` for each completed RACEvent.
+/// Converts each RACEvent in the receiver back into "real" RACSignal events.
+///
+/// Returns a signal which sends `next` for each value RACEvent, `error` for each
+/// error RACEvent, and `completed` for each completed RACEvent.
 - (RACSignal *)dematerialize;
 
-// Inverts each NSNumber-wrapped BOOL sent by the receiver. It will assert if
-// the receiver sends anything other than NSNumbers.
-//
-// Returns a signal of inverted NSNumber-wrapped BOOLs.
+/// Inverts each NSNumber-wrapped BOOL sent by the receiver. It will assert if
+/// the receiver sends anything other than NSNumbers.
+///
+/// Returns a signal of inverted NSNumber-wrapped BOOLs.
 - (RACSignal *)not;
 
-// Performs a boolean AND on all of the RACTuple of NSNumbers in sent by the receiver.
-//
-// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
-//
-// Returns a signal that applies AND to each NSNumber in the tuple.
+/// Performs a boolean AND on all of the RACTuple of NSNumbers in sent by the receiver.
+///
+/// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
+///
+/// Returns a signal that applies AND to each NSNumber in the tuple.
 - (RACSignal *)and;
 
-// Performs a boolean OR on all of the RACTuple of NSNumbers in sent by the receiver.
-//
-// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
-// 
-// Returns a signal that applies OR to each NSNumber in the tuple.
+/// Performs a boolean OR on all of the RACTuple of NSNumbers in sent by the receiver.
+///
+/// Asserts if the receiver sends anything other than a RACTuple of one or more NSNumbers.
+/// 
+/// Returns a signal that applies OR to each NSNumber in the tuple.
 - (RACSignal *)or;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.h
@@ -16,194 +16,194 @@
 
 @interface RACSignal : RACStream
 
-// Creates a new signal. This is the preferred way to create a new signal
-// operation or behavior.
-//
-// Events can be sent to new subscribers immediately in the `didSubscribe`
-// block, but the subscriber will not be able to dispose of the signal until
-// a RACDisposable is returned from `didSubscribe`. In the case of infinite
-// signals, this won't _ever_ happen if events are sent immediately.
-//
-// To ensure that the signal is disposable, events can be scheduled on the
-// +[RACScheduler currentScheduler] (so that they're deferred, not sent
-// immediately), or they can be sent in the background. The RACDisposable
-// returned by the `didSubscribe` block should cancel any such scheduling or
-// asynchronous work.
-//
-// didSubscribe - Called when the signal is subscribed to. The new subscriber is
-//                passed in. You can then manually control the <RACSubscriber> by
-//                sending it -sendNext:, -sendError:, and -sendCompleted,
-//                as defined by the operation you're implementing. This block
-//                should return a RACDisposable which cancels any ongoing work
-//                triggered by the subscription, and cleans up any resources or
-//                disposables created as part of it. When the disposable is
-//                disposed of, the signal must not send any more events to the
-//                `subscriber`. If no cleanup is necessary, return nil.
-//
-// **Note:** The `didSubscribe` block is called every time a new subscriber
-// subscribes. Any side effects within the block will thus execute once for each
-// subscription, not necessarily on one thread, and possibly even
-// simultaneously!
+/// Creates a new signal. This is the preferred way to create a new signal
+/// operation or behavior.
+///
+/// Events can be sent to new subscribers immediately in the `didSubscribe`
+/// block, but the subscriber will not be able to dispose of the signal until
+/// a RACDisposable is returned from `didSubscribe`. In the case of infinite
+/// signals, this won't _ever_ happen if events are sent immediately.
+///
+/// To ensure that the signal is disposable, events can be scheduled on the
+/// +[RACScheduler currentScheduler] (so that they're deferred, not sent
+/// immediately), or they can be sent in the background. The RACDisposable
+/// returned by the `didSubscribe` block should cancel any such scheduling or
+/// asynchronous work.
+///
+/// didSubscribe - Called when the signal is subscribed to. The new subscriber is
+///                passed in. You can then manually control the <RACSubscriber> by
+///                sending it -sendNext:, -sendError:, and -sendCompleted,
+///                as defined by the operation you're implementing. This block
+///                should return a RACDisposable which cancels any ongoing work
+///                triggered by the subscription, and cleans up any resources or
+///                disposables created as part of it. When the disposable is
+///                disposed of, the signal must not send any more events to the
+///                `subscriber`. If no cleanup is necessary, return nil.
+///
+/// **Note:** The `didSubscribe` block is called every time a new subscriber
+/// subscribes. Any side effects within the block will thus execute once for each
+/// subscription, not necessarily on one thread, and possibly even
+/// simultaneously!
 + (RACSignal *)createSignal:(RACDisposable * (^)(id<RACSubscriber> subscriber))didSubscribe;
 
-// Returns a signal that immediately sends the given error.
+/// Returns a signal that immediately sends the given error.
 + (RACSignal *)error:(NSError *)error;
 
-// Returns a signal that never completes.
+/// Returns a signal that never completes.
 + (RACSignal *)never;
 
-// Immediately schedules the given block on the given scheduler. The block is
-// given a subscriber to which it can send events.
-//
-// scheduler - The scheduler on which `block` will be scheduled and results
-//             delivered. Cannot be nil.
-// block     - The block to invoke. Cannot be NULL.
-//
-// Returns a signal which will send all events sent on the subscriber given to
-// `block`. All events will be sent on `scheduler` and it will replay any missed
-// events to new subscribers.
+/// Immediately schedules the given block on the given scheduler. The block is
+/// given a subscriber to which it can send events.
+///
+/// scheduler - The scheduler on which `block` will be scheduled and results
+///             delivered. Cannot be nil.
+/// block     - The block to invoke. Cannot be NULL.
+///
+/// Returns a signal which will send all events sent on the subscriber given to
+/// `block`. All events will be sent on `scheduler` and it will replay any missed
+/// events to new subscribers.
 + (RACSignal *)startEagerlyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block;
 
-// Invokes the given block only on the first subscription. The block is given a
-// subscriber to which it can send events.
-//
-// Note that disposing of the subscription to the returned signal will *not*
-// dispose of the underlying subscription. If you need that behavior, see
-// -[RACMulticastConnection autoconnect]. The underlying subscription will never
-// be disposed of. Because of this, `block` should never return an infinite
-// signal since there would be no way of ending it.
-//
-// scheduler - The scheduler on which the block should be scheduled. Note that 
-//             if given +[RACScheduler immediateScheduler], the block will be
-//             invoked synchronously on the first subscription. Cannot be nil.
-// block     - The block to invoke on the first subscription. Cannot be NULL.
-//
-// Returns a signal which will pass through the events sent to the subscriber
-// given to `block` and replay any missed events to new subscribers.
+/// Invokes the given block only on the first subscription. The block is given a
+/// subscriber to which it can send events.
+///
+/// Note that disposing of the subscription to the returned signal will *not*
+/// dispose of the underlying subscription. If you need that behavior, see
+/// -[RACMulticastConnection autoconnect]. The underlying subscription will never
+/// be disposed of. Because of this, `block` should never return an infinite
+/// signal since there would be no way of ending it.
+///
+/// scheduler - The scheduler on which the block should be scheduled. Note that 
+///             if given +[RACScheduler immediateScheduler], the block will be
+///             invoked synchronously on the first subscription. Cannot be nil.
+/// block     - The block to invoke on the first subscription. Cannot be NULL.
+///
+/// Returns a signal which will pass through the events sent to the subscriber
+/// given to `block` and replay any missed events to new subscribers.
 + (RACSignal *)startLazilyWithScheduler:(RACScheduler *)scheduler block:(void (^)(id<RACSubscriber> subscriber))block;
 
 @end
 
 @interface RACSignal (RACStream)
 
-// Returns a signal that immediately sends the given value and then completes.
+/// Returns a signal that immediately sends the given value and then completes.
 + (RACSignal *)return:(id)value;
 
-// Returns a signal that immediately completes.
+/// Returns a signal that immediately completes.
 + (RACSignal *)empty;
 
-// Subscribes to `signal` when the source signal completes.
+/// Subscribes to `signal` when the source signal completes.
 - (RACSignal *)concat:(RACSignal *)signal;
 
-// Zips the values in the receiver with those of the given signal to create
-// RACTuples.
-//
-// The first `next` of each stream will be combined, then the second `next`, and
-// so forth, until either signal completes or errors.
-//
-// signal - The signal to zip with. This must not be `nil`.
-//
-// Returns a new signal of RACTuples, representing the combined values of the
-// two signals. Any error from one of the original signals will be forwarded on
-// the returned signal.
+/// Zips the values in the receiver with those of the given signal to create
+/// RACTuples.
+///
+/// The first `next` of each stream will be combined, then the second `next`, and
+/// so forth, until either signal completes or errors.
+///
+/// signal - The signal to zip with. This must not be `nil`.
+///
+/// Returns a new signal of RACTuples, representing the combined values of the
+/// two signals. Any error from one of the original signals will be forwarded on
+/// the returned signal.
 - (RACSignal *)zipWith:(RACSignal *)signal;
 
 @end
 
 @interface RACSignal (Subscription)
 
-// Subscribes `subscriber` to changes on the receiver. The receiver defines which
-// events it actually sends and in what situations the events are sent.
-//
-// Subscription will always happen on a valid RACScheduler. If the
-// +[RACScheduler currentScheduler] cannot be determined at the time of
-// subscription (e.g., because the calling code is running on a GCD queue or
-// NSOperationQueue), subscription will occur on a private background scheduler.
-// On the main thread, subscriptions will always occur immediately, with a
-// +[RACScheduler currentScheduler] of +[RACScheduler mainThreadScheduler].
-//
-// Returns nil or a disposable. You can call -[RACDisposable dispose] if you
-// need to end your subscription before it would "naturally" end, either by
-// completing or erroring. Once the disposable has been disposed, the subscriber
-// won't receive any more events from the subscription.
+/// Subscribes `subscriber` to changes on the receiver. The receiver defines which
+/// events it actually sends and in what situations the events are sent.
+///
+/// Subscription will always happen on a valid RACScheduler. If the
+/// +[RACScheduler currentScheduler] cannot be determined at the time of
+/// subscription (e.g., because the calling code is running on a GCD queue or
+/// NSOperationQueue), subscription will occur on a private background scheduler.
+/// On the main thread, subscriptions will always occur immediately, with a
+/// +[RACScheduler currentScheduler] of +[RACScheduler mainThreadScheduler].
+///
+/// Returns nil or a disposable. You can call -[RACDisposable dispose] if you
+/// need to end your subscription before it would "naturally" end, either by
+/// completing or erroring. Once the disposable has been disposed, the subscriber
+/// won't receive any more events from the subscription.
 - (RACDisposable *)subscribe:(id<RACSubscriber>)subscriber;
 
-// Convenience method to subscribe to the `next` event.
-//
-// This corresponds to `IObserver<T>.OnNext` in Rx.
+/// Convenience method to subscribe to the `next` event.
+///
+/// This corresponds to `IObserver<T>.OnNext` in Rx.
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock;
 
-// Convenience method to subscribe to the `next` and `completed` events.
+/// Convenience method to subscribe to the `next` and `completed` events.
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock completed:(void (^)(void))completedBlock;
 
-// Convenience method to subscribe to the `next`, `completed`, and `error` events.
+/// Convenience method to subscribe to the `next`, `completed`, and `error` events.
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock;
 
-// Convenience method to subscribe to `error` events.
-//
-// This corresponds to the `IObserver<T>.OnError` in Rx.
+/// Convenience method to subscribe to `error` events.
+///
+/// This corresponds to the `IObserver<T>.OnError` in Rx.
 - (RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock;
 
-// Convenience method to subscribe to `completed` events.
-//
-// This corresponds to the `IObserver<T>.OnCompleted` in Rx.
+/// Convenience method to subscribe to `completed` events.
+///
+/// This corresponds to the `IObserver<T>.OnCompleted` in Rx.
 - (RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock;
 
-// Convenience method to subscribe to `next` and `error` events.
+/// Convenience method to subscribe to `next` and `error` events.
 - (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock;
 
-// Convenience method to subscribe to `error` and `completed` events.
+/// Convenience method to subscribe to `error` and `completed` events.
 - (RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock;
 
 @end
 
-// Additional methods to assist with debugging.
+/// Additional methods to assist with debugging.
 @interface RACSignal (Debugging)
 
-// Logs all events that the receiver sends.
+/// Logs all events that the receiver sends.
 - (RACSignal *)logAll;
 
-// Logs each `next` that the receiver sends.
+/// Logs each `next` that the receiver sends.
 - (RACSignal *)logNext;
 
-// Logs any error that the receiver sends.
+/// Logs any error that the receiver sends.
 - (RACSignal *)logError;
 
-// Logs any `completed` event that the receiver sends.
+/// Logs any `completed` event that the receiver sends.
 - (RACSignal *)logCompleted;
 
 @end
 
-// Additional methods to assist with unit testing.
-//
-// **These methods should never ship in production code.**
+/// Additional methods to assist with unit testing.
+///
+/// **These methods should never ship in production code.**
 @interface RACSignal (Testing)
 
-// Spins the main run loop for a short while, waiting for the receiver to send a `next`.
-//
-// **Because this method executes the run loop recursively, it should only be used
-// on the main thread, and only from a unit test.**
-//
-// defaultValue - Returned if the receiver completes or errors before sending
-//                a `next`, or if the method times out. This argument may be
-//                nil.
-// success      - If not NULL, set to whether the receiver completed
-//                successfully.
-// error        - If not NULL, set to any error that occurred.
-//
-// Returns the first value received, or `defaultValue` if no value is received
-// before the signal finishes or the method times out.
+/// Spins the main run loop for a short while, waiting for the receiver to send a `next`.
+///
+/// **Because this method executes the run loop recursively, it should only be used
+/// on the main thread, and only from a unit test.**
+///
+/// defaultValue - Returned if the receiver completes or errors before sending
+///                a `next`, or if the method times out. This argument may be
+///                nil.
+/// success      - If not NULL, set to whether the receiver completed
+///                successfully.
+/// error        - If not NULL, set to any error that occurred.
+///
+/// Returns the first value received, or `defaultValue` if no value is received
+/// before the signal finishes or the method times out.
 - (id)asynchronousFirstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error;
 
-// Spins the main run loop for a short while, waiting for the receiver to complete.
-//
-// **Because this method executes the run loop recursively, it should only be used
-// on the main thread, and only from a unit test.**
-//
-// error - If not NULL, set to any error that occurs.
-//
-// Returns whether the signal completed successfully before timing out. If NO,
-// `error` will be set to any error that occurred.
+/// Spins the main run loop for a short while, waiting for the receiver to complete.
+///
+/// **Because this method executes the run loop recursively, it should only be used
+/// on the main thread, and only from a unit test.**
+///
+/// error - If not NULL, set to any error that occurs.
+///
+/// Returns whether the signal completed successfully before timing out. If NO,
+/// `error` will be set to any error that occurred.
 - (BOOL)asynchronouslyWaitUntilCompleted:(NSError **)error;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignalSequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignalSequence.h
@@ -10,10 +10,10 @@
 
 @class RACSignal;
 
-// Private class that adapts a RACSignal to the RACSequence interface.
+/// Private class that adapts a RACSignal to the RACSequence interface.
 @interface RACSignalSequence : RACSequence
 
-// Returns a sequence for enumerating over the given signal.
+/// Returns a sequence for enumerating over the given signal.
 + (RACSequence *)sequenceWithSignal:(RACSignal *)signal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream+Private.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream+Private.h
@@ -10,14 +10,14 @@
 
 @interface RACStream ()
 
-// Combines a list of streams using the logic of the given block.
-//
-// streams - The streams to combine.
-// block   - An operator that combines two streams and returns a new one. The
-//           returned stream should contain 2-tuples of the streams' combined
-//           values.
-//
-// Returns a combined stream.
+/// Combines a list of streams using the logic of the given block.
+///
+/// streams - The streams to combine.
+/// block   - An operator that combines two streams and returns a new one. The
+///           returned stream should contain 2-tuples of the streams' combined
+///           values.
+///
+/// Returns a combined stream.
 + (instancetype)join:(id<NSFastEnumeration>)streams block:(RACStream * (^)(id, id))block;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
@@ -10,299 +10,299 @@
 
 @class RACStream;
 
-// A block which accepts a value from a RACStream and returns a new instance
-// of the same stream class.
-//
-// Setting `stop` to `YES` will cause the bind to terminate after the returned
-// value. Returning `nil` will result in immediate termination.
+/// A block which accepts a value from a RACStream and returns a new instance
+/// of the same stream class.
+///
+/// Setting `stop` to `YES` will cause the bind to terminate after the returned
+/// value. Returning `nil` will result in immediate termination.
 typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 
-// An abstract class representing any stream of values.
-//
-// This class represents a monad, upon which many stream-based operations can
-// be built.
-//
-// When subclassing RACStream, only the methods in the main @interface body need
-// to be overridden.
+/// An abstract class representing any stream of values.
+///
+/// This class represents a monad, upon which many stream-based operations can
+/// be built.
+///
+/// When subclassing RACStream, only the methods in the main @interface body need
+/// to be overridden.
 @interface RACStream : NSObject
 
-// Returns an empty stream.
+/// Returns an empty stream.
 + (instancetype)empty;
 
-// Lifts `value` into the stream monad.
-//
-// Returns a stream containing only the given value.
+/// Lifts `value` into the stream monad.
+///
+/// Returns a stream containing only the given value.
 + (instancetype)return:(id)value;
 
-// Lazily binds a block to the values in the receiver.
-//
-// This should only be used if you need to terminate the bind early, or close
-// over some state. -flattenMap: is more appropriate for all other cases.
-//
-// block - A block returning a RACStreamBindBlock. This block will be invoked
-//         each time the bound stream is re-evaluated. This block must not be
-//         nil or return nil.
-//
-// Returns a new stream which represents the combined result of all lazy
-// applications of `block`.
+/// Lazily binds a block to the values in the receiver.
+///
+/// This should only be used if you need to terminate the bind early, or close
+/// over some state. -flattenMap: is more appropriate for all other cases.
+///
+/// block - A block returning a RACStreamBindBlock. This block will be invoked
+///         each time the bound stream is re-evaluated. This block must not be
+///         nil or return nil.
+///
+/// Returns a new stream which represents the combined result of all lazy
+/// applications of `block`.
 - (instancetype)bind:(RACStreamBindBlock (^)(void))block;
 
-// Appends the values of `stream` to the values in the receiver.
-//
-// stream - A stream to concatenate. This must be an instance of the same
-//          concrete class as the receiver, and should not be `nil`.
-//
-// Returns a new stream representing the receiver followed by `stream`.
+/// Appends the values of `stream` to the values in the receiver.
+///
+/// stream - A stream to concatenate. This must be an instance of the same
+///          concrete class as the receiver, and should not be `nil`.
+///
+/// Returns a new stream representing the receiver followed by `stream`.
 - (instancetype)concat:(RACStream *)stream;
 
-// Zips the values in the receiver with those of the given stream to create
-// RACTuples.
-//
-// The first value of each stream will be combined, then the second value, and
-// so forth, until at least one of the streams is exhausted.
-//
-// stream - The stream to zip with. This must be an instance of the same
-//          concrete class as the receiver, and should not be `nil`.
-//
-// Returns a new stream of RACTuples, representing the zipped values of the
-// two streams.
+/// Zips the values in the receiver with those of the given stream to create
+/// RACTuples.
+///
+/// The first value of each stream will be combined, then the second value, and
+/// so forth, until at least one of the streams is exhausted.
+///
+/// stream - The stream to zip with. This must be an instance of the same
+///          concrete class as the receiver, and should not be `nil`.
+///
+/// Returns a new stream of RACTuples, representing the zipped values of the
+/// two streams.
 - (instancetype)zipWith:(RACStream *)stream;
 
 @end
 
-// This extension contains functionality to support naming streams for
-// debugging.
-//
-// Subclasses do not need to override the methods here.
+/// This extension contains functionality to support naming streams for
+/// debugging.
+///
+/// Subclasses do not need to override the methods here.
 @interface RACStream ()
 
-// The name of the stream. This is for debugging/human purposes only.
+/// The name of the stream. This is for debugging/human purposes only.
 @property (copy) NSString *name;
 
-// Sets the name of the receiver to the given format string.
-//
-// This is for debugging purposes only, and won't do anything unless the DEBUG
-// preprocessor macro is defined.
-//
-// Returns the receiver, for easy method chaining.
+/// Sets the name of the receiver to the given format string.
+///
+/// This is for debugging purposes only, and won't do anything unless the DEBUG
+/// preprocessor macro is defined.
+///
+/// Returns the receiver, for easy method chaining.
 - (instancetype)setNameWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1, 2);
 
 @end
 
-// Operations built on the RACStream primitives.
-//
-// These methods do not need to be overridden, although subclasses may
-// occasionally gain better performance from doing so.
+/// Operations built on the RACStream primitives.
+///
+/// These methods do not need to be overridden, although subclasses may
+/// occasionally gain better performance from doing so.
 @interface RACStream (Operations)
 
-// Maps `block` across the values in the receiver and flattens the result.
-//
-// Note that operators applied _after_ -flattenMap: behave differently from
-// operators _within_ -flattenMap:. See the Examples section below.
-//
-// This corresponds to the `SelectMany` method in Rx.
-//
-// block - A block which accepts the values in the receiver and returns a new
-//         instance of the receiver's class. This block should not return `nil`.
-//
-// Examples
-//
-//   [signal flattenMap:^(id x) {
-//       // Logs each time a returned signal completes.
-//       return [[RACSignal return:x] logCompleted];
-//   }];
-//
-//   [[signal
-//       flattenMap:^(id x) {
-//           return [RACSignal return:x];
-//       }]
-//       // Logs only once, when all of the signals complete.
-//       logCompleted];
-//
-// Returns a new stream which represents the combined streams resulting from
-// mapping `block`.
+/// Maps `block` across the values in the receiver and flattens the result.
+///
+/// Note that operators applied _after_ -flattenMap: behave differently from
+/// operators _within_ -flattenMap:. See the Examples section below.
+///
+/// This corresponds to the `SelectMany` method in Rx.
+///
+/// block - A block which accepts the values in the receiver and returns a new
+///         instance of the receiver's class. This block should not return `nil`.
+///
+/// Examples
+///
+///   [signal flattenMap:^(id x) {
+///       // Logs each time a returned signal completes.
+///       return [[RACSignal return:x] logCompleted];
+///   }];
+///
+///   [[signal
+///       flattenMap:^(id x) {
+///           return [RACSignal return:x];
+///       }]
+///       // Logs only once, when all of the signals complete.
+///       logCompleted];
+///
+/// Returns a new stream which represents the combined streams resulting from
+/// mapping `block`.
 - (instancetype)flattenMap:(RACStream * (^)(id value))block;
 
-// Flattens a stream of streams.
-//
-// This corresponds to the `Merge` method in Rx.
-//
-// Returns a stream consisting of the combined streams obtained from the
-// receiver.
+/// Flattens a stream of streams.
+///
+/// This corresponds to the `Merge` method in Rx.
+///
+/// Returns a stream consisting of the combined streams obtained from the
+/// receiver.
 - (instancetype)flatten;
 
-// Maps `block` across the values in the receiver.
-//
-// This corresponds to the `Select` method in Rx.
-//
-// Returns a new stream with the mapped values.
+/// Maps `block` across the values in the receiver.
+///
+/// This corresponds to the `Select` method in Rx.
+///
+/// Returns a new stream with the mapped values.
 - (instancetype)map:(id (^)(id value))block;
 
-// Replace each value in the receiver with the given object.
-//
-// Returns a new stream which includes the given object once for each value in
-// the receiver.
+/// Replace each value in the receiver with the given object.
+///
+/// Returns a new stream which includes the given object once for each value in
+/// the receiver.
 - (instancetype)mapReplace:(id)object;
 
-// Filters out values in the receiver that don't pass the given test.
-//
-// This corresponds to the `Where` method in Rx.
-//
-// Returns a new stream with only those values that passed.
+/// Filters out values in the receiver that don't pass the given test.
+///
+/// This corresponds to the `Where` method in Rx.
+///
+/// Returns a new stream with only those values that passed.
 - (instancetype)filter:(BOOL (^)(id value))block;
 
-// Filters out values in the receiver that equal (via -isEqual:) the provided value.
-//
-// value - The value can be `nil`, in which case it ignores `nil` values.
-//
-// Returns a new stream containing only the values which did not compare equal
-// to `value`.
+/// Filters out values in the receiver that equal (via -isEqual:) the provided value.
+///
+/// value - The value can be `nil`, in which case it ignores `nil` values.
+///
+/// Returns a new stream containing only the values which did not compare equal
+/// to `value`.
 - (instancetype)ignore:(id)value;
 
-// Unpacks each RACTuple in the receiver and maps the values to a new value.
-//
-// reduceBlock - The block which reduces each RACTuple's values into one value.
-//               It must take as many arguments as the number of tuple elements
-//               to process. Each argument will be an object argument. The
-//               return value must be an object. This argument cannot be nil.
-//
-// Returns a new stream of reduced tuple values.
+/// Unpacks each RACTuple in the receiver and maps the values to a new value.
+///
+/// reduceBlock - The block which reduces each RACTuple's values into one value.
+///               It must take as many arguments as the number of tuple elements
+///               to process. Each argument will be an object argument. The
+///               return value must be an object. This argument cannot be nil.
+///
+/// Returns a new stream of reduced tuple values.
 - (instancetype)reduceEach:(id (^)())reduceBlock;
 
-// Returns a stream consisting of `value`, followed by the values in the
-// receiver.
+/// Returns a stream consisting of `value`, followed by the values in the
+/// receiver.
 - (instancetype)startWith:(id)value;
 
-// Skips the first `skipCount` values in the receiver.
-//
-// Returns the receiver after skipping the first `skipCount` values. If
-// `skipCount` is greater than the number of values in the stream, an empty
-// stream is returned.
+/// Skips the first `skipCount` values in the receiver.
+///
+/// Returns the receiver after skipping the first `skipCount` values. If
+/// `skipCount` is greater than the number of values in the stream, an empty
+/// stream is returned.
 - (instancetype)skip:(NSUInteger)skipCount;
 
-// Returns a stream of the first `count` values in the receiver. If `count` is
-// greater than or equal to the number of values in the stream, a stream
-// equivalent to the receiver is returned.
+/// Returns a stream of the first `count` values in the receiver. If `count` is
+/// greater than or equal to the number of values in the stream, a stream
+/// equivalent to the receiver is returned.
 - (instancetype)take:(NSUInteger)count;
 
-// Zips the values in the given streams to create RACTuples.
-//
-// The first value of each stream will be combined, then the second value, and
-// so forth, until at least one of the streams is exhausted.
-//
-// streams - The streams to combine. These must all be instances of the same
-//           concrete class implementing the protocol. If this collection is
-//           empty, the returned stream will be empty.
-//
-// Returns a new stream containing RACTuples of the zipped values from the
-// streams.
+/// Zips the values in the given streams to create RACTuples.
+///
+/// The first value of each stream will be combined, then the second value, and
+/// so forth, until at least one of the streams is exhausted.
+///
+/// streams - The streams to combine. These must all be instances of the same
+///           concrete class implementing the protocol. If this collection is
+///           empty, the returned stream will be empty.
+///
+/// Returns a new stream containing RACTuples of the zipped values from the
+/// streams.
 + (instancetype)zip:(id<NSFastEnumeration>)streams;
 
-// Zips streams using +zip:, then reduces the resulting tuples into a single
-// value using -reduceEach:
-//
-// streams     - The streams to combine. These must all be instances of the
-//               same concrete class implementing the protocol. If this
-//               collection is empty, the returned stream will be empty.
-// reduceBlock - The block which reduces the values from all the streams
-//               into one value. It must take as many arguments as the
-//               number of streams given. Each argument will be an object
-//               argument. The return value must be an object. This argument
-//               must not be nil.
-//
-// Example:
-//
-//   [RACStream zip:@[ stringSignal, intSignal ] reduce:^(NSString *string, NSNumber *number) {
-//       return [NSString stringWithFormat:@"%@: %@", string, number];
-//   }];
-//
-// Returns a new stream containing the results from each invocation of
-// `reduceBlock`.
+/// Zips streams using +zip:, then reduces the resulting tuples into a single
+/// value using -reduceEach:
+///
+/// streams     - The streams to combine. These must all be instances of the
+///               same concrete class implementing the protocol. If this
+///               collection is empty, the returned stream will be empty.
+/// reduceBlock - The block which reduces the values from all the streams
+///               into one value. It must take as many arguments as the
+///               number of streams given. Each argument will be an object
+///               argument. The return value must be an object. This argument
+///               must not be nil.
+///
+/// Example:
+///
+///   [RACStream zip:@[ stringSignal, intSignal ] reduce:^(NSString *string, NSNumber *number) {
+///       return [NSString stringWithFormat:@"%@: %@", string, number];
+///   }];
+///
+/// Returns a new stream containing the results from each invocation of
+/// `reduceBlock`.
 + (instancetype)zip:(id<NSFastEnumeration>)streams reduce:(id (^)())reduceBlock;
 
-// Returns a stream obtained by concatenating `streams` in order.
+/// Returns a stream obtained by concatenating `streams` in order.
 + (instancetype)concat:(id<NSFastEnumeration>)streams;
 
-// Combines values in the receiver from left to right using the given block.
-//
-// The algorithm proceeds as follows:
-//
-//  1. `startingValue` is passed into the block as the `running` value, and the
-//  first element of the receiver is passed into the block as the `next` value.
-//  2. The result of the invocation is added to the returned stream.
-//  3. The result of the invocation (`running`) and the next element of the
-//  receiver (`next`) is passed into `block`.
-//  4. Steps 2 and 3 are repeated until all values have been processed.
-//
-// startingValue - The value to be combined with the first element of the
-//                 receiver. This value may be `nil`.
-// block         - A block that describes how to combine values of the
-//                 receiver. If the receiver is empty, this block will never be
-//                 invoked.
-//
-// Examples
-//
-//      RACSequence *numbers = @[ @1, @2, @3, @4 ].rac_sequence;
-//
-//      // Contains 1, 3, 6, 10
-//      RACSequence *sums = [numbers scanWithStart:@0 reduce:^(NSNumber *sum, NSNumber *next) {
-//          return @(sum.integerValue + next.integerValue);
-//      }];
-//
-// Returns a new stream that consists of each application of `block`. If the
-// receiver is empty, an empty stream is returned.
+/// Combines values in the receiver from left to right using the given block.
+///
+/// The algorithm proceeds as follows:
+///
+///  1. `startingValue` is passed into the block as the `running` value, and the
+///  first element of the receiver is passed into the block as the `next` value.
+///  2. The result of the invocation is added to the returned stream.
+///  3. The result of the invocation (`running`) and the next element of the
+///  receiver (`next`) is passed into `block`.
+///  4. Steps 2 and 3 are repeated until all values have been processed.
+///
+/// startingValue - The value to be combined with the first element of the
+///                 receiver. This value may be `nil`.
+/// block         - A block that describes how to combine values of the
+///                 receiver. If the receiver is empty, this block will never be
+///                 invoked.
+///
+/// Examples
+///
+///      RACSequence *numbers = @[ @1, @2, @3, @4 ].rac_sequence;
+///
+///      // Contains 1, 3, 6, 10
+///      RACSequence *sums = [numbers scanWithStart:@0 reduce:^(NSNumber *sum, NSNumber *next) {
+///          return @(sum.integerValue + next.integerValue);
+///      }];
+///
+/// Returns a new stream that consists of each application of `block`. If the
+/// receiver is empty, an empty stream is returned.
 - (instancetype)scanWithStart:(id)startingValue reduce:(id (^)(id running, id next))block;
 
-// Combines each previous and current value into one object.
-//
-// This method is similar to -scanWithStart:reduce:, but only ever operates on
-// the previous and current values (instead of the whole stream), and does not
-// pass the return value of `reduceBlock` into the next invocation of it.
-//
-// start       - The value passed into `reduceBlock` as `previous` for the
-//               first value.
-// reduceBlock - The block that combines the previous value and the current
-//               value to create the reduced value. Cannot be nil.
-//
-// Examples
-//
-//      RACSequence *numbers = @[ @1, @2, @3, @4 ].rac_sequence;
-//
-//      // Contains 1, 3, 5, 7
-//      RACSequence *sums = [numbers combinePreviousWithStart:@0 reduce:^(NSNumber *previous, NSNumber *next) {
-//          return @(previous.integerValue + next.integerValue);
-//      }];
-//
-// Returns a new stream consisting of the return values from each application of
-// `reduceBlock`.
+/// Combines each previous and current value into one object.
+///
+/// This method is similar to -scanWithStart:reduce:, but only ever operates on
+/// the previous and current values (instead of the whole stream), and does not
+/// pass the return value of `reduceBlock` into the next invocation of it.
+///
+/// start       - The value passed into `reduceBlock` as `previous` for the
+///               first value.
+/// reduceBlock - The block that combines the previous value and the current
+///               value to create the reduced value. Cannot be nil.
+///
+/// Examples
+///
+///      RACSequence *numbers = @[ @1, @2, @3, @4 ].rac_sequence;
+///
+///      // Contains 1, 3, 5, 7
+///      RACSequence *sums = [numbers combinePreviousWithStart:@0 reduce:^(NSNumber *previous, NSNumber *next) {
+///          return @(previous.integerValue + next.integerValue);
+///      }];
+///
+/// Returns a new stream consisting of the return values from each application of
+/// `reduceBlock`.
 - (instancetype)combinePreviousWithStart:(id)start reduce:(id (^)(id previous, id current))reduceBlock;
 
-// Takes values until the given block returns `YES`.
-//
-// Returns a stream of the initial values in the receiver that fail `predicate`.
-// If `predicate` never returns `YES`, a stream equivalent to the receiver is
-// returned.
+/// Takes values until the given block returns `YES`.
+///
+/// Returns a stream of the initial values in the receiver that fail `predicate`.
+/// If `predicate` never returns `YES`, a stream equivalent to the receiver is
+/// returned.
 - (instancetype)takeUntilBlock:(BOOL (^)(id x))predicate;
 
-// Takes values until the given block returns `NO`.
-//
-// Returns a stream of the initial values in the receiver that pass `predicate`.
-// If `predicate` never returns `NO`, a stream equivalent to the receiver is
-// returned.
+/// Takes values until the given block returns `NO`.
+///
+/// Returns a stream of the initial values in the receiver that pass `predicate`.
+/// If `predicate` never returns `NO`, a stream equivalent to the receiver is
+/// returned.
 - (instancetype)takeWhileBlock:(BOOL (^)(id x))predicate;
 
-// Skips values until the given block returns `YES`.
-//
-// Returns a stream containing the values of the receiver that follow any
-// initial values failing `predicate`. If `predicate` never returns `YES`,
-// an empty stream is returned.
+/// Skips values until the given block returns `YES`.
+///
+/// Returns a stream containing the values of the receiver that follow any
+/// initial values failing `predicate`. If `predicate` never returns `YES`,
+/// an empty stream is returned.
 - (instancetype)skipUntilBlock:(BOOL (^)(id x))predicate;
 
-// Skips values until the given block returns `NO`.
-//
-// Returns a stream containing the values of the receiver that follow any
-// initial values passing `predicate`. If `predicate` never returns `NO`, an
-// empty stream is returned.
+/// Skips values until the given block returns `NO`.
+///
+/// Returns a stream containing the values of the receiver that follow any
+/// initial values passing `predicate`. If `predicate` never returns `NO`, an
+/// empty stream is returned.
 - (instancetype)skipWhileBlock:(BOOL (^)(id x))predicate;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStringSequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStringSequence.h
@@ -8,11 +8,11 @@
 
 #import "RACSequence.h"
 
-// Private class that adapts a string to the RACSequence interface.
+/// Private class that adapts a string to the RACSequence interface.
 @interface RACStringSequence : RACSequence
 
-// Returns a sequence for enumerating over the given string, starting from the
-// given character offset. The string will be copied to prevent mutation.
+/// Returns a sequence for enumerating over the given string, starting from the
+/// given character offset. The string will be copied to prevent mutation.
 + (RACSequence *)sequenceWithString:(NSString *)string offset:(NSUInteger)offset;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubject.h
@@ -9,14 +9,14 @@
 #import "RACSignal.h"
 #import "RACSubscriber.h"
 
-// A subject can be thought of as a signal that you can manually control by
-// sending next, completed, and error.
-//
-// They're most helpful in bridging the non-RAC world to RAC, since they let you
-// manually control the sending of events.
+/// A subject can be thought of as a signal that you can manually control by
+/// sending next, completed, and error.
+///
+/// They're most helpful in bridging the non-RAC world to RAC, since they let you
+/// manually control the sending of events.
 @interface RACSubject : RACSignal <RACSubscriber>
 
-// Returns a new subject.
+/// Returns a new subject.
 + (instancetype)subject;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber+Private.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber+Private.h
@@ -8,10 +8,10 @@
 
 #import "RACSubscriber.h"
 
-// A simple block-based subscriber.
+/// A simple block-based subscriber.
 @interface RACSubscriber : NSObject <RACSubscriber>
 
-// Creates a new subscriber with the given blocks.
+/// Creates a new subscriber with the given blocks.
 + (instancetype)subscriberWithNext:(void (^)(id x))next error:(void (^)(NSError *error))error completed:(void (^)(void))completed;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.h
@@ -10,42 +10,42 @@
 
 @class RACDisposable;
 
-// Represents any object which can directly receive values from a RACSignal.
-//
-// You generally shouldn't need to implement this protocol. +[RACSignal
-// createSignal:], RACSignal's subscription methods, or RACSubject should work
-// for most uses.
-//
-// Implementors of this protocol may receive messages and values from multiple
-// threads simultaneously, and so should be thread-safe. Subscribers will also
-// be weakly referenced so implementations must allow that.
+/// Represents any object which can directly receive values from a RACSignal.
+///
+/// You generally shouldn't need to implement this protocol. +[RACSignal
+/// createSignal:], RACSignal's subscription methods, or RACSubject should work
+/// for most uses.
+///
+/// Implementors of this protocol may receive messages and values from multiple
+/// threads simultaneously, and so should be thread-safe. Subscribers will also
+/// be weakly referenced so implementations must allow that.
 @protocol RACSubscriber <NSObject>
 @required
 
-// Send the next value to subscribers.
-//
-// value - The value to send. This can be `nil`.
+/// Send the next value to subscribers.
+///
+/// value - The value to send. This can be `nil`.
 - (void)sendNext:(id)value;
 
-// Send the error to subscribers.
-//
-// error - The error to send. This can be `nil`.
-//
-// This terminates the subscription, and invalidates the subscriber (such that
-// it cannot subscribe to anything else in the future).
+/// Send the error to subscribers.
+///
+/// error - The error to send. This can be `nil`.
+///
+/// This terminates the subscription, and invalidates the subscriber (such that
+/// it cannot subscribe to anything else in the future).
 - (void)sendError:(NSError *)error;
 
-// Send completed to subscribers.
-//
-// This terminates the subscription, and invalidates the subscriber (such that
-// it cannot subscribe to anything else in the future).
+/// Send completed to subscribers.
+///
+/// This terminates the subscription, and invalidates the subscriber (such that
+/// it cannot subscribe to anything else in the future).
 - (void)sendCompleted;
 
-// Sends the subscriber a disposable that represents one of its subscriptions.
-//
-// A subscriber may receive multiple disposables if it gets subscribed to
-// multiple signals; however, any error or completed events must terminate _all_
-// subscriptions.
+/// Sends the subscriber a disposable that represents one of its subscriptions.
+///
+/// A subscriber may receive multiple disposables if it gets subscribed to
+/// multiple signals; however, any error or completed events must terminate _all_
+/// subscriptions.
 - (void)didSubscribeWithDisposable:(RACDisposable *)disposable;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h
@@ -11,35 +11,35 @@
 
 @class RACSignal;
 
-// Assigns a signal to an object property, automatically setting the given key
-// path on every `next`. When the signal completes, the binding is automatically
-// disposed of.
-//
-// There are two different versions of this macro:
-//
-//  - RAC(TARGET, KEYPATH, NILVALUE) will bind the `KEYPATH` of `TARGET` to the
-//    given signal. If the signal ever sends a `nil` value, the property will be
-//    set to `NILVALUE` instead. `NILVALUE` may itself be `nil` for object
-//    properties, but an NSValue should be used for primitive properties, to
-//    avoid an exception if `nil` is sent (which might occur if an intermediate
-//    object is set to `nil`).
-//  - RAC(TARGET, KEYPATH) is the same as the above, but `NILVALUE` defaults to
-//    `nil`.
-//
-// See -[RACSignal setKeyPath:onObject:nilValue:] for more information about the
-// binding's semantics.
-//
-// Examples
-//
-//  RAC(self, objectProperty) = objectSignal;
-//  RAC(self, stringProperty, @"foobar") = stringSignal;
-//  RAC(self, integerProperty, @42) = integerSignal;
+/// Assigns a signal to an object property, automatically setting the given key
+/// path on every `next`. When the signal completes, the binding is automatically
+/// disposed of.
+///
+/// There are two different versions of this macro:
+///
+///  - RAC(TARGET, KEYPATH, NILVALUE) will bind the `KEYPATH` of `TARGET` to the
+///    given signal. If the signal ever sends a `nil` value, the property will be
+///    set to `NILVALUE` instead. `NILVALUE` may itself be `nil` for object
+///    properties, but an NSValue should be used for primitive properties, to
+///    avoid an exception if `nil` is sent (which might occur if an intermediate
+///    object is set to `nil`).
+///  - RAC(TARGET, KEYPATH) is the same as the above, but `NILVALUE` defaults to
+///    `nil`.
+///
+/// See -[RACSignal setKeyPath:onObject:nilValue:] for more information about the
+/// binding's semantics.
+///
+/// Examples
+///
+///  RAC(self, objectProperty) = objectSignal;
+///  RAC(self, stringProperty, @"foobar") = stringSignal;
+///  RAC(self, integerProperty, @42) = integerSignal;
 #define RAC(TARGET, ...) \
     metamacro_if_eq(1, metamacro_argcount(__VA_ARGS__)) \
         (RAC_(TARGET, __VA_ARGS__, nil)) \
         (RAC_(TARGET, __VA_ARGS__))
 
-// Do not use this directly. Use the RAC macro above.
+/// Do not use this directly. Use the RAC macro above.
 #define RAC_(TARGET, KEYPATH, NILVALUE) \
     [[RACSubscriptingAssignmentTrampoline alloc] initWithTarget:(TARGET) nilValue:(NILVALUE)][@keypath(TARGET, KEYPATH)]
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptionScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptionScheduler.h
@@ -8,7 +8,7 @@
 
 #import "RACScheduler.h"
 
-// A private scheduler used only for subscriptions. See the private
-// +[RACScheduler subscriptionScheduler] method for more information.
+/// A private scheduler used only for subscriptions. See the private
+/// +[RACScheduler subscriptionScheduler] method for more information.
 @interface RACSubscriptionScheduler : RACScheduler
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTargetQueueScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTargetQueueScheduler.h
@@ -8,17 +8,17 @@
 
 #import "RACQueueScheduler.h"
 
-// A scheduler that enqueues blocks on a private serial queue, targeting an
-// arbitrary GCD queue.
+/// A scheduler that enqueues blocks on a private serial queue, targeting an
+/// arbitrary GCD queue.
 @interface RACTargetQueueScheduler : RACQueueScheduler
 
-// Initializes the receiver with a serial queue that will target the given
-// `targetQueue`.
-//
-// name        - The name of the scheduler. If nil, a default name will be used.
-// targetQueue - The queue to target. Cannot be NULL.
-//
-// Returns the initialized object.
+/// Initializes the receiver with a serial queue that will target the given
+/// `targetQueue`.
+///
+/// name        - The name of the scheduler. If nil, a default name will be used.
+/// targetQueue - The queue to target. Cannot be NULL.
+///
+/// Returns the initialized object.
 - (id)initWithName:(NSString *)name targetQueue:(dispatch_queue_t)targetQueue;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTestScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTestScheduler.h
@@ -8,35 +8,35 @@
 
 #import "RACScheduler.h"
 
-// A special kind of scheduler that steps through virtualized time.
-//
-// This scheduler class can be used in unit tests to verify asynchronous
-// behaviors without spending significant time waiting.
-//
-// This class can be used from multiple threads, but only one thread can `step`
-// through the enqueued actions at a time. Other threads will wait while the
-// scheduled blocks are being executed.
+/// A special kind of scheduler that steps through virtualized time.
+///
+/// This scheduler class can be used in unit tests to verify asynchronous
+/// behaviors without spending significant time waiting.
+///
+/// This class can be used from multiple threads, but only one thread can `step`
+/// through the enqueued actions at a time. Other threads will wait while the
+/// scheduled blocks are being executed.
 @interface RACTestScheduler : RACScheduler
 
-// Initializes a new test scheduler.
+/// Initializes a new test scheduler.
 - (instancetype)init;
 
-// Executes the next scheduled block, if any.
-//
-// This method will block until the scheduled action has completed.
+/// Executes the next scheduled block, if any.
+///
+/// This method will block until the scheduled action has completed.
 - (void)step;
 
-// Executes up to the next `ticks` scheduled blocks.
-//
-// This method will block until the scheduled actions have completed.
-//
-// ticks - The number of scheduled blocks to execute. If there aren't this many
-//         blocks enqueued, all scheduled blocks are executed.
+/// Executes up to the next `ticks` scheduled blocks.
+///
+/// This method will block until the scheduled actions have completed.
+///
+/// ticks - The number of scheduled blocks to execute. If there aren't this many
+///         blocks enqueued, all scheduled blocks are executed.
 - (void)step:(NSUInteger)ticks;
 
-// Executes all of the scheduled blocks on the receiver.
-//
-// This method will block until the scheduled actions have completed.
+/// Executes all of the scheduled blocks on the receiver.
+///
+/// This method will block until the scheduled actions have completed.
 - (void)stepAll;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTuple.h
@@ -11,56 +11,56 @@
 
 @class RACSequence;
 
-// Creates a new tuple with the given values. At least one value must be given.
-// Values can be nil.
+/// Creates a new tuple with the given values. At least one value must be given.
+/// Values can be nil.
 #define RACTuplePack(...) \
     RACTuplePack_(__VA_ARGS__)
 
-// Declares new object variables and unpacks a RACTuple into them.
-//
-// This macro should be used on the left side of an assignment, with the
-// tuple on the right side. Nothing else should appear on the same line, and the
-// macro should not be the only statement in a conditional or loop body.
-//
-// If the tuple has more values than there are variables listed, the excess
-// values are ignored.
-//
-// If the tuple has fewer values than there are variables listed, the excess
-// variables are initialized to nil.
-//
-// Examples
-//
-//   RACTupleUnpack(NSString *string, NSNumber *num) = [RACTuple tupleWithObjects:@"foo", @5, nil];
-//   NSLog(@"string: %@", string);
-//   NSLog(@"num: %@", num);
-//
-//   /* The above is equivalent to: */
-//   RACTuple *t = [RACTuple tupleWithObjects:@"foo", @5, nil];
-//   NSString *string = t[0];
-//   NSNumber *num = t[1];
-//   NSLog(@"string: %@", string);
-//   NSLog(@"num: %@", num);
+/// Declares new object variables and unpacks a RACTuple into them.
+///
+/// This macro should be used on the left side of an assignment, with the
+/// tuple on the right side. Nothing else should appear on the same line, and the
+/// macro should not be the only statement in a conditional or loop body.
+///
+/// If the tuple has more values than there are variables listed, the excess
+/// values are ignored.
+///
+/// If the tuple has fewer values than there are variables listed, the excess
+/// variables are initialized to nil.
+///
+/// Examples
+///
+///   RACTupleUnpack(NSString *string, NSNumber *num) = [RACTuple tupleWithObjects:@"foo", @5, nil];
+///   NSLog(@"string: %@", string);
+///   NSLog(@"num: %@", num);
+///
+///   /* The above is equivalent to: */
+///   RACTuple *t = [RACTuple tupleWithObjects:@"foo", @5, nil];
+///   NSString *string = t[0];
+///   NSNumber *num = t[1];
+///   NSLog(@"string: %@", string);
+///   NSLog(@"num: %@", num);
 #define RACTupleUnpack(...) \
         RACTupleUnpack_(__VA_ARGS__)
 
-// A sentinel object that represents nils in the tuple.
-//
-// It should never be necessary to create a tuple nil yourself. Just use
-// +tupleNil.
+/// A sentinel object that represents nils in the tuple.
+///
+/// It should never be necessary to create a tuple nil yourself. Just use
+/// +tupleNil.
 @interface RACTupleNil : NSObject <NSCopying, NSCoding>
-// A singleton instance.
+/// A singleton instance.
 + (RACTupleNil *)tupleNil;
 @end
 
 
-// A tuple is an ordered collection of objects. It may contain nils, represented
-// by RACTupleNil.
+/// A tuple is an ordered collection of objects. It may contain nils, represented
+/// by RACTupleNil.
 @interface RACTuple : NSObject <NSCoding, NSCopying, NSFastEnumeration>
 
 @property (nonatomic, readonly) NSUInteger count;
 
-// These properties all return the object at that index or nil if the number of 
-// objects is less than the index.
+/// These properties all return the object at that index or nil if the number of 
+/// objects is less than the index.
 @property (nonatomic, readonly) id first;
 @property (nonatomic, readonly) id second;
 @property (nonatomic, readonly) id third;
@@ -68,50 +68,50 @@
 @property (nonatomic, readonly) id fifth;
 @property (nonatomic, readonly) id last;
 
-// Creates a new tuple out of the array. Does not convert nulls to nils.
+/// Creates a new tuple out of the array. Does not convert nulls to nils.
 + (instancetype)tupleWithObjectsFromArray:(NSArray *)array;
 
-// Creates a new tuple out of the array. If `convert` is YES, it also converts
-// every NSNull to RACTupleNil.
+/// Creates a new tuple out of the array. If `convert` is YES, it also converts
+/// every NSNull to RACTupleNil.
 + (instancetype)tupleWithObjectsFromArray:(NSArray *)array convertNullsToNils:(BOOL)convert;
 
-// Creates a new tuple with the given objects. Use RACTupleNil to represent
-// nils.
+/// Creates a new tuple with the given objects. Use RACTupleNil to represent
+/// nils.
 + (instancetype)tupleWithObjects:(id)object, ... NS_REQUIRES_NIL_TERMINATION;
 
-// Returns the object at `index` or nil if the object is a RACTupleNil. Unlike
-// NSArray and friends, it's perfectly fine to ask for the object at an index
-// past the tuple's count - 1. It will simply return nil.
+/// Returns the object at `index` or nil if the object is a RACTupleNil. Unlike
+/// NSArray and friends, it's perfectly fine to ask for the object at an index
+/// past the tuple's count - 1. It will simply return nil.
 - (id)objectAtIndex:(NSUInteger)index;
 
-// Returns an array of all the objects. RACTupleNils are converted to NSNulls.
+/// Returns an array of all the objects. RACTupleNils are converted to NSNulls.
 - (NSArray *)allObjects;
 
-// Appends `obj` to the receiver.
-//
-// obj - The object to add to the tuple. This argument may be nil.
-//
-// Returns a new tuple.
+/// Appends `obj` to the receiver.
+///
+/// obj - The object to add to the tuple. This argument may be nil.
+///
+/// Returns a new tuple.
 - (instancetype)tupleByAddingObject:(id)obj;
 
 @end
 
 @interface RACTuple (RACSequenceAdditions)
 
-// Returns a sequence of all the objects. RACTupleNils are converted to NSNulls.
+/// Returns a sequence of all the objects. RACTupleNils are converted to NSNulls.
 @property (nonatomic, copy, readonly) RACSequence *rac_sequence;
 
 @end
 
 @interface RACTuple (ObjectSubscripting)
-// Returns the object at that index or nil if the number of objects is less
-// than the index.
+/// Returns the object at that index or nil if the number of objects is less
+/// than the index.
 - (id)objectAtIndexedSubscript:(NSUInteger)idx; 
 @end
 
-// This and everything below is for internal use only.
-//
-// See RACTuplePack() and RACTupleUnpack() instead.
+/// This and everything below is for internal use only.
+///
+/// See RACTuplePack() and RACTupleUnpack() instead.
 #define RACTuplePack_(...) \
     ([RACTuple tupleWithObjectsFromArray:@[ metamacro_foreach(RACTuplePack_object_or_ractuplenil,, __VA_ARGS__) ]])
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTupleSequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTupleSequence.h
@@ -8,11 +8,11 @@
 
 #import "RACSequence.h"
 
-// Private class that adapts a RACTuple to the RACSequence interface.
+/// Private class that adapts a RACTuple to the RACSequence interface.
 @interface RACTupleSequence : RACSequence
 
-// Returns a sequence for enumerating over the given backing array (from
-// a RACTuple), starting from the given offset.
+/// Returns a sequence for enumerating over the given backing array (from
+/// a RACTuple), starting from the given offset.
 + (instancetype)sequenceWithTupleBackingArray:(NSArray *)backingArray offset:(NSUInteger)offset;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACUnarySequence.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACUnarySequence.h
@@ -8,6 +8,6 @@
 
 #import "RACSequence.h"
 
-// Private class representing a sequence of exactly one value.
+/// Private class representing a sequence of exactly one value.
 @interface RACUnarySequence : RACSequence
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACUnit.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACUnit.h
@@ -9,12 +9,12 @@
 #import <Foundation/Foundation.h>
 
 
-// A unit represents an empty value.
-//
-// It should never be necessary to create a unit yourself. Just use +defaultUnit.
+/// A unit represents an empty value.
+///
+/// It should never be necessary to create a unit yourself. Just use +defaultUnit.
 @interface RACUnit : NSObject
 
-// A singleton instance.
+/// A singleton instance.
 + (RACUnit *)defaultUnit;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIActionSheet+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIActionSheet+RACSignalSupport.h
@@ -13,20 +13,20 @@
 
 @interface UIActionSheet (RACSignalSupport)
 
-// A delegate proxy which will be set as the receiver's delegate when any of the
-// methods in this category are used.
+/// A delegate proxy which will be set as the receiver's delegate when any of the
+/// methods in this category are used.
 @property (nonatomic, strong, readonly) RACDelegateProxy *rac_delegateProxy;
 
-// Creates a signal for button clicks on the receiver.
-//
-// When this method is invoked, the `rac_delegateProxy` will become the
-// receiver's delegate. Any previous delegate will become the -[RACDelegateProxy
-// rac_proxiedDelegate], so that it receives any messages that the proxy doesn't
-// know how to handle. Setting the receiver's `delegate` afterward is
-// considered undefined behavior.
-//
-// Returns a signal which will send the index of the specific button clicked.
-// The signal will complete when the receiver is deallocated.
+/// Creates a signal for button clicks on the receiver.
+///
+/// When this method is invoked, the `rac_delegateProxy` will become the
+/// receiver's delegate. Any previous delegate will become the -[RACDelegateProxy
+/// rac_proxiedDelegate], so that it receives any messages that the proxy doesn't
+/// know how to handle. Setting the receiver's `delegate` afterward is
+/// considered undefined behavior.
+///
+/// Returns a signal which will send the index of the specific button clicked.
+/// The signal will complete when the receiver is deallocated.
 - (RACSignal *)rac_buttonClickedSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIAlertView+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIAlertView+RACSignalSupport.h
@@ -13,20 +13,20 @@
 
 @interface UIAlertView (RACSignalSupport)
 
-// A delegate proxy which will be set as the receiver's delegate when any of the
-// methods in this category are used.
+/// A delegate proxy which will be set as the receiver's delegate when any of the
+/// methods in this category are used.
 @property (nonatomic, strong, readonly) RACDelegateProxy *rac_delegateProxy;
 
-// Creates a signal for button clicks on the receiver.
-//
-// When this method is invoked, the `rac_delegateProxy` will become the
-// receiver's delegate. Any previous delegate will become the -[RACDelegateProxy
-// rac_proxiedDelegate], so that it receives any messages that the proxy doesn't
-// know how to handle. Setting the receiver's `delegate` afterward is considered
-// undefined behavior.
-//
-// Returns a signal which will send the index of the specific button clicked.
-// The signal will complete itself when the receiver is deallocated.
+/// Creates a signal for button clicks on the receiver.
+///
+/// When this method is invoked, the `rac_delegateProxy` will become the
+/// receiver's delegate. Any previous delegate will become the -[RACDelegateProxy
+/// rac_proxiedDelegate], so that it receives any messages that the proxy doesn't
+/// know how to handle. Setting the receiver's `delegate` afterward is considered
+/// undefined behavior.
+///
+/// Returns a signal which will send the index of the specific button clicked.
+/// The signal will complete itself when the receiver is deallocated.
 - (RACSignal *)rac_buttonClickedSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h
@@ -12,11 +12,11 @@
 
 @interface UIBarButtonItem (RACCommandSupport)
 
-// Sets the control's command. When the control is clicked, the command is
-// executed with the sender of the event. The control's enabledness is bound
-// to the command's `canExecute`.
-//
-// Note: this will reset the control's target and action.
+/// Sets the control's command. When the control is clicked, the command is
+/// executed with the sender of the event. The control's enabledness is bound
+/// to the command's `canExecute`.
+///
+/// Note: this will reset the control's target and action.
 @property (nonatomic, strong) RACCommand *rac_command;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIButton+RACCommandSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIButton+RACCommandSupport.h
@@ -12,9 +12,9 @@
 
 @interface UIButton (RACCommandSupport)
 
-// Sets the button's command. When the button is clicked, the command is
-// executed with the sender of the event. The button's enabledness is bound
-// to the command's `canExecute`.
+/// Sets the button's command. When the button is clicked, the command is
+/// executed with the sender of the event. The button's enabledness is bound
+/// to the command's `canExecute`.
 @property (nonatomic, strong) RACCommand *rac_command;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIControl+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIControl+RACSignalSupport.h
@@ -12,8 +12,8 @@
 
 @interface UIControl (RACSignalSupport)
 
-// Creates and returns a signal that sends the sender of the control event
-// whenever one of the control events is triggered.
+/// Creates and returns a signal that sends the sender of the control event
+/// whenever one of the control events is triggered.
 - (RACSignal *)rac_signalForControlEvents:(UIControlEvents)controlEvents;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIControl+RACSignalSupportPrivate.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIControl+RACSignalSupportPrivate.h
@@ -12,18 +12,18 @@
 
 @interface UIControl (RACSignalSupportPrivate)
 
-// Adds a RACChannel-based interface to the receiver for the given
-// UIControlEvents and exposes it.
-//
-// controlEvents - A mask of UIControlEvents on which to send new values.
-// key           - The key whose value should be read and set when a control
-//                 event fires and when a value is sent to the
-//                 RACChannelTerminal respectively.
-// nilValue      - The value to be assigned to the key when `nil` is sent to the
-//                 RACChannelTerminal.
-//
-// Returns a RACChannelTerminal which will send future values from the receiver,
-// and update the receiver when values are sent to the terminal.
+/// Adds a RACChannel-based interface to the receiver for the given
+/// UIControlEvents and exposes it.
+///
+/// controlEvents - A mask of UIControlEvents on which to send new values.
+/// key           - The key whose value should be read and set when a control
+///                 event fires and when a value is sent to the
+///                 RACChannelTerminal respectively.
+/// nilValue      - The value to be assigned to the key when `nil` is sent to the
+///                 RACChannelTerminal.
+///
+/// Returns a RACChannelTerminal which will send future values from the receiver,
+/// and update the receiver when values are sent to the terminal.
 - (RACChannelTerminal *)rac_channelForControlEvents:(UIControlEvents)controlEvents key:(NSString *)key nilValue:(id)nilValue;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIDatePicker+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIDatePicker+RACSignalSupport.h
@@ -12,13 +12,13 @@
 
 @interface UIDatePicker (RACSignalSupport)
 
-// Creates a new RACChannel-based binding to the receiver.
-//
-// nilValue - The date to set when the terminal receives `nil`.
-//
-// Returns a RACChannelTerminal that sends the receiver's date whenever the
-// UIControlEventValueChanged control event is fired, and sets the date to the
-// values it receives.
+/// Creates a new RACChannel-based binding to the receiver.
+///
+/// nilValue - The date to set when the terminal receives `nil`.
+///
+/// Returns a RACChannelTerminal that sends the receiver's date whenever the
+/// UIControlEventValueChanged control event is fired, and sets the date to the
+/// values it receives.
 - (RACChannelTerminal *)rac_newDateChannelWithNilValue:(NSDate *)nilValue;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h
@@ -12,7 +12,7 @@
 
 @interface UIGestureRecognizer (RACSignalSupport)
 
-// Returns a signal that sends the receiver when its gesture occurs.
+/// Returns a signal that sends the receiver when its gesture occurs.
 - (RACSignal *)rac_gestureSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UISegmentedControl+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UISegmentedControl+RACSignalSupport.h
@@ -12,13 +12,13 @@
 
 @interface UISegmentedControl (RACSignalSupport)
 
-// Creates a new RACChannel-based binding to the receiver.
-//
-// nilValue - The segment to select when the terminal receives `nil`.
-//
-// Returns a RACChannelTerminal that sends the receiver's currently selected
-// segment's index whenever the UIControlEventValueChanged control event is
-// fired, and sets the selected segment index to the values it receives.
+/// Creates a new RACChannel-based binding to the receiver.
+///
+/// nilValue - The segment to select when the terminal receives `nil`.
+///
+/// Returns a RACChannelTerminal that sends the receiver's currently selected
+/// segment's index whenever the UIControlEventValueChanged control event is
+/// fired, and sets the selected segment index to the values it receives.
 - (RACChannelTerminal *)rac_newSelectedSegmentIndexChannelWithNilValue:(NSNumber *)nilValue;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UISlider+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UISlider+RACSignalSupport.h
@@ -12,13 +12,13 @@
 
 @interface UISlider (RACSignalSupport)
 
-// Creates a new RACChannel-based binding to the receiver.
-//
-// nilValue - The value to set when the terminal receives `nil`.
-//
-// Returns a RACChannelTerminal that sends the receiver's value whenever the
-// UIControlEventValueChanged control event is fired, and sets the value to the
-// values it receives.
+/// Creates a new RACChannel-based binding to the receiver.
+///
+/// nilValue - The value to set when the terminal receives `nil`.
+///
+/// Returns a RACChannelTerminal that sends the receiver's value whenever the
+/// UIControlEventValueChanged control event is fired, and sets the value to the
+/// values it receives.
 - (RACChannelTerminal *)rac_newValueChannelWithNilValue:(NSNumber *)nilValue;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UIStepper+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIStepper+RACSignalSupport.h
@@ -12,13 +12,13 @@
 
 @interface UIStepper (RACSignalSupport)
 
-// Creates a new RACChannel-based binding to the receiver.
-//
-// nilValue - The value to set when the terminal receives `nil`.
-//
-// Returns a RACChannelTerminal that sends the receiver's value whenever the
-// UIControlEventValueChanged control event is fired, and sets the value to the
-// values it receives.
+/// Creates a new RACChannel-based binding to the receiver.
+///
+/// nilValue - The value to set when the terminal receives `nil`.
+///
+/// Returns a RACChannelTerminal that sends the receiver's value whenever the
+/// UIControlEventValueChanged control event is fired, and sets the value to the
+/// values it receives.
 - (RACChannelTerminal *)rac_newValueChannelWithNilValue:(NSNumber *)nilValue;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UISwitch+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UISwitch+RACSignalSupport.h
@@ -12,11 +12,11 @@
 
 @interface UISwitch (RACSignalSupport)
 
-// Creates a new RACChannel-based binding to the receiver.
-//
-// Returns a RACChannelTerminal that sends whether the receiver is on whenever
-// the UIControlEventValueChanged control event is fired, and sets it on or off
-// when it receives @YES or @NO respectively.
+/// Creates a new RACChannel-based binding to the receiver.
+///
+/// Returns a RACChannelTerminal that sends whether the receiver is on whenever
+/// the UIControlEventValueChanged control event is fired, and sets it on or off
+/// when it receives @YES or @NO respectively.
 - (RACChannelTerminal *)rac_newOnChannel;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UITableViewCell+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITableViewCell+RACSignalSupport.h
@@ -12,17 +12,17 @@
 
 @interface UITableViewCell (RACSignalSupport)
 
-// A signal which will send a RACUnit whenever -prepareForReuse is invoked upon
-// the receiver.
-//
-// Examples
-//
-//  [[[self.cancelButton
-//     rac_signalForControlEvents:UIControlEventTouchUpInside]
-//     takeUntil:self.rac_prepareForReuseSignal]
-//     subscribeNext:^(UIButton *x) {
-//         // do other things
-//     }];
+/// A signal which will send a RACUnit whenever -prepareForReuse is invoked upon
+/// the receiver.
+///
+/// Examples
+///
+///  [[[self.cancelButton
+///     rac_signalForControlEvents:UIControlEventTouchUpInside]
+///     takeUntil:self.rac_prepareForReuseSignal]
+///     subscribeNext:^(UIButton *x) {
+///         // do other things
+///     }];
 @property (nonatomic, strong, readonly) RACSignal *rac_prepareForReuseSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextField+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextField+RACSignalSupport.h
@@ -12,16 +12,16 @@
 
 @interface UITextField (RACSignalSupport)
 
-// Creates and returns a signal for the text of the field. It always starts with
-// the current text. The signal sends next when the UIControlEventEditingChanged
-// control event is fired on the control.
+/// Creates and returns a signal for the text of the field. It always starts with
+/// the current text. The signal sends next when the UIControlEventEditingChanged
+/// control event is fired on the control.
 - (RACSignal *)rac_textSignal;
 
-// Creates a new RACChannel-based binding to the receiver.
-//
-// Returns a RACChannelTerminal that sends the receiver's text whenever the
-// UIControlEventEditingChanged control event is fired, and sets the text to the
-// values it receives.
+/// Creates a new RACChannel-based binding to the receiver.
+///
+/// Returns a RACChannelTerminal that sends the receiver's text whenever the
+/// UIControlEventEditingChanged control event is fired, and sets the text to the
+/// values it receives.
 - (RACChannelTerminal *)rac_newTextChannel;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.h
@@ -13,21 +13,21 @@
 
 @interface UITextView (RACSignalSupport)
 
-// A delegate proxy which will be set as the receiver's delegate when any of the
-// methods in this category are used.
+/// A delegate proxy which will be set as the receiver's delegate when any of the
+/// methods in this category are used.
 @property (nonatomic, strong, readonly) RACDelegateProxy *rac_delegateProxy;
 
-// Creates a signal for the text of the receiver.
-//
-// When this method is invoked, the `rac_delegateProxy` will become the
-// receiver's delegate. Any previous delegate will become the -[RACDelegateProxy
-// rac_proxiedDelegate], so that it receives any messages that the proxy doesn't
-// know how to handle. Setting the receiver's `delegate` afterward is
-// considered undefined behavior.
-//
-// Returns a signal which will send the current text upon subscription, then
-// again whenever the receiver's text is changed. The signal will complete when
-// the receiver is deallocated.
+/// Creates a signal for the text of the receiver.
+///
+/// When this method is invoked, the `rac_delegateProxy` will become the
+/// receiver's delegate. Any previous delegate will become the -[RACDelegateProxy
+/// rac_proxiedDelegate], so that it receives any messages that the proxy doesn't
+/// know how to handle. Setting the receiver's `delegate` afterward is
+/// considered undefined behavior.
+///
+/// Returns a signal which will send the current text upon subscription, then
+/// again whenever the receiver's text is changed. The signal will complete when
+/// the receiver is deallocated.
 - (RACSignal *)rac_textSignal;
 
 @end


### PR DESCRIPTION
Closes #804 

This let's Xcode recognize the header documentation for classes, methods, etc.
