### PR TITLE
Minor guidelines corrections

### DIFF
--- a/Documentation/DesignGuidelines.md
+++ b/Documentation/DesignGuidelines.md
@@ -623,7 +623,7 @@ concurrently perform their work.
 
 Callers always have the ability to subscribe or deliver events on a specific
 [RACScheduler][], and RAC offers powerful ways to [parallelize
-work](#parallelizing-independent-work) without making operators unnecessarily
+work][Parallelizing Independent Work] without making operators unnecessarily
 complex.
 
 ### Cancel work and clean up all resources in a disposable
@@ -748,3 +748,4 @@ By contrast, this version will avoid a stack overflow:
 [RACStream]: ../ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
 [RACSubscriber]: ../ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.h
 [Subjects]: FrameworkOverview.md#subjects
+[Parallelizing Independent Work]: ../README.md#parallelizing-independent-work


### PR DESCRIPTION
Just a couple minor fixes to `DesignGuidelines.md`.

[[Rendered](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/guidelines-fixes/Documentation/DesignGuidelines.md)]
