### PR TITLE
Allow nil inner streams when flattening

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -776,9 +776,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 
 		RACDisposable *subscriptionDisposable = [[connection.signal
 			flattenMap:^(RACSignal *x) {
-				if (x == nil) return [RACSignal empty];
-
-				NSCAssert([x isKindOfClass:RACSignal.class], @"-switchToLatest requires that the source signal (%@) send signals. Instead we got: %@", self, x);
+				NSCAssert(x == nil || [x isKindOfClass:RACSignal.class], @"-switchToLatest requires that the source signal (%@) send signals. Instead we got: %@", self, x);
 
 				// -concat:[RACSignal never] prevents completion of the receiver from
 				// prematurely terminating the inner signal.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
@@ -103,7 +103,8 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 /// This corresponds to the `SelectMany` method in Rx.
 ///
 /// block - A block which accepts the values in the receiver and returns a new
-///         instance of the receiver's class. This block should not return `nil`.
+///         instance of the receiver's class. Returning `nil` from this block is
+///         equivalent to returning an empty signal.
 ///
 /// Examples
 ///

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
@@ -68,10 +68,12 @@
 @implementation RACStream (Operations)
 
 - (instancetype)flattenMap:(RACStream * (^)(id value))block {
+	Class class = self.class;
+
 	return [[self bind:^{
 		return ^(id value, BOOL *stop) {
-			id stream = block(value);
-			NSCAssert(stream != nil, @"Expected non-nil stream to be returned from -flattenMap:");
+			id stream = block(value) ?: [class empty];
+			NSCAssert([stream isKindOfClass:RACStream.class], @"Value returned from -flattenMap: is not a stream: %@", stream);
 
 			return stream;
 		};
@@ -81,7 +83,6 @@
 - (instancetype)flatten {
 	__weak RACStream *stream __attribute__((unused)) = self;
 	return [[self flattenMap:^(id value) {
-		NSCAssert([value isKindOfClass:RACStream.class], @"Stream %@ being flattened contains an object that is not a stream: %@", stream, value);
 		return value;
 	}] setNameWithFormat:@"[%@] -flatten", self.name];
 }

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACStreamExamples.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACStreamExamples.m
@@ -213,6 +213,18 @@ sharedExamplesFor(RACStreamExamples, ^(NSDictionary *data) {
 
 			verifyValues(stream, @[ @1, @3 ]);
 		});
+
+		it(@"should treat nil streams like empty streams", ^{
+			RACStream *baseStream = streamWithValues(@[ @0, @1, @2 ]);
+			RACStream *stream = [baseStream flattenMap:^ RACStream * (NSNumber *value) {
+				if (value.integerValue == 1) return nil;
+
+				NSNumber *newValue = @(value.integerValue + 1);
+				return [streamClass return:newValue];
+			}];
+
+			verifyValues(stream, @[ @1, @3 ]);
+		});
 	});
 
 	it(@"should map", ^{


### PR DESCRIPTION
After #941, we started hitting the added assertion pretty frequently. The usual culprit was something like this:

``` objc
[signal flattenMap:^(id _) {
    @strongify(self);
    return [self methodReturningASignal];
}];
```

Arguably, we should be more vigilant in checking for `nil`, but it's also a bit silly that returning `nil` doesn't do something sane. This makes `nil` behave like you returned an empty stream.
