### PR TITLE
Fix ownership race condition when swapping disposables

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.m
@@ -75,7 +75,7 @@
 	// Only retain the new disposable if it's not `self`.
 	// Take ownership before attempting the swap so that a subsequent swap
 	// receives an owned reference.
-	void *newDisposablePtr = (void *)(newDisposable != nil ? CFRetain((__bridge CFTypeRef)newDisposable) : (__bridge CFTypeRef)self);
+	void *newDisposablePtr = (void *)(newDisposable != nil ? CFBridgingRetain(newDisposable) : (__bridge CFTypeRef)self);
 
 	void *existingDisposablePtr;
 	// Keep trying while we're not disposed.


### PR DESCRIPTION
In `RACSerialDisposable` the compare and swap loop only took ownership after the swap was successful. This leaves an opportunity for another thread to come in and perform a subsequent swap, and `CFBridgingRelease` the value that the first thread swapped in, before the first thread has finished retaining the value.

Instead, retain the disposable before performing the swap, and release it in the event that the swap fails.

This would be extremely hard to test because our tests target is ARC and is inserting retains of the arguments.
