### PR TITLE
[WIP] Replace channels with "validated bindings"

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -548,6 +548,12 @@
 		D0EE284E164D906B006954A4 /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D0EE284A164D906B006954A4 /* RACSignalSequence.m */; };
 		D0F117C8179F0A95006CE68F /* libReactiveCocoa-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 88F440AB153DAC820097B4C3 /* libReactiveCocoa-iOS.a */; };
 		D0F117CC179F0B97006CE68F /* UITableViewCellRACSupportSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F117CB179F0B97006CE68F /* UITableViewCellRACSupportSpec.m */; };
+		D0F327F2184EA66B00A0C90C /* RACValidatedBinding.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F327F0184EA66B00A0C90C /* RACValidatedBinding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0F327F3184EA66B00A0C90C /* RACValidatedBinding.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F327F0184EA66B00A0C90C /* RACValidatedBinding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0F327F4184EA66B00A0C90C /* RACValidatedBinding.h in Headers */ = {isa = PBXBuildFile; fileRef = D0F327F0184EA66B00A0C90C /* RACValidatedBinding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D0F327F5184EA66B00A0C90C /* RACValidatedBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F327F1184EA66B00A0C90C /* RACValidatedBinding.m */; };
+		D0F327F6184EA66B00A0C90C /* RACValidatedBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F327F1184EA66B00A0C90C /* RACValidatedBinding.m */; };
+		D0F327F7184EA66B00A0C90C /* RACValidatedBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = D0F327F1184EA66B00A0C90C /* RACValidatedBinding.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1008,6 +1014,8 @@
 		D0EE2849164D906B006954A4 /* RACSignalSequence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACSignalSequence.h; sourceTree = "<group>"; };
 		D0EE284A164D906B006954A4 /* RACSignalSequence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACSignalSequence.m; sourceTree = "<group>"; };
 		D0F117CB179F0B97006CE68F /* UITableViewCellRACSupportSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UITableViewCellRACSupportSpec.m; sourceTree = "<group>"; };
+		D0F327F0184EA66B00A0C90C /* RACValidatedBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACValidatedBinding.h; sourceTree = "<group>"; };
+		D0F327F1184EA66B00A0C90C /* RACValidatedBinding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACValidatedBinding.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1550,6 +1558,8 @@
 				5F6FE8521692568A00A8D7A6 /* RACChannel.m */,
 				5F45A883168CFA3E00B58A2B /* RACKVOChannel.h */,
 				5F45A884168CFA3E00B58A2B /* RACKVOChannel.m */,
+				D0F327F0184EA66B00A0C90C /* RACValidatedBinding.h */,
+				D0F327F1184EA66B00A0C90C /* RACValidatedBinding.m */,
 			);
 			name = Channels;
 			sourceTree = "<group>";
@@ -1850,6 +1860,7 @@
 				880D7A5A16F7B351004A3361 /* NSObject+RACSelectorSignal.h in Headers */,
 				6E58405516F22D7500F588A6 /* NSObject+RACDeallocating.h in Headers */,
 				5F6FE8531692568A00A8D7A6 /* RACChannel.h in Headers */,
+				D0F327F2184EA66B00A0C90C /* RACValidatedBinding.h in Headers */,
 				882D072117615381009EDA69 /* RACQueueScheduler+Subclass.h in Headers */,
 				D005A259169A3B7D00A9D2DB /* RACBacktrace.h in Headers */,
 				5F773DEA169B46670023069D /* NSEnumerator+RACSupport.h in Headers */,
@@ -1897,6 +1908,7 @@
 				D08FF27F169A331B00743C6D /* RACScheduler.h in Headers */,
 				D08FF26B169A330000743C6D /* NSObject+RACLifting.h in Headers */,
 				D08FF280169A333400743C6D /* NSArray+RACSupport.h in Headers */,
+				D0F327F3184EA66B00A0C90C /* RACValidatedBinding.h in Headers */,
 				D0BD34C6182B159500B324CB /* RACSignalGenerator.h in Headers */,
 				4973429B18359F29005C25CB /* NSObject+RACKVOWrapper.h in Headers */,
 				D028DB75179E53CB00D1042F /* RACSerialDisposable.h in Headers */,
@@ -1979,6 +1991,7 @@
 				4973429A18359EE2005C25CB /* ReactiveCocoa.h in Headers */,
 				D05AD41C17F2DB6A0080895B /* NSString+RACSupport.h in Headers */,
 				D05AD42417F2DB6E0080895B /* NSText+RACSupport.h in Headers */,
+				D0F327F4184EA66B00A0C90C /* RACValidatedBinding.h in Headers */,
 				D05AD3C017F2DA300080895B /* RACSubscriber.h in Headers */,
 				D05AD42A17F2DB840080895B /* NSObject+RACKVOWrapper.h in Headers */,
 				D0E3632F1811305B007C985A /* RACPromise.h in Headers */,
