### PR TITLE
Point more directly to the "What to do" part for Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ are some resources related to FRP:
 
 ReactiveCocoa also has a chat room on [Slack](https://slack.com/). If you'd like
 to join, just [provide your email
-address](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/871) and we'll
+address](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/871#issuecomment-44237545) and we'll
 happily send you an invite!
 
 [Basic Operators]: Documentation/BasicOperators.md


### PR DESCRIPTION
If you arrive at the top of that issue it's super confusing, link more towards the anchor where people are dropping in Emails
