### PR TITLE
Remove mentions of RACPromise in deprecation messages

### DIFF
--- a/Documentation/FrameworkOverview.md
+++ b/Documentation/FrameworkOverview.md
@@ -40,7 +40,7 @@ problematic if the signal has side effects or the work is expensive (for
 example, sending a network request).
 
 To share the values of a signal without duplicating its side effects, use
-a [subject](#subjects) or a [promise](#promises).
+a [subject](#subjects).
 
 ### Subscription
 
@@ -146,7 +146,6 @@ On iOS, only queue hops from within RAC and your project will be captured (but
 the information is still valuable).
 
 [Design Guidelines]: DesignGuidelines.md
-[Futures and promises]: http://en.wikipedia.org/wiki/Futures_and_promises
 [Memory Management]: MemoryManagement.md
 [RACAction]: ../ReactiveCocoaFramework/ReactiveCocoa/RACAction.h
 [RACBacktrace]: ../ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.h

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBehaviorSubject.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBehaviorSubject.h
@@ -9,7 +9,7 @@
 #import "RACDeprecated.h"
 #import "RACSubject.h"
 
-RACDeprecated("Use a plain RACSignal or -[RACSignal promise] instead")
+RACDeprecated("Bind to a property with RAC() and give it a default value instead")
 @interface RACBehaviorSubject : RACSubject
 
 + (instancetype)behaviorSubjectWithDefaultValue:(id)value;

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -832,10 +832,10 @@ typedef enum : NSUInteger {
 - (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory reduce:(id (^)(id running, id next))reduceBlock RACDeprecated("Use +defer: and -aggregateWithStart:reduce: instead");
 - (RACSignal *)then:(RACSignal * (^)(void))block RACDeprecated("Use -ignoreValues followed by -concat: with +defer: instead");
 - (RACMulticastConnection *)publish RACDeprecated("Send events to a shared RACSubject instead");
-- (RACMulticastConnection *)multicast:(RACSubject *)subject RACDeprecated("Use -promiseOnScheduler: or send events to a shared RACSubject instead");
-- (RACSignal *)replay RACDeprecated("Use -promiseOnScheduler: instead");
-- (RACSignal *)replayLast RACDeprecated("Use -takeLast: and -promiseOnScheduler: instead");
-- (RACSignal *)replayLazily RACDeprecated("Use -promiseOnScheduler: instead");
+- (RACMulticastConnection *)multicast:(RACSubject *)subject RACDeprecated("Send events to a shared RACSubject instead");
+- (RACSignal *)replay RACDeprecated("Bind to a property with RAC() instead");
+- (RACSignal *)replayLast RACDeprecated("Bind to a property with RAC() instead");
+- (RACSignal *)replayLazily RACDeprecated("Bind to a property with RAC() or use -shareWhileActive instead");
 - (NSArray *)toArray RACDeprecated("Renamed to -array");
 
 @end


### PR DESCRIPTION
Truly, `RACPromise` died too young.
