### PR TITLE
Switch RACSignal primitives to map and flatten

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
@@ -20,6 +20,10 @@ extern const NSInteger RACSignalErrorTimedOut;
 /// match any of the cases, and no default was given.
 extern const NSInteger RACSignalErrorNoMatchingCase;
 
+/// The value to pass to -flatten:withPolicy: to flatten unlimited signals
+/// concurrently.
+extern const NSUInteger RACSignalUnlimitedConcurrentSubscriptions;
+
 /// A block which accepts a value from a RACSignal and returns a new signal.
 ///
 /// Setting `stop` to `YES` will cause the bind to terminate after the returned
@@ -458,7 +462,9 @@ typedef enum : NSUInteger {
 /// in Rx.
 ///
 /// maxConcurrent - The maximum number of signals to subscribe to at a
-///                 time. This must be greater than 0.
+///                 time. This must be greater than 0 or
+///                 RACSignalUnlimitedConcurrentSubscriptions to not enforce a
+///                 maximum number.
 /// policy        - Describes what to do when `maxConcurrent` is exceeded.
 ///
 /// Returns a signal that forwards values from up to `maxConcurrent` signals at

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.m
@@ -34,6 +34,7 @@ NSString * const RACSignalErrorDomain = @"RACSignalErrorDomain";
 
 const NSInteger RACSignalErrorTimedOut = 1;
 const NSInteger RACSignalErrorNoMatchingCase = 2;
+const NSUInteger RACSignalUnlimitedConcurrentSubscriptions = 0;
 
 @implementation RACSignal (Operations)
 
@@ -59,7 +60,7 @@ const NSInteger RACSignalErrorNoMatchingCase = 2;
 }
 
 - (RACSignal *)flatten {
-	return [self flatten:0 withPolicy:RACSignalFlattenPolicyQueue];
+	return [self flatten:RACSignalUnlimitedConcurrentSubscriptions withPolicy:RACSignalFlattenPolicyQueue];
 }
 
 - (RACSignal *)map:(id (^)(id value))block {
@@ -640,6 +641,8 @@ const NSInteger RACSignalErrorNoMatchingCase = 2;
 }
 
 - (RACSignal *)flatten:(NSUInteger)maxConcurrent withPolicy:(RACSignalFlattenPolicy)policy {
+	NSCParameterAssert(maxConcurrent > 0 || maxConcurrent == RACSignalUnlimitedConcurrentSubscriptions);
+
 	return [[RACSignal create:^(id<RACSubscriber> subscriber) {
 		// Contains disposables for the currently active subscriptions.
 		//


### PR DESCRIPTION
This changes `RACSignal` to use `-map:` as a primitive and have `-flattenMap:` be implemented in terms of `-map:` and `-flatten` rather than the other way around.

This allows `-concatMap:` and `-switchMap:` to not go through `-flattenMap:`, saving one signal transformation.

(To be clear `-concatMap:` and `-switchMap:` do not exist yet, but the patterns they represent do)
