### PR TITLE
Give -initially: top-down composition

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -2881,6 +2881,20 @@ describe(@"-initially:", ^{
 		[signal subscribe:[RACSubscriber new]];
 		expect(initiallyInvokedCount).to.equal(2);
 	});
+
+	it(@"should compose top-down", ^{
+		__block NSMutableArray* scratch = [NSMutableArray array];
+		RACSignal *doubleDown = [[subject
+			initially:^{
+				[scratch addObject:@1];
+			}]
+			initially:^{
+				[scratch addObject:@2];
+			}];
+
+		[doubleDown subscribe:[RACSubscriber new]];
+		expect(scratch).to.equal((@[ @1, @2 ]));
+	});
 });
 
 describe(@"-finally:", ^{


### PR DESCRIPTION
This might be a case against `-initially:`, but here's a fix for a problem I noticed.

The problem is that `-initially:` composes bottom-up, following subscription, but that can present unexpected results. Especially when compared to `-finally:` and other side-effect introducing operators.

``` objc
[[[[[[RACSignal
    empty]
    initially:^{
        NSLog(@"A");
    }]
    initially:^{
        NSLog(@"B");
    }]
    finally:^{
        NSLog(@"Y");
    }]
    finally:^{
        NSLog(@"Z");
    }]
    subscribeCompleted:^{}];
```

Produces B A Y Z.

For some real code, I came across this problem when I wanted to do this:

``` objc
[[self
    rac_signalForSelector:@selector(prepareForSegue:sender:)]
    initially:^{
        [self performSegueWithIdentifier:@"SegueIdentifier" sender:self];
    }];
```

In this case `-performSegueWithIdentifier:` gets called prior to subscribing to the signal returned from `-rac_signalForSelector:`, and consequentially, the call to `-prepareForSegue:` happens before the subscriber chain is setup to observe it.

I switched to `+createSignal:`, to control the order of side effects, but I'm thinking `-initially:` should either be changed, or ~~removed~~ deprecated.
