### PR TITLE
Generalized -distinctUntilChanged to RACStream

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -307,10 +307,6 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// This can be used to effectively turn a hot signal into a cold signal.
 + (RACSignal *)defer:(RACSignal * (^)(void))block;
 
-/// Send only `next`s for which -isEqual: returns NO when compared to the
-/// previous `next`.
-- (RACSignal *)distinctUntilChanged;
-
 /// Every time the receiver sends a new RACSignal, subscribes and sends `next`s and
 /// `error`s only for that signal.
 ///

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -862,21 +862,6 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 	}] setNameWithFormat:@"+defer:"];
 }
 
-- (RACSignal *)distinctUntilChanged {
-	return [[self bind:^{
-		__block id lastValue = nil;
-		__block BOOL initial = YES;
-
-		return ^(id x, BOOL *stop) {
-			if (!initial && (lastValue == x || [x isEqual:lastValue])) return [RACSignal empty];
-
-			initial = NO;
-			lastValue = x;
-			return [RACSignal return:x];
-		};
-	}] setNameWithFormat:@"[%@] -distinctUntilChanged", self.name];
-}
-
 - (NSArray *)toArray {
 	return [[[self collect] first] copy];
 }

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
@@ -305,6 +305,10 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 /// empty stream is returned.
 - (instancetype)skipWhileBlock:(BOOL (^)(id x))predicate;
 
+/// Returns a stream of values for which -isEqual: returns NO when compared to the
+/// previous value.
+- (instancetype)distinctUntilChanged;
+
 @end
 
 @interface RACStream (Deprecated)

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
@@ -314,6 +314,23 @@
 	}] setNameWithFormat:@"[%@] -skipUntilBlock:", self.name];
 }
 
+- (instancetype)distinctUntilChanged {
+	Class class = self.class;
+
+	return [[self bind:^{
+		__block id lastValue = nil;
+		__block BOOL initial = YES;
+
+		return ^(id x, BOOL *stop) {
+			if (!initial && (lastValue == x || [x isEqual:lastValue])) return [class empty];
+
+			initial = NO;
+			lastValue = x;
+			return [class return:x];
+		};
+	}] setNameWithFormat:@"[%@] -distinctUntilChanged", self.name];
+}
+
 @end
 
 @implementation RACStream (Deprecated)


### PR DESCRIPTION
I realized this morning that `-distinctUntilChanged` doesn't actually use any kit which is specific to signals, as opposed to other streams. Seems to make sense to just move it to `RACStream`. Thoughts?
