### PR TITLE
How to -retry: only matched error?

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -764,6 +764,14 @@ typedef enum : NSUInteger {
 /// Resubscribes to the receiving signal if an error occurs.
 - (RACSignal *)retry;
 
+/// Resubscribes to the receiving signal if an error occurs, up until it has
+/// retried the given number of times.
+///
+/// retryCount - if 0, it keeps retrying until it completes.
+/// errorMatchingBlock - retry only this block returns YES.
+///                      can be nil, and assumes it returns YES.
+- (RACSignal *)retry:(NSUInteger)retryCount matchingError:(BOOL (^)(NSError *error))errorMatchingBlock;
+
 /// Sends the latest value from the receiver only when `sampler` sends a value.
 /// The returned signal could repeat values if `sampler` fires more often than
 /// the receiver. Values from `sampler` are ignored before the receiver sends


### PR DESCRIPTION
How can I `-retry:` only some type of error?

With this patch, you can retry on time-out error only.

```
[signal retry:3 matchingError:^BOOL(NSError *error) {
    return [error.domain compare:NSURLErrorDomain] == 0 && error.code == NSURLErrorTimedOut;
}];
```

How do you think? Is there another recommended way without patch the core operators?
