### PR TITLE
subscribeErrorOrCompleted

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.h
@@ -157,6 +157,9 @@
 /// Convenience method to subscribe to `error` and `completed` events.
 - (RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock;
 
+/// Convenience method to subscribe to both `error` and `completed` events.
+- (RACDisposable *)subscribeErrorOrCompleted:(void(^)(NSError *errorOrNil))block;
+
 @end
 
 /// Additional methods to assist with debugging.

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSignal.m
@@ -332,6 +332,16 @@
 	return [self subscribe:o];
 }
 
+- (RACDisposable *)subscribeErrorOrCompleted:(void(^)(NSError *errorOrNil))block
+{
+	NSCParameterAssert(block != NULL);
+
+	RACSubscriber *o = [RACSubscriber subscriberWithNext:NULL error:block completed:^{
+		block(nil);
+	}];
+	return [self subscribe:o];
+}
+
 @end
 
 @implementation RACSignal (Debugging)


### PR DESCRIPTION
It is too tedious to write something like this over and over again

```
void (^onDone)() = ^{
    // do something
};

[signal subscribeError:^(NSError *error) {
    onDone();
} completed:^{
    onDone();
}];
```
