### PR TITLE
Replace OSAtomicIncrement/Decrement32Barrier with OSAtomicAdd32Barrier

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACMulticastConnection.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACMulticastConnection.m
@@ -66,7 +66,7 @@
 
 	return [[RACSignal
 		createSignal:^(id<RACSubscriber> subscriber) {
-			OSAtomicIncrement32Barrier(&subscriberCount);
+			OSAtomicAdd32Barrier(1, &subscriberCount);
 
 			RACDisposable *subscriptionDisposable = [self.signal subscribe:subscriber];
 			RACDisposable *connectionDisposable = [self connect];
@@ -74,7 +74,7 @@
 			return [RACDisposable disposableWithBlock:^{
 				[subscriptionDisposable dispose];
 
-				if (OSAtomicDecrement32Barrier(&subscriberCount) == 0) {
+				if (OSAtomicAdd32Barrier(-1, &subscriberCount); == 0) {
 					[connectionDisposable dispose];
 				}
 			}];


### PR DESCRIPTION
fix issue with running on iOS 7.0 devices with application built against iOS 7.1 sdk.  OSAtomicIncrement32Barrier and OSAtomicDecrement32Barrier cause a dyld: lazy symbol binding failed: Symbol not found: _OSAtomicIncrement32Barrier error in this case on iOS 7.0.  resolves #1223
