### PR TITLE
Add import for UIRefreshControl+RACCommandSupport

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
@@ -59,6 +59,7 @@
 	#import "UIControl+RACSignalSupport.h"
 	#import "UIDatePicker+RACSignalSupport.h"
 	#import "UIGestureRecognizer+RACSignalSupport.h"
+	#import "UIRefreshControl+RACCommandSupport.h"
 	#import "UISegmentedControl+RACSignalSupport.h"
 	#import "UISlider+RACSignalSupport.h"
 	#import "UIStepper+RACSignalSupport.h"


### PR DESCRIPTION
Include an import statement for "UIRefreshControl+RACCommandSupport.h" in the ReactiveCocoa header.
