### PR TITLE
The disposable was not added, so it was never called (Swift beta 3)

### DIFF
--- a/ReactiveCocoa/Disposable.swift
+++ b/ReactiveCocoa/Disposable.swift
@@ -81,14 +81,18 @@ struct CompositeDisposable: Disposable {
 			return
 		}
 	
-		let shouldDispose: Bool = _disposables.withValue {
-			if var ds = $0 {
-				ds.append(d!)
-				return false
-			} else {
-				return true
-			}
-		}
+        var shouldDispose = false
+        _disposables.modify {
+            if var ds = $0 {
+                ds.append(d!)
+                shouldDispose = false
+                return ds
+            }
+            else {
+                shouldDispose = true
+                return nil
+            }
+        }
 		
 		if shouldDispose {
 			d!.dispose()


### PR DESCRIPTION
Hello.

I do not know if it is a bug from current beta version of Swift or the `Atomic` implementation, but the value inside `_disposables` was not equal to `ds` (that is a copy, not a reference), so `d` was added to `ds` and not to `_disposables` value; therefore the `d` disposable was never called.

Congrat for the great work you are doing!
