### PR TITLE
Update BasicOperators.md

### DIFF
--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -242,6 +242,8 @@ RACSignal *letters = [@"A B C D E F G H I" componentsSeparatedByString:@" "].rac
     }];
 ```
 
+A detailed explanation about the difference between `-map:` and `-flattenMap:` can be seen [here](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/448#issuecomment-34977600). 
+
 ## Combining signals
 
 These operators combine multiple signals into a single new [RACSignal][].


### PR DESCRIPTION
Added a link to https://github.com/ReactiveCocoa/ReactiveCocoa/issues/448#issuecomment-34977600 as it explains very well the difference between `-map:` and `-flattenMap`.
