### PR TITLE
Fix Xcode 6 compile error

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACReplaySubject.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACReplaySubject.m
@@ -33,7 +33,7 @@ const NSUInteger RACReplaySubjectUnlimitedCapacity = NSUIntegerMax;
 #pragma mark Lifecycle
 
 + (instancetype)replaySubjectWithCapacity:(NSUInteger)capacity {
-	return [[self alloc] initWithCapacity:capacity];
+	return [(RACReplaySubject *)[self alloc] initWithCapacity:capacity];
 }
 
 - (instancetype)init {


### PR DESCRIPTION
Multiple methods named 'initWithCapacity:' found, found in NSMutableArray (NSMutableArrayCreation) and NSMutableString (NSMutableStringExtensionMethods)
#1368
