### PR TITLE
Fix -retry: test

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACSignalSpec.m
@@ -897,10 +897,9 @@ describe(@"-retry:", ^{
 		__block NSUInteger numberOfSubscriptions = 0;
 
 		RACSignal *signal = [RACSignal create:^(id<RACSubscriber> subscriber) {
-			[subscriber.disposable addDisposable:[scheduler schedule:^{
-				numberOfSubscriptions++;
-				expect(numberOfSubscriptions).to.beLessThanOrEqualTo(totalTryCount);
+			numberOfSubscriptions++;
 
+			[subscriber.disposable addDisposable:[scheduler schedule:^{
 				[subscriber sendNext:@"1"];
 				[subscriber sendError:RACSignalTestError];
 			}]];
@@ -916,6 +915,7 @@ describe(@"-retry:", ^{
 		}];
 		
 		expect(receivedError).will.equal(RACSignalTestError);
+		expect(numberOfSubscriptions).to.equal(totalTryCount);
 		expect(nextCount).to.equal(totalTryCount);
 	});
 


### PR DESCRIPTION
Clarify retry count vs total try count. Also, wait for the error before asserting the total try count.

Fixes #1033 
