### PR TITLE
-shareWhileActive

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -462,15 +462,14 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns the lazily connected, multicasted signal.
 - (RACSignal *)replayLazily;
 
-/// Serializes and deduplicates subscriptions to the receiver, ensuring that
-/// only one subscription is active at a time.
+/// Deduplicates subscriptions to the receiver, and shares results between them,
+/// ensuring that only one subscription is active at a time.
 ///
 /// This is useful to ensure that a signal's side effects are never performed
 /// multiple times _concurrently_. It _does not_ prevent a signal's side effects
 /// from being repeated multiple times serially.
 ///
-/// **This is not the same as the `Serialize` method in Rx.** This operator
-/// corresponds to the `RefCount` method in Rx.
+/// This operator corresponds to the `RefCount` method in Rx.
 ///
 /// Returns a signal that will have at most one subscription to the receiver at
 /// any time. When the returned signal gets its first subscriber, the underlying
@@ -478,7 +477,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// underlying subscription is disposed. Whenever an underlying subscription is
 /// already open, new subscribers to the returned signal will receive all events
 /// sent so far.
-- (RACSignal *)serialize;
+- (RACSignal *)shareWhileActive;
 
 /// Sends an error after `interval` seconds if the source doesn't complete
 /// before then.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -931,9 +931,9 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		setNameWithFormat:@"[%@] -replayLazily", self.name];
 }
 
-- (RACSignal *)serialize {
+- (RACSignal *)shareWhileActive {
 	NSRecursiveLock *lock = [[NSRecursiveLock alloc] init];
-	lock.name = @"com.github.ReactiveCocoa.serialize";
+	lock.name = @"com.github.ReactiveCocoa.shareWhileActive";
 
 	// These should only be used while `lock` is held.
 	__block NSUInteger subscriberCount = 0;
@@ -973,7 +973,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 				}
 			}];
 		}]
-		setNameWithFormat:@"[%@] -serialize", self.name];
+		setNameWithFormat:@"[%@] -shareWhileActive", self.name];
 }
 
 - (RACSignal *)timeout:(NSTimeInterval)interval onScheduler:(RACScheduler *)scheduler {

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -3558,7 +3558,7 @@ describe(@"-replayLazily", ^{
 	});
 });
 
-describe(@"-serialize", ^{
+describe(@"-shareWhileActive", ^{
 	__block NSUInteger totalSubscriptions;
 	__block NSUInteger activeSubscriptions;
 
@@ -3580,7 +3580,7 @@ describe(@"-serialize", ^{
 					activeSubscriptions--;
 				}];
 			}]
-			serialize];
+			shareWhileActive];
 	});
 
 	it(@"should lazily subscribe to the underlying signal", ^{


### PR DESCRIPTION
This behaves like `RefCount` in Rx, _temporarily_ multicasting a signal while there are subscriptions to it, disposing of it when there aren't, and being able to do this any number of times (unlike `-autoconnect`, which is being deprecated in #877).

These commits were cherry-picked out of #874, since that keeps getting delayed/refocused.
