### PR TITLE
Fix RACObserve with protocols.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACPropertySubscribing.h
@@ -47,7 +47,7 @@
 /// subscription, then sends the new value every time it changes, and sends
 /// completed if self or observer is deallocated.
 #define RACObserve(TARGET, KEYPATH) \
-    [(TARGET) rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]
+    [(id)(TARGET) rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]
 
 @class RACDisposable;
 @class RACSignal;


### PR DESCRIPTION
I don't think the downside of this is too bad, and it allows me to use RACObserve with non-object properties defined in protocols.

``` objective-c
@protocol Foo
@property (nonatomic, readonly) NSUInteger bar;
@end


- (void)baz:(id<Foo> foo) {

    // Won't compile, because [foo rac_valuesForKeyPath:observer:] is not found:
    RACObserve(foo, bar)

    // Won't compile, because foo.bar can't be cast to id:
    RACObserve((id)foo, bar)

    // Won't compile because ((id)foo).bar can't be found:
    RACObserve(((id)foo), bar)

    // This is fine!
    [(id)foo rac_valuesForKeyPath:@keypath(foo, bar) observer:self]

}
```