@@ -2429,6 +2442,7 @@
 				D013A3D91807B5ED0072B6CE /* RACErrorSignal.m in Sources */,
 				D05F9D3717984EC000FD7982 /* EXTRuntimeExtensions.m in Sources */,
 				D009307B1788AB7B00EE7E8B /* RACTestScheduler.m in Sources */,
+				D0F327F5184EA66B00A0C90C /* RACValidatedBinding.m in Sources */,
 				55C39DE417F1EC6E006DC60C /* NSData+RACSupport.m in Sources */,
 				D0BD34C8182B159500B324CB /* RACSignalGenerator.m in Sources */,
 				55C39DE517F1EC6E006DC60C /* NSFileHandle+RACSupport.m in Sources */,
@@ -2540,6 +2554,7 @@
 				D0E967921641EF9C00FCFF06 /* RACStringSequence.m in Sources */,
 				D013A3F31807B9690072B6CE /* RACDynamicSignal.m in Sources */,
 				D0D487041642550100DD7605 /* RACStream.m in Sources */,
+				D0F327F6184EA66B00A0C90C /* RACValidatedBinding.m in Sources */,
 				D013A3DA1807B5ED0072B6CE /* RACErrorSignal.m in Sources */,
 				D0E363311811305B007C985A /* RACPromise.m in Sources */,
 				D0EE284E164D906B006954A4 /* RACSignalSequence.m in Sources */,
@@ -2654,6 +2669,7 @@
 				D013A3DB1807B5ED0072B6CE /* RACErrorSignal.m in Sources */,
 				D05AD42B17F2DB840080895B /* NSObject+RACKVOWrapper.m in Sources */,
 				D05AD3E117F2DB1D0080895B /* RACBehaviorSubject.m in Sources */,
+				D0F327F7184EA66B00A0C90C /* RACValidatedBinding.m in Sources */,
 				D05AD3D717F2DB1D0080895B /* RACEvent.m in Sources */,
 				D02C7C841822CFD200CB20D6 /* RACAction.m in Sources */,
 				D0BD34CA182B159500B324CB /* RACSignalGenerator.m in Sources */,

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACValidatedBinding.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACValidatedBinding.h
@@ -1,0 +1,35 @@
+//
+//  RACValidatedBinding.h
+//  ReactiveCocoa
+//
+//  Created by Justin Spahr-Summers on 2013-12-03.
+//  Copyright (c) 2013 GitHub, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+// Represents a kind of two-way binding, where one side must always validate its
+// values.
+//
+// For example, when binding a view to its model, the model's values should
+// always be honored as-is, while the values coming from the view (and, by
+// extension, the user) must be validated before taking effect.
+@interface RACValidatedBinding : NSObject
+
+// The final, validated values for this binding.
+//
+// In the example of a view-to-model binding, this signal will consist of the
+// model's values.
+@property RACSignal *values;
+
+// Validates proposed values from one side of the binding.
+//
+// If a value passes validation, it may be transformed as well, before finally
+// being sent on `values`.
+//
+// In the example of a view-to-model binding, this generator will accept the
+// view's values, and create a signal that validates them (sending an error if
+// validation fails), then updates the value on the model.
+@property RACSignalGenerator *validator;
+
+@end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACValidatedBinding.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACValidatedBinding.m
@@ -1,0 +1,13 @@
+//
+//  RACValidatedBinding.m
+//  ReactiveCocoa
+//
+//  Created by Justin Spahr-Summers on 2013-12-03.
+//  Copyright (c) 2013 GitHub, Inc. All rights reserved.
+//
+
+#import "RACValidatedBinding.h"
+
+@implementation RACValidatedBinding
+
+@end


### PR DESCRIPTION
**:warning: NOT READY TO MERGE :warning:**

See #960 and #951.

This horribly documented and horribly named class is kind of a throwback to ["facts and rumors"](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/695), because it puts stronger emphasis on the idea of one side of the binding being more authoritative than the other.

Basically, your [view] model always has _the_ canonical data. It can provide that data—or a transformed version of it—for the view to display directly. However, when the user updates the view, the [view] model should be offered a chance to validate and/or transform the user-entered data. If validation fails, the view should revert to the last "canonical" version.

To [communicate errors](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/951), like validation failures, I went with a signal generator. This will make the UI bindings pretty weird (because the validated/transformed value may not arrive in time for synchronous methods, like `-textField:shouldChangeCharactersInRange:replacementString:`), but allows the class to support non-UI use cases as well.

My hope is that maybe replacing `RACChannel` with something that's less "two dumb pipes, side-by-side" and more "a two-way binding with validation logic on one side" will make it less confusing overall.

Thoughts?

**To do:**
- [ ] Add a transactional signal generator (to merge the results of `validator`)?
- [ ] Implement and test `RACValidatedBinding`.
- [ ] Add a subclass that uses KVO/KVC/KVV for its work.
- [ ] Test that the KVO variant doesn't result in an infinite loop.
- [ ] Remove `RACChannel` classes.
- [ ] Deprecate `RACChannel` extensions for AppKit/UIKit, replace them with validated bindings.
