### PR TITLE
Fix another analyzer false positive in RACSerialDisposable

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSerialDisposable.m
@@ -98,7 +98,7 @@
 		if (existingDisposablePtr == selfPtr) {
 			return nil;
 		} else {
-			return CFBridgingRelease(newDisposablePtr);
+			return CFBridgingRelease(existingDisposablePtr);
 		}
 	}
 


### PR DESCRIPTION
Fixes:

> warning: Potential leak of an object stored into 'newDisposablePtr'

This was caused by using different conditions to determine whether `newDisposable` is retained and released. Although the behavior couldn't be different for one vs. the other, Clang didn't know that.
