### PR TITLE
Include RACEXTScope in ReactiveCocoa.h

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/ReactiveCocoa.h
@@ -7,6 +7,7 @@
 //
 
 #import "EXTKeyPathCoding.h"
+#import "RACEXTScope.h"
 #import "NSArray+RACSequenceAdditions.h"
 #import "NSData+RACSupport.h"
 #import "NSDictionary+RACSequenceAdditions.h"


### PR DESCRIPTION
`@weakify` and `@strongify` are used in the README examples so this should be in the frameworks header.
