### PR TITLE
Prevent static analyzer false positive

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.m
@@ -93,11 +93,12 @@
 		return (existingDisposablePtr == (__bridge void *)self ? nil : CFBridgingRelease(existingDisposablePtr));
 	}
 
+	// At this point, we've found out that we were already disposed.
+	[newDisposable dispose];
+
 	// Failed to swap, clean up the ownership we took prior to the swap.
 	if (newDisposablePtr != (__bridge void *)self) CFRelease(newDisposablePtr);
 
-	// At this point, we've found out that we were already disposed.
-	[newDisposable dispose];
 	return nil;
 }
 


### PR DESCRIPTION
Follow-up on #859.

This change is to avoid a false positive by the static analyzer, wherein it believes that `newDisposable` is released by the time `-dispose` is called outside of the `while` loop, i.e. when trying to assign a disposable to a serial disposable that has already been disposed.

It appears that ARC bridging + casting to `void *` is what confuses the static analyzer. If `existingDisposablePtr`'s type is changed to `CFTypeRef` and then casted to `void *` for the `OSAtomicCompareAndSwapPtrBarrier` call, then the static analyzer does not complain.
