### PR TITLE
Remove RACCommand.observationInfo override

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACCommand.m
@@ -49,11 +49,6 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 // The signal block that the receiver was initialized with.
 @property (nonatomic, copy, readonly) RACSignal * (^signalBlock)(id input);
 
-// Improves the performance of KVO on the receiver.
-//
-// See the documentation for <NSKeyValueObserving> for more information.
-@property (atomic) void *observationInfo;
-
 // Adds a signal to `activeExecutionSignals` and generates a KVO notification.
 - (void)addActiveExecutionSignal:(RACSignal *)signal;
 


### PR DESCRIPTION
Although storing this information on the object directly is supposed to improve performance, it seems to introduce `EXC_BAD_ACCESS` crashes during some KVO calls.

Whether it’s the direct cause or just exposes some underlying issue is unclear, but we can at least reduce the incidence by going through the global KVO machinery.
