### PR TITLE
Fix the italics and fixed width text being nested wrong.

### DIFF
--- a/Documentation/MemoryManagement.md
+++ b/Documentation/MemoryManagement.md
@@ -87,7 +87,7 @@ header:
 }];
 ```
 
-_(Replace `__weak` or `@weakify` with `__unsafe_unretained` or `@unsafeify`,
+_(Replace_ `__weak` _or_ `@weakify` _with_ `__unsafe_unretained` _or_ `@unsafeify` _,
 respectively, if the object doesn't support weak references.)_
 
 However, [there's probably a better pattern you could use instead][avoid-explicit-subscriptions-and-disposal]. For


### PR DESCRIPTION
[Rendered](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/15cf6e15f257df224282517c4d79a2308e811313/Documentation/MemoryManagement.md)

[Old version](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/bcb3d9a680adcea12927a74dea9216b0e40d96b5/Documentation/MemoryManagement.md)

Note that I had to add a space between `@unsafeify` and the following comma to appease my editor, though I'm not sure it's necessary for Github to get it right, so it line-breaks wrong now.

I'm not sure whether this is to be considered a bug in how Github interprets overlapping tags, given how the flexibilities markdown implementations take with the "spec", and how the "spec" isn't really a formal specification to begin with, but just for future reference, where does one report bugs with Github?
