### PR TITLE
Added a scheduler/synchronized-primitive: RACInOrderScheduler

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -262,6 +262,12 @@
 		88FC735716114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 88FC735416114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.m */; };
 		88FC735816114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = 88FC735416114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.m */; };
 		88FC735B16114FFB00F8A774 /* RACSubscriptingAssignmentTrampolineSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 88FC735A16114FFB00F8A774 /* RACSubscriptingAssignmentTrampolineSpec.m */; };
+		A19A6D0C18B44CDD003AC652 /* RACInOrderScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = A19A6D0A18B44CDD003AC652 /* RACInOrderScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A19A6D0D18B44CDD003AC652 /* RACInOrderScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = A19A6D0A18B44CDD003AC652 /* RACInOrderScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A19A6D0E18B44CDD003AC652 /* RACInOrderScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = A19A6D0A18B44CDD003AC652 /* RACInOrderScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A19A6D0F18B44CDD003AC652 /* RACInOrderScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = A19A6D0B18B44CDD003AC652 /* RACInOrderScheduler.m */; };
+		A19A6D1D18B459D5003AC652 /* RACInOrderScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = A19A6D0B18B44CDD003AC652 /* RACInOrderScheduler.m */; };
+		A19A6D1E18B459D5003AC652 /* RACInOrderScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = A19A6D0B18B44CDD003AC652 /* RACInOrderScheduler.m */; };
 		A1FCC27715666AA3008C9686 /* UITextView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = A1FCC27315666AA3008C9686 /* UITextView+RACSignalSupport.m */; };
 		A1FCC374156754A7008C9686 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = A1FCC371156754A7008C9686 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		A1FCC375156754A7008C9686 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = A1FCC371156754A7008C9686 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -893,6 +899,8 @@
 		88FC735316114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACSubscriptingAssignmentTrampoline.h; sourceTree = "<group>"; };
 		88FC735416114F9C00F8A774 /* RACSubscriptingAssignmentTrampoline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACSubscriptingAssignmentTrampoline.m; sourceTree = "<group>"; };
 		88FC735A16114FFB00F8A774 /* RACSubscriptingAssignmentTrampolineSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACSubscriptingAssignmentTrampolineSpec.m; sourceTree = "<group>"; };
+		A19A6D0A18B44CDD003AC652 /* RACInOrderScheduler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACInOrderScheduler.h; sourceTree = "<group>"; };
+		A19A6D0B18B44CDD003AC652 /* RACInOrderScheduler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACInOrderScheduler.m; sourceTree = "<group>"; };
 		A1FCC27215666AA3008C9686 /* UITextView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITextView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		A1FCC27315666AA3008C9686 /* UITextView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITextView+RACSignalSupport.m"; sourceTree = "<group>"; };
 		A1FCC370156754A7008C9686 /* RACObjCRuntime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACObjCRuntime.h; sourceTree = "<group>"; };
@@ -1551,6 +1559,8 @@
 				882D071817614FA7009EDA69 /* RACTargetQueueScheduler.m */,
 				881E87B016695EDF00667F7B /* RACImmediateScheduler.h */,
 				881E87B116695EDF00667F7B /* RACImmediateScheduler.m */,
+				A19A6D0A18B44CDD003AC652 /* RACInOrderScheduler.h */,
+				A19A6D0B18B44CDD003AC652 /* RACInOrderScheduler.m */,
 				881E87C21669635F00667F7B /* RACSubscriptionScheduler.h */,
 				881E87C31669636000667F7B /* RACSubscriptionScheduler.m */,
 				D00930771788AB7B00EE7E8B /* RACTestScheduler.h */,
@@ -1758,6 +1768,7 @@
 				880B9176150B09190008488E /* RACSubject.h in Headers */,
 				D090767F17FBEADE00EB087A /* NSURLConnection+RACSupport.h in Headers */,
 				88F440D3153DADEA0097B4C3 /* NSObject+RACAppKitBindings.h in Headers */,
+				A19A6D0C18B44CDD003AC652 /* RACInOrderScheduler.h in Headers */,
 				88D4AB3E1510F6C30011494F /* RACReplaySubject.h in Headers */,
 				7479F6E5186177D200575CDB /* RACIndexSetSequence.h in Headers */,
 				883A84DA1513964B006DB4C7 /* RACBehaviorSubject.h in Headers */,
@@ -1852,6 +1863,7 @@
 				D08FF285169A333400743C6D /* UIControl+RACSignalSupport.h in Headers */,
 				D08FF286169A333400743C6D /* UITextField+RACSignalSupport.h in Headers */,
 				D08FF287169A333400743C6D /* UITextView+RACSignalSupport.h in Headers */,
+				A19A6D0D18B44CDD003AC652 /* RACInOrderScheduler.h in Headers */,
 				D08FF289169A333400743C6D /* NSObject+RACPropertySubscribing.h in Headers */,
 				5F773DEB169B46670023069D /* NSEnumerator+RACSequenceAdditions.h in Headers */,
 				D077A16E169B740200057BB1 /* RACEvent.h in Headers */,
