### PR TITLE
Support UIBarButtonItem with UIButton customView

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/UIBarButtonItem+RACCommandSupport.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 GitHub, Inc. All rights reserved.
 //
 
+#import "UIButton+RACCommandSupport.h"
 #import "UIBarButtonItem+RACCommandSupport.h"
 #import "EXTKeyPathCoding.h"
 #import "RACCommand.h"
@@ -23,6 +24,11 @@ static void *UIControlEnabledDisposableKey = &UIControlEnabledDisposableKey;
 }
 
 - (void)setRac_command:(RACCommand *)command {
+	if ([self.customView isKindOfClass:[UIButton class]]) {
+		UIButton *button = [self customView];
+		return [button setRac_command:command];
+	}
+		
 	objc_setAssociatedObject(self, UIControlRACCommandKey, command, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 	
 	// Check for stored signal in order to remove it and add a new one


### PR DESCRIPTION
In my application, I need to set up `rac_command` for UIBarButtonItem

``` objC
    UIImage *backImage = [UIImage imageNamed:@"back-arrow-button.png"];
    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
    [button setImage:backImage forState:UIControlStateNormal];
    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];

    self.navigationItem.leftBarButtonItem.rac_command = [[RACCommand alloc] initWithSignalBlock:^RACSignal *(id input) {
        return [RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
            // do some thing in here
            return nil;
        }];
    }];
```

But since UIBarButtonItem with customView does not support set `target` and `action`, so I need to make a new variable of class to store `self.button`

This fix will resolve this issue
