### PR TITLE
Remove inclusion of config.h

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/extobjc/metamacros.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/extobjc/metamacros.h
@@ -9,10 +9,6 @@
 #ifndef EXTC_METAMACROS_H
 #define EXTC_METAMACROS_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 /**
  * Executes one or more expressions (which may have a void type, such as a call
  * to a function that returns no value) and always returns true.


### PR DESCRIPTION
Other libraries define the `HAVE_CONFIG_H` condition to include `config.h`, such as `LibYAML` or `YAML.framework`. When this happens ReactiveCocoa’s extobjc tries to include its own `config.h` file which doesn't exist. As this doesn’t seem to be used in ReactiveCocoa, we can safely remove it and thus prevent compile errors.

I did run all unit tests provided by the project, they did all pass without any error. Hope this pull request could make it to main repo :-)

As a reference, I did the same on Mantle: https://github.com/MantleFramework/Mantle/pull/126

Thanks,
Jérémy
