### PR TITLE
Fix ARC Error

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
@@ -221,21 +221,12 @@ static void RACExceptionHandler (NSException *ex) {
 		if (self == nil) return nil;
 
 		_backtrace = [RACBacktrace backtraceIgnoringFrames:1];
-
-		dispatch_retain(queue);
 		_queue = queue;
 
 		_function = function;
 		_context = context;
 
 		return self;
-	}
-}
-
-- (void)dealloc {
-	if (_queue != NULL) {
-		dispatch_release(_queue);
-		_queue = NULL;
 	}
 }
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.m
@@ -16,17 +16,12 @@
 
 #pragma mark Lifecycle
 
-- (void)dealloc {
-	dispatch_release(_queue);
-}
-
 - (id)initWithName:(NSString *)name queue:(dispatch_queue_t)queue {
 	NSCParameterAssert(queue != NULL);
 
 	self = [super initWithName:name];
 	if (self == nil) return nil;
 
-	dispatch_retain(queue);
 	_queue = queue;
 
 	return self;
@@ -93,8 +88,7 @@
 
 	return [RACDisposable disposableWithBlock:^{
 		dispatch_source_cancel(timer);
-		dispatch_release(timer);
-	}];
+        }];
 }
 
 - (void)performAsCurrentScheduler:(void (^)(void))block {

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACTargetQueueScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACTargetQueueScheduler.m
@@ -29,8 +29,6 @@
 	self = [super initWithName:name queue:queue];
 	if (self == nil) return nil;
 
-	dispatch_release(queue);
-
 	return self;
 }
 


### PR DESCRIPTION
I noticed that you were explicitly retaining/releasing GCD objects. This was causing errors under Objective-C Automatic Reference Counting, which the bulk of the framework requires. I fixed this for you by removing the offending code.
