### PR TITLE
Assert that the result of a -flattenMap: block isn't nil

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
@@ -70,10 +70,10 @@
 - (instancetype)flattenMap:(RACStream * (^)(id value))block {
 	return [[self bind:^{
 		return ^(id value, BOOL *stop) {
-			RACSignal *signal = block(value);
-			NSCAssert(signal != nil, @"Expected RACSignal to be returned from -flattenMap:, not %@", signal);
+			id stream = block(value);
+			NSCAssert(stream != nil, @"Expected non-nil stream to be returned from -flattenMap:");
 
-			return signal;
+			return stream;
 		};
 	}] setNameWithFormat:@"[%@] -flattenMap:", self.name];
 }


### PR DESCRIPTION
If it _is_ `nil`, it will prematurely terminate the bind without warning or explanation, which is very confusing.

@dannygreg 
