### PR TITLE
Fix the ReactiveCocoa-Mac target headers

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -3240,7 +3240,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_PREFIX_HEADER = "ReactiveCocoa/ReactiveCocoa-Prefix.pch";
-				PRIVATE_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 			};
@@ -3253,7 +3252,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_PREFIX_HEADER = "ReactiveCocoa/ReactiveCocoa-Prefix.pch";
-				PRIVATE_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 			};
@@ -3266,7 +3264,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_PREFIX_HEADER = "ReactiveCocoa/ReactiveCocoa-Prefix.pch";
-				PRIVATE_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 			};
@@ -3279,7 +3276,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_PREFIX_HEADER = "ReactiveCocoa/ReactiveCocoa-Prefix.pch";
-				PRIVATE_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/ReactiveCocoa;
 			};


### PR DESCRIPTION
Ensure the public headers includes the libextobjc headers, as the Framework
target does Rename the include directory so that you can `#import
"ReactiveCocoa/ReactiveCocoa.h"` whether you’re using the Framework or Static
Archive target
