### PR TITLE
Break disposable reference cycle

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
@@ -136,6 +136,8 @@
 			RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
 			[compoundDisposable addDisposable:selfDisposable];
 
+			__weak RACDisposable *weakSelfDisposable = selfDisposable;
+
 			RACDisposable *disposable = [signal subscribeNext:^(id x) {
 				[subscriber sendNext:x];
 			} error:^(NSError *error) {
@@ -143,7 +145,7 @@
 				[subscriber sendError:error];
 			} completed:^{
 				@autoreleasepool {
-					completeSignal(signal, selfDisposable);
+					completeSignal(signal, weakSelfDisposable);
 				}
 			}];
 
@@ -154,13 +156,15 @@
 			RACSerialDisposable *selfDisposable = [[RACSerialDisposable alloc] init];
 			[compoundDisposable addDisposable:selfDisposable];
 
+			__weak RACDisposable *weakSelfDisposable = selfDisposable;
+
 			RACDisposable *bindingDisposable = [self subscribeNext:^(id x) {
 				BOOL stop = NO;
 				id signal = bindingBlock(x, &stop);
 
 				@autoreleasepool {
 					if (signal != nil) addSignal(signal);
-					if (signal == nil || stop) completeSignal(self, selfDisposable);
+					if (signal == nil || stop) completeSignal(self, weakSelfDisposable);
 				}
 			} error:^(NSError *error) {
 				[compoundDisposable dispose];


### PR DESCRIPTION
Fixes #860 

Check that, _I believe_ this fixes #860, fixing an overlooked retain cycle introduced in #830, where serial disposables in `-bind:` are being captured strongly by subscription blocks, and those subscription disposables are being strongly referenced by the serial disposable. Ultimately there's a cycle between a a serial disposable and its subordinate disposable.
