### PR TITLE
Don't use DEBUG for RACBacktrace

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.h
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 GitHub, Inc. All rights reserved.
 //
 
-#ifdef DEBUG
+#ifdef RAC_DEBUG_BACKTRACE
 
 extern void rac_dispatch_async(dispatch_queue_t queue, dispatch_block_t block);
 extern void rac_dispatch_barrier_async(dispatch_queue_t queue, dispatch_block_t block);

--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
@@ -12,7 +12,7 @@
 
 #define RAC_BACKTRACE_MAX_CALL_STACK_FRAMES 128
 
-#ifdef DEBUG
+#ifdef RAC_DEBUG_BACKTRACE
 
 // Undefine the macros that hide the real GCD functions.
 #undef dispatch_async

--- a/ReactiveCocoaFramework/ReactiveCocoaTests/RACBacktraceSpec.m
+++ b/ReactiveCocoaFramework/ReactiveCocoaTests/RACBacktraceSpec.m
@@ -14,7 +14,7 @@
 #import "RACSequence.h"
 #import "RACSignal+Operations.h"
 
-#ifdef DEBUG
+#ifdef RAC_DEBUG_BACKTRACE
 
 static RACBacktrace *previousBacktrace;
 


### PR DESCRIPTION
Guard `RACBacktrace` with `RAC_DEBUG_BACKTRACE` instead of `DEBUG`.

Fixes #1463.
