### PR TITLE
Updated bootstrap to search for xctool.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ xcuserdata
 profile
 *.moved-aside
 
+# OS X
+.DS_Store

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,7 +9,7 @@ export SCRIPT_DIR=$(dirname "$0")
 config ()
 {
     # A whitespace-separated list of executables that must be present and locatable.
-    : ${REQUIRED_TOOLS="xctool"}
+    : ${REQUIRED_TOOLS="xctool.sh"}
     
     export REQUIRED_TOOLS
 }


### PR DESCRIPTION
Bootstrap was lamenting the fact that xctool was awol. Submodule import does not then complete.

Fix is to for xctool.sh.
