### PR TITLE
Lift with a signal of tuples of arguments.

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
@@ -37,6 +37,10 @@
 /// a variadic list of arguments.
 - (RACSignal *)rac_liftSelector:(SEL)selector withSignalsFromArray:(NSArray *)signals;
 
+/// Like -rac_liftSelector:withSignals:, but accepts a signal sending tuples of
+/// arguments instead of a variadic list of arguments.
+- (RACSignal *)rac_liftSelector:(SEL)selector withSignalOfArguments:(RACSignal *)arguments;
+
 @end
 
 @interface NSObject (RACLiftingDeprecated)


### PR DESCRIPTION
I often have a signal sending tuples whose values are to be the arguments in some message; typically, I send these using `-rac_liftSelector:withSignals:` (vs. e.g. `-subscribeNext:`).

Unpacking these signals-of-tuples into the arguments to `-rac_liftSelector:withSignals:` distracts from the intent of the code, and is needless—RAC just goes and re-packs them into tuples anyway. Therefore, I’ve added the `rac_liftSelector:withSignalOfArguments:` method (which is called into from `-rac_liftSelector:withSignalsFromArray:`) to clarify this use case.

**Usage:**

``` objective-c
RACSignal *friendsAndNames = [RACObserve(self, friends)
    map:(Friend *friend) {
        return RACTuplePack(friend, friend.name);
    }];

[friendsByName rac_liftSelector:@selector(setObject:forKey:) withSignalOfArguments:friendsAndNames];
```
