### PR TITLE
Add `-[RACStream distinctWithPredicate:]`

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
@@ -310,6 +310,10 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 /// previous value.
 - (instancetype)distinctUntilChanged;
 
+/// Returns a stream of values for which the predicate returns NO when compared
+/// to the previous value.
+- (instancetype)distinctWithPredicate:(BOOL (^)(id previous, id current))predicate;
+
 @end
 
 @interface RACStream (Deprecated)

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACStream.m
@@ -318,6 +318,12 @@
 }
 
 - (instancetype)distinctUntilChanged {
+	return [[self distinctWithPredicate:^BOOL(id previous, id current) {
+		return (previous == current || [current isEqual:previous]);
+	}] setNameWithFormat:@"[%@] -distinctUntilChanged", self.name];
+}
+
+- (instancetype)distinctWithPredicate:(BOOL (^)(id, id))predicate {
 	Class class = self.class;
 
 	return [[self bind:^{
@@ -325,13 +331,13 @@
 		__block BOOL initial = YES;
 
 		return ^(id x, BOOL *stop) {
-			if (!initial && (lastValue == x || [x isEqual:lastValue])) return [class empty];
+			if (!initial && predicate(lastValue, x)) return [class empty];
 
 			initial = NO;
 			lastValue = x;
 			return [class return:x];
 		};
-	}] setNameWithFormat:@"[%@] -distinctUntilChanged", self.name];
+	}] setNameWithFormat:@"[%@] -distinctWithPredicate:", self.name];
 }
 
 @end


### PR DESCRIPTION
We wanted to filter out NSValues containing duplicate structs, so `-distinctUntilChanged` wasn't sufficient for us.
