### PR TITLE
Fixed typo in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ RACSignal *fileSignal = [RACSignal startEagerlyWithScheduler:[RACScheduler sched
 
 [[RACSignal
     combineLatest:@[ databaseSignal, fileSignal ]
-    reduce:^id(NSArray *databaseObjects, NSArray *fileContents) {
+    reduce:^ id (NSArray *databaseObjects, NSArray *fileContents) {
         [self finishProcessingDatabaseObjects:databaseObjects fileContents:fileContents];
         return nil;
     }]


### PR DESCRIPTION
Without "id" specified as the return type of the block, the compiler gives an incompatible block pointer type error.
