### PR TITLE
Behavior of -sample: before receiver sends a value

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -531,7 +531,8 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 /// Sends the latest value from the receiver only when `sampler` sends a value.
 /// The returned signal could repeat values if `sampler` fires more often than
-/// the receiver.
+/// the receiver. Values from `sampler` are ignored before the receiver sends
+/// its first value.
 ///
 /// sampler - The signal that controls when the latest value from the receiver
 ///           is sent. Cannot be nil.

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -2810,6 +2810,9 @@ describe(@"-sample:", ^{
 			[values addObject:x];
 		}];
 		
+		[sampleSubject sendNext:RACUnit.defaultUnit];
+		expect(values).to.equal(@[]);
+		
 		[subject sendNext:@1];
 		[subject sendNext:@2];
 		expect(values).to.equal(@[]);


### PR DESCRIPTION
The doc is ambiguous about how `[x sample:y]` behaves if `y` sends a value before `x` does. I wasn't sure if it would send `nil` immediately, defer sending a value until `x` sent a value, or ignore the value from `y` completely. Turns out to be the last one.