@@ -1914,6 +1926,7 @@
 				D05AD42017F2DB6E0080895B /* NSControl+RACTextSignalSupport.h in Headers */,
 				D05AD3FD17F2DB5D0080895B /* RACQueueScheduler+Subclass.h in Headers */,
 				D05AD42217F2DB6E0080895B /* NSObject+RACAppKitBindings.h in Headers */,
+				A19A6D0E18B44CDD003AC652 /* RACInOrderScheduler.h in Headers */,
 				BE527E9518636F7F006349E8 /* NSUserDefaults+RACSupport.h in Headers */,
 				D05AD3DA17F2DB1D0080895B /* RACGroupedSignal.h in Headers */,
 				D05AD41617F2DB6A0080895B /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
@@ -2357,6 +2370,7 @@
 				881E87B416695EDF00667F7B /* RACImmediateScheduler.m in Sources */,
 				881E87C61669636000667F7B /* RACSubscriptionScheduler.m in Sources */,
 				5F45A887168CFA3E00B58A2B /* RACKVOChannel.m in Sources */,
+				A19A6D0F18B44CDD003AC652 /* RACInOrderScheduler.m in Sources */,
 				5F6FE8551692568A00A8D7A6 /* RACChannel.m in Sources */,
 				88C5A026169246140045EF05 /* RACMulticastConnection.m in Sources */,
 				5F9743F91694A2460024EB82 /* RACEagerSequence.m in Sources */,
@@ -2481,6 +2495,7 @@
 				D0E9677A1641EF9C00FCFF06 /* NSSet+RACSequenceAdditions.m in Sources */,
 				D0E9677E1641EF9C00FCFF06 /* NSString+RACSequenceAdditions.m in Sources */,
 				D0E967821641EF9C00FCFF06 /* RACArraySequence.m in Sources */,
+				A19A6D1D18B459D5003AC652 /* RACInOrderScheduler.m in Sources */,
 				D0E967861641EF9C00FCFF06 /* RACDynamicSequence.m in Sources */,
 				D028DB88179E616700D1042F /* UITableViewCell+RACSignalSupport.m in Sources */,
 				BE527E9718636F7F006349E8 /* NSUserDefaults+RACSupport.m in Sources */,
@@ -2585,6 +2600,7 @@
 				D05AD3D117F2DB100080895B /* RACStream.m in Sources */,
 				D05AD3F717F2DB4F0080895B /* RACUnarySequence.m in Sources */,
 				D05AD3D317F2DB1D0080895B /* RACSignal.m in Sources */,
