### PR TITLE
Add UITableViewHeaderFooterView... to main header

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
@@ -83,6 +83,7 @@
 	#import "UISwitch+RACSupport.h"
 	#import "UITableView+RACSupport.h"
 	#import "UITableViewCell+RACSupport.h"
+	#import "UITableViewHeaderFooterView+RACSignalSupport.h"
 	#import "UITextField+RACSupport.h"
 	#import "UITextView+RACSupport.h"
 #elif TARGET_OS_MAC


### PR DESCRIPTION
The `UITableViewHeaderFooterView+RACSupport.h` header isn't included in the umbrella `ReactiveCocoa.h` header.
