### PR TITLE
Make RACScheduler easier to subclass.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoaFramework/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -631,6 +631,7 @@
 		3C163DE018FE843D001AA13E /* UIImagePickerController+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImagePickerController+RACSignalSupport.h"; sourceTree = "<group>"; };
 		3C163DE118FE843D001AA13E /* UIImagePickerController+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImagePickerController+RACSignalSupport.m"; sourceTree = "<group>"; };
 		3C80F51D18FFCF810018AE41 /* UIImagePickerControllerRACSupportSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIImagePickerControllerRACSupportSpec.m; sourceTree = "<group>"; };
+		3F477B16AF0120164B3827C8 /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RACScheduler+Subclass.h"; sourceTree = "<group>"; };
 		4925E805181BCC71000B2FEE /* NSControllerRACSupportSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSControllerRACSupportSpec.m; sourceTree = "<group>"; };
 		554D9E5B181064E200F21262 /* UIRefreshControl+RACCommandSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIRefreshControl+RACCommandSupport.h"; sourceTree = "<group>"; };
 		554D9E5C181064E200F21262 /* UIRefreshControl+RACCommandSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIRefreshControl+RACCommandSupport.m"; sourceTree = "<group>"; };
@@ -1435,6 +1436,7 @@
 				881E87C31669636000667F7B /* RACSubscriptionScheduler.m */,
 				D00930771788AB7B00EE7E8B /* RACTestScheduler.h */,
 				D00930781788AB7B00EE7E8B /* RACTestScheduler.m */,
+				3F477B16AF0120164B3827C8 /* RACScheduler+Subclass.h */,
 			);
 			name = Schedulers;
 			sourceTree = "<group>";

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler+Subclass.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler+Subclass.h
@@ -7,15 +7,11 @@
 //
 
 #import "RACQueueScheduler.h"
+#import "RACScheduler+Subclass.h"
 
-/// An interface for use by subclasses.
+/// An interface for use by GCD queue-based subclasses.
 ///
-/// Subclasses should use `-performAsCurrentScheduler:` to do the actual block
-/// invocation so that +[RACScheduler currentScheduler] behaves as expected.
-///
-/// **Note that RACSchedulers are expected to be serial**. Subclasses must honor
-/// that contract. See `RACTargetQueueScheduler` for a queue-based scheduler
-/// which will enforce the serialization guarantee.
+/// See RACScheduler+Subclass.h for subclassing notes.
 @interface RACQueueScheduler ()
 
 /// The queue on which blocks are enqueued.
@@ -30,13 +26,6 @@
 ///
 /// Returns the initialized object.
 - (id)initWithName:(NSString *)name queue:(dispatch_queue_t)queue;
-
-/// Performs the given block with the receiver as the current scheduler for
-/// `queue`. This should only be called by subclasses to perform scheduled blocks
-/// on their queue.
-///
-/// block - The block to execute. Cannot be NULL.
-- (void)performAsCurrentScheduler:(void (^)(void))block;
 
 /// Converts a date into a GCD time using dispatch_walltime().
 ///

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACQueueScheduler.m
@@ -97,24 +97,4 @@
 	}];
 }
 
-- (void)performAsCurrentScheduler:(void (^)(void))block {
-	NSCParameterAssert(block != NULL);
-
-	// If we're using a concurrent queue, we could end up in here concurrently,
-	// in which case we *don't* want to clear the current scheduler immediately
-	// after our block is done executing, but only *after* all our concurrent
-	// invocations are done.
-
-	RACScheduler *previousScheduler = RACScheduler.currentScheduler;
-	NSThread.currentThread.threadDictionary[RACSchedulerCurrentSchedulerKey] = self;
-
-	block();
-
-	if (previousScheduler != nil) {
-		NSThread.currentThread.threadDictionary[RACSchedulerCurrentSchedulerKey] = previousScheduler;
-	} else {
-		[NSThread.currentThread.threadDictionary removeObjectForKey:RACSchedulerCurrentSchedulerKey];
-	}
-}
-
 @end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler+Subclass.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler+Subclass.h
@@ -1,0 +1,29 @@
+//
+//  RACScheduler.m
+//  ReactiveCocoa
+//
+//  Created by Miķelis Vindavs on 5/27/14.
+//  Copyright (c) 2014 GitHub, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RACScheduler.h"
+
+/// An interface for use by subclasses.
+///
+/// Subclasses should use `-performAsCurrentScheduler:` to do the actual block
+/// invocation so that +[RACScheduler currentScheduler] behaves as expected.
+///
+/// **Note that RACSchedulers are expected to be serial**. Subclasses must honor
+/// that contract. See `RACTargetQueueScheduler` for a queue-based scheduler
+/// which will enforce the serialization guarantee.
+@interface RACScheduler (Subclass)
+
+/// Performs the given block with the receiver as the current scheduler for
+/// its thread. This should only be called by subclasses to perform their
+/// scheduled blocks.
+///
+/// block - The block to execute. Cannot be NULL.
+- (void)performAsCurrentScheduler:(void (^)(void))block;
+
+@end

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.m
@@ -188,6 +188,26 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 	}
 }
 
+- (void)performAsCurrentScheduler:(void (^)(void))block {
+	NSCParameterAssert(block != NULL);
+
+	// If we're using a concurrent queue, we could end up in here concurrently,
+	// in which case we *don't* want to clear the current scheduler immediately
+	// after our block is done executing, but only *after* all our concurrent
+	// invocations are done.
+
+	RACScheduler *previousScheduler = RACScheduler.currentScheduler;
+	NSThread.currentThread.threadDictionary[RACSchedulerCurrentSchedulerKey] = self;
+
+	block();
+
+	if (previousScheduler != nil) {
+		NSThread.currentThread.threadDictionary[RACSchedulerCurrentSchedulerKey] = previousScheduler;
+	} else {
+		[NSThread.currentThread.threadDictionary removeObjectForKey:RACSchedulerCurrentSchedulerKey];
+	}
+}
+
 @end
 
 @implementation RACScheduler (Deprecated)


### PR DESCRIPTION
See #1329 for rationale.

"RACBacktrace should trace across an NSOperationQueue" fails but it did so on master as well