+				A19A6D1E18B459D5003AC652 /* RACInOrderScheduler.m in Sources */,
 				D05AD42F17F2DB840080895B /* NSObject+RACPropertySubscribing.m in Sources */,
 				D05AD3F317F2DB4F0080895B /* RACEmptySequence.m in Sources */,
 				D05AD42317F2DB6E0080895B /* NSObject+RACAppKitBindings.m in Sources */,

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACInOrderScheduler.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACInOrderScheduler.h
@@ -1,0 +1,19 @@
+#import "RACScheduler.h"
+
+/// A scheduler which runs scheduled work in order on an underlying scheduler.
+///
+/// When not specified, the underlying scheduler defaults to the immediate scheduler.
+///
+/// This scheduler can be used as a synchronization primitive, like a lock that queues instead of blocking.
+@interface RACInOrderScheduler : RACScheduler
+
+/// Initializes the receiving RACInOrderScheduler to run scheduled blocks as immediately as possible.
+- (instancetype)init;
+
+/// Initializes the receiving RACInOrderScheduler to run scheduled blocks on the given scheduler.
+- (instancetype)initWithScheduler:(RACScheduler*)scheduler;
+
+/// Returns a new RACInOrderScheduler, initialized to run scheduled blocks on the given scheduler.
++ (RACInOrderScheduler *)inOrderSchedulerOnScheduler:(RACScheduler*)scheduler;
+
+@end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACInOrderScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACInOrderScheduler.m
@@ -1,0 +1,132 @@
+#import "RACInOrderScheduler.h"
+#import <libkern/OSAtomic.h>
+
+struct RACInOrderSchedulerQueueNode {
+	void* block;
+	void* next;
+};
+
+@implementation RACInOrderScheduler {
+// producers atomically increment this counter when enqueueing
+// whoever increments-from-zero becomes responsible for draining the queue
+// after each action is run, the draining producer atomically decrements the counter
+// must continue draining until the counter decrements-to-zero
+@private int32_t _drainToZeroCounter;
+
+// thread-safe queue for storing queued blocks
+@private OSQueueHead _queue;
+	
+// the underlying scheduler that blocks will be run on
+@private RACScheduler* _scheduler;
+	
+// used on fast path to quickly determine if we can avoid involving the scheduler
+@private bool _isImmediate;
+}
+
+#pragma mark Lifecycle
+
+-(instancetype)initWithScheduler:(RACScheduler*)scheduler {
+	assert(scheduler != nil);
+	if (self = [super init]) {
+		self->_isImmediate = scheduler == RACScheduler.immediateScheduler;
+		self->_scheduler = scheduler;
+		self->_queue = (OSQueueHead)OS_ATOMIC_QUEUE_INIT;
+	}
+	return self;
+}
+-(instancetype)init {
+	return [self initWithScheduler:RACScheduler.immediateScheduler];
+}
++(RACInOrderScheduler*)inOrderSchedulerOnScheduler:(RACScheduler*)scheduler {
+	return [[RACInOrderScheduler alloc] initWithScheduler:scheduler];
+}
+
+-(void(^)(void))_tryDequeueAction {
+	// try dequeue
+	void* dequeuedVoid = OSAtomicDequeue(&_queue, offsetof(struct RACInOrderSchedulerQueueNode, next));
+	if (dequeuedVoid == NULL) return nil;
+
+	// extract block
+	struct RACInOrderSchedulerQueueNode* dequeuedNode = (struct RACInOrderSchedulerQueueNode*)dequeuedVoid;
+	void(^dequeuedBlock)(void) = (__bridge_transfer void(^)(void))dequeuedNode->block;
+	free(dequeuedVoid);
+	
+	return dequeuedBlock;
+}
+
+-(void)dealloc {
+	// action queue should be empty, but empty it anyways just to be safe
+	// e.g. maybe a scheduled block threw, putting this scheduler into a stuck state
+	while ([self _tryDequeueAction] != nil) {
+		// discard
+	}
+}
+
+#pragma mark Queueing
+
+-(void)_performDrain {
+	do {
+		// dequeue
+		void(^action)(void) = [self _tryDequeueAction];
+		assert(action != nil); // because of how _drainToZeroCounter is used
+		
+		// perform
+		action();
+		
+		// try release draining responsibility
+	} while (OSAtomicDecrement32Barrier(&_drainToZeroCounter) > 0);
+}
+
+-(void)_didSchedule:(void(^)(void))action {
+	// attempt fast path
+	if (OSAtomicCompareAndSwap32Barrier(0, 1, &_drainToZeroCounter)) {
+		action();
+		if (OSAtomicDecrement32Barrier(&_drainToZeroCounter) > 0) {
+			[self _performDrain];
+		}
+		return;
+	}
+	
+	// enqeue
+	struct RACInOrderSchedulerQueueNode* n = (struct RACInOrderSchedulerQueueNode*)malloc(sizeof(struct RACInOrderSchedulerQueueNode));
+	n->block = (__bridge_retained void*)action;
+	n->next = NULL;
+	OSAtomicEnqueue(&_queue, (void*)n, offsetof(struct RACInOrderSchedulerQueueNode, next));
+	
+	// try acquire draining responsibility
+	if (OSAtomicIncrement32Barrier(&_drainToZeroCounter) > 1) return;
+	
+	// start draining
+	[self _performDrain];
+}
+
+#pragma mark Scheduling
+
+-(RACDisposable *)schedule:(void(^)(void))block {
+	NSCParameterAssert(block != nil);
+	
+	// attempt fast path
+	if (_isImmediate && OSAtomicCompareAndSwap32Barrier(0, 1, &_drainToZeroCounter)) {
+		block();
+		if (OSAtomicDecrement32Barrier(&_drainToZeroCounter) > 0) [self _performDrain];
+		return nil;
+	}
+	
+	return [_scheduler schedule:^{ [self _didSchedule:block]; }];
+}
+
+-(RACDisposable *)after:(NSDate *)date schedule:(void (^)(void))block {
+	NSCParameterAssert(block != nil);
+	return [_scheduler after:date
+					schedule:^{ [self _didSchedule:block]; }];
+}
+
+-(RACDisposable *)after:(NSDate *)date repeatingEvery:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway schedule:(void (^)(void))block {
+	NSCParameterAssert(block != nil);
+	return [_scheduler after:date
+			  repeatingEvery:interval
+				  withLeeway:leeway
+					schedule:^{ [self _didSchedule:block]; }];
+}
+
+@end

--- a/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
@@ -49,6 +49,7 @@
 #import "RACTestScheduler.h"
 #import "RACTuple.h"
 #import "RACUnit.h"
+#import "RACInOrderScheduler.h"
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
 	#import "UIActionSheet+RACSignalSupport.h"


### PR DESCRIPTION
- Runs scheduled actions in order on an underlying scheduler
- Defaults to immediate underlying scheduler
- Usable as a synchronized primitive
- Faster than @synchronized, without deadlock or re-entrant re-order risks

Can be used to resolve possible deadlocks (see: https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1012 ).

Instead of using @synchronized(_lock), you would use [inOrder schedule:^{ ... }]. In my tests this is twice as fast as @synchronized when on a single thread, and would be almost three times as fast if schedule returned void instead of a nil RACDisposable.
