### PR TITLE
Add -[RACSignal signalGenerator]

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignalGenerator.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignalGenerator.h
@@ -7,8 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-
-@class RACSignal;
+#import "RACSignal.h"
 
 /// An abstract class representing the logic for creating a signal from one
 /// input value.
@@ -37,6 +36,16 @@
 ///
 /// Returns a new signal.
 - (RACSignal *)signalWithValue:(id)input;
+
+@end
+
+@interface RACSignal (RACSignalGeneratorAdditions)
+
+/// Creates a constant signal generator from the receiver.
+///
+/// Returns a signal generator that will discard input to -signalWithValue: and
+/// always return the receiver.
+- (RACSignalGenerator *)signalGenerator;
 
 @end
 

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignalGenerator.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignalGenerator.m
@@ -21,6 +21,16 @@
 
 @end
 
+@implementation RACSignal (RACSignalGeneratorAdditions)
+
+- (RACSignalGenerator *)signalGenerator {
+	return [RACDynamicSignalGenerator generatorWithBlock:^(id _) {
+		return self;
+	}];
+}
+
+@end
+
 @implementation RACSignalGenerator (Operations)
 
 - (RACSignalGenerator *)postcompose:(RACSignalGenerator *)otherGenerator {

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACDynamicSignalGeneratorSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACDynamicSignalGeneratorSpec.m
@@ -7,9 +7,11 @@
 //
 
 #import "RACDynamicSignalGenerator.h"
+
 #import "NSObject+RACDeallocating.h"
 #import "RACCompoundDisposable.h"
 #import "RACSignal+Operations.h"
+#import "RACUnit.h"
 
 SpecBegin(RACDynamicSignalGenerator)
 
@@ -22,6 +24,17 @@ it(@"should generate signals using a block", ^{
 	expect([[generator signalWithValue:@0] array]).to.equal(@[ @0 ]);
 	expect([[generator signalWithValue:@1] array]).to.equal(@[ @2 ]);
 	expect([[generator signalWithValue:@2] array]).to.equal(@[ @4 ]);
+});
+
+it(@"should generate a constant signal", ^{
+	RACSignalGenerator *generator = [[RACSignal
+		return:RACUnit.defaultUnit]
+		signalGenerator];
+
+	expect(generator).notTo.beNil();
+	expect([[generator signalWithValue:@0] array]).to.equal(@[ RACUnit.defaultUnit ]);
+	expect([[generator signalWithValue:@1] array]).to.equal(@[ RACUnit.defaultUnit ]);
+	expect([[generator signalWithValue:@2] array]).to.equal(@[ RACUnit.defaultUnit ]);
 });
 
 describe(@"with a reflexive block", ^{


### PR DESCRIPTION
[`RACAction`](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1001) already does this internally. It's a useful operation for easily creating `RACAggregatingSignalGenerator`s, as well as avoiding block lifetime management when you only need a constant generator.
