### PR TITLE
Replace NSString.rac_signal with generic enumeration

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSString+RACSupport.h
@@ -15,11 +15,17 @@
 
 @interface NSString (RACSupport)
 
-/// A signal that will send NSStrings corresponding to each composed character
-/// sequence in the receiver.
+/// Enumerates substrings in the receiver.
 ///
 /// Mutating the string will not affect the signal after it's been created.
-@property (nonatomic, strong, readonly) RACSignal *rac_signal;
+///
+/// range   - The range to enumerate over.
+/// options - Options specifying types of substrings and enumeration styles.
+///
+/// Returns a signal which will send tuples of three values: the substring, the
+/// `NSRange` of the substring, and the "enclosing range" of the substring
+/// (which includes separator or filler characters).
+- (RACSignal *)rac_substringsInRange:(NSRange)range options:(NSStringEnumerationOptions)options;
 
 // Reads in the contents of the given URL using +[NSString
 // stringWithContentsOfURL:usedEncoding:error:].
@@ -33,7 +39,7 @@
 
 @interface NSString (RACSupportDeprecated)
 
-@property (nonatomic, copy, readonly) RACSequence *rac_sequence RACDeprecated("Use -rac_signal instead");
+@property (nonatomic, copy, readonly) RACSequence *rac_sequence RACDeprecated("Use -rac_substringsInRange:options: instead");
 
 + (RACSignal *)rac_readContentsOfURL:(NSURL *)URL usedEncoding:(NSStringEncoding *)encoding scheduler:(RACScheduler *)scheduler RACDeprecated("Use +rac_contentsAndEncodingOfURL: instead");
 


### PR DESCRIPTION
This allows easy enumeration of lines, words, etc. in addition to characters.
