### PR TITLE
Allow binding a signal other than command.enabled to the control's enabled

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACCommandSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSControl+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class RACCommand;
+@class RACCommand, RACSignal;
 
 @interface NSControl (RACCommandSupport)
 
@@ -18,5 +18,8 @@
 ///
 /// Note: this will reset the control's target and action.
 @property (nonatomic, strong) RACCommand *rac_command;
+
+/// Substitute another signal for the control's `enabled` value binding.
+- (void)rac_rebindEnabled:(RACSignal *)enabledSignal;
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACControlCommandExamples.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACControlCommandExamples.m
@@ -24,6 +24,8 @@ NSString * const RACControlCommandExampleActivateBlock = @"RACControlCommandExam
 
 - (BOOL)isEnabled;
 
+- (void)rac_rebindEnabled:(RACSignal *)enabledSignal;
+
 @end
 
 SharedExampleGroupsBegin(RACControlCommandExamples)
@@ -54,6 +56,19 @@ sharedExamplesFor(RACControlCommandExamples, ^(NSDictionary *data) {
 		expect([control isEnabled]).will.beFalsy();
 		
 		[enabledSubject sendNext:@YES];
+		expect([control isEnabled]).will.beTruthy();
+	});
+	
+	it(@"should accept another signal for binding to enabledness", ^{
+		expect([control isEnabled]).will.beTruthy();
+			   
+		RACSubject * newEnabledSubject = [RACSubject subject];
+		[control rac_rebindEnabled:newEnabledSubject];
+		
+		[newEnabledSubject sendNext:@NO];
+		expect([control isEnabled]).will.beFalsy();
+		
+		[newEnabledSubject sendNext:@YES];
 		expect([control isEnabled]).will.beTruthy();
 	});
 


### PR DESCRIPTION
Using NSControl+RACCommandSupport, it's not currently possible to set up a connection to an object such that it has access to the control's command signal in its initialization while the control's `enabled` is bound to a signal coming from that same object:

```
[aButton setRac_command:
    [[RACCommand alloc] initWithSignalBlock:^RACSignal *(NSButton * _) {
                                    return [RACSignal return:@YES];
}]];

RACSignal * buttonSignal = [[aButton rac_command] executionSignals]; 

MyController * controller = [[MyController alloc] initWithButtonSignal:buttonSignal];

// Does not exist
[aButton <#bind enabled to#>:[controller aSignal]];
```

The alternative

```
// Set up signal as best as possible without button
MyController * controller = [MyController new];

[aButton setRac_command:
    [[RACCommand alloc] initWithEnabled:[controller aSignal]
                            signalBlock:^RACSignal *(NSButton * _) {
                                    return [RACSignal return:@YES];
}]];

[controller setButtonSignal:[[aButton rac_command] executionSignals]];
```

necessitates a potentially awkward (certainly repetitive) re-wiring of the controller's already-created signal in `setButtonSignal:`

I propose adding a single method to `NSControl+RACCommandSupport` to allow the control's `enabled` to be rebound to any signal after the command is set. This pull request implements that solution, and includes a test for the new functionality.

The change is very minor; the existing code binding the control's `enabled` in `setRac_command:` was simply moved to its own method.

If you think it's necessary that the command's `enabled` be involved in the control's status, my alternate proposal is to allow setting a "secondary" signal whose values will be ANDed with `command.enabled`. I have that code in a branch NSControl-mergeEnabledBindingSignals in my fork of RAC and can submit another pull request.
