### PR TITLE
Fixing RACDynamicSignal.h import

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACDynamicSignal.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACDynamicSignal.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 GitHub, Inc. All rights reserved.
 //
 
-#import <ReactiveCocoa/ReactiveCocoa.h>
+#import "RACSignal.h"
 
 // A private `RACSignal` subclasses that implements its subscription behavior
 // using a block.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACDynamicSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACDynamicSignal.m
@@ -11,6 +11,7 @@
 #import "RACPassthroughSubscriber.h"
 #import "RACScheduler+Private.h"
 #import "RACSubscriber.h"
+#import "RACCompoundDisposable.h"
 #import <libkern/OSAtomic.h>
 
 // Retains dynamic signals while they wait for subscriptions.


### PR DESCRIPTION
After wrestling with ReactiveCocoa and CocoaPods for a while I discovered that `RACDynamicSignal.h` imported its super via `#import <ReactiveCocoa/ReactiveCocoa.h>` instead of just the necessary `#import RACSignal.h`.

This import caused a ton of redefinition errors when installing ReactiveCocoa via CocoaPods (see image). This change seems to fix the problem allowing it to compile successfully. :pray: 

![image](https://f.cloud.github.com/assets/130534/1950411/a9061436-8145-11e3-939e-2e885bdbf867.png)
