### PR TITLE
Remove delegate proxy from UITextView category

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.h
@@ -8,22 +8,12 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACDelegateProxy;
+
 @class RACSignal;
 
 @interface UITextView (RACSignalSupport)
 
-/// A delegate proxy which will be set as the receiver's delegate when any of the
-/// methods in this category are used.
-@property (nonatomic, strong, readonly) RACDelegateProxy *rac_delegateProxy;
-
 /// Creates a signal for the text of the receiver.
-///
-/// When this method is invoked, the `rac_delegateProxy` will become the
-/// receiver's delegate. Any previous delegate will become the -[RACDelegateProxy
-/// rac_proxiedDelegate], so that it receives any messages that the proxy doesn't
-/// know how to handle. Setting the receiver's `delegate` afterward is
-/// considered undefined behavior.
 ///
 /// Returns a signal which will send the current text upon subscription, then
 /// again whenever the receiver's text is changed. The signal will complete when
@@ -32,8 +22,11 @@
 
 @end
 
+@class RACDelegateProxy;
 @interface UITextView (RACSignalSupportUnavailable)
 
+
+@property (nonatomic, strong, readonly) RACDelegateProxy *rac_delegateProxy __attribute__((unavailable("Use the `delegate` property of UITextView normally.")));
 - (RACSignal *)rac_signalForDelegateMethod:(SEL)method __attribute__((unavailable("Use -rac_signalForSelector:fromProtocol: instead")));
 
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UITextView+RACSignalSupport.m
@@ -9,47 +9,30 @@
 #import "UITextView+RACSignalSupport.h"
 #import "EXTScope.h"
 #import "NSObject+RACDeallocating.h"
-#import "RACDelegateProxy.h"
 #import "RACSignal+Operations.h"
 #import "RACTuple.h"
 #import "NSObject+RACDescription.h"
+#import "NSNotificationCenter+RACSupport.h"
 #import <objc/runtime.h>
 
 @implementation UITextView (RACSignalSupport)
 
-static void RACUseDelegateProxy(UITextView *self) {
-    if (self.delegate == self.rac_delegateProxy) return;
-
-    self.rac_delegateProxy.rac_proxiedDelegate = self.delegate;
-    self.delegate = (id)self.rac_delegateProxy;
-}
-
-- (RACDelegateProxy *)rac_delegateProxy {
-	RACDelegateProxy *proxy = objc_getAssociatedObject(self, _cmd);
-	if (proxy == nil) {
-		proxy = [[RACDelegateProxy alloc] initWithProtocol:@protocol(UITextViewDelegate)];
-		objc_setAssociatedObject(self, _cmd, proxy, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-	}
-
-	return proxy;
-}
-
 - (RACSignal *)rac_textSignal {
 	@weakify(self);
-	RACSignal *signal = [[[[[RACSignal
-		defer:^{
-			@strongify(self);
-			return [RACSignal return:RACTuplePack(self)];
-		}]
-		concat:[self.rac_delegateProxy signalForSelector:@selector(textViewDidChange:)]]
-		reduceEach:^(UITextView *x) {
-			return x.text;
-		}]
-		takeUntil:self.rac_willDeallocSignal]
-		setNameWithFormat:@"%@ -rac_textSignal", [self rac_description]];
-
-	RACUseDelegateProxy(self);
-
+    RACSignal *noteSignal = [[[NSNotificationCenter defaultCenter] rac_addObserverForName:UITextViewTextDidChangeNotification object:self] map:^id(NSNotification *note) {
+        UITextView *tv = note.object;
+        return tv.text;
+    }];
+	RACSignal *signal = [[[[RACSignal
+                            defer:^{
+                                @strongify(self);
+                                return [RACSignal return:self.text];
+                            }]
+                           concat:noteSignal]
+                          takeUntil:self.rac_willDeallocSignal]
+                         setNameWithFormat:@"%@ -rac_textSignal", [self rac_description]];
+    
+    
 	return signal;
 }
 


### PR DESCRIPTION
NSNotificationCenter multicasts text changes for text views, so this way we don't have to fiddle with delegate proxies.

This should patch cleanly onto either 3.0-dev or master. Great library, by the way!
