### PR TITLE
Replaced interval+take1+subscribeNext with afterDelay in bufferWithTime

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -335,12 +335,9 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		RACDisposable *selfDisposable = [self subscribeNext:^(id x) {
 			@synchronized (values) {
 				if (values.count == 0) {
-					timerDisposable.disposable = [[[RACSignal
-						interval:interval onScheduler:scheduler]
-						take:1]
-						subscribeNext:^(id _) {
-							flushValues();
-						}];
+					timerDisposable.disposable = [scheduler
+					                              afterDelay:interval
+					                              schedule:flushValues];
 				}
 
 				[values addObject:x ?: RACTupleNil.tupleNil];


### PR DESCRIPTION
Cuts about three layers of incidental wrapping.
