### PR TITLE
Fix: Crash on iOS5 in RacBacktrace #1321

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACBacktrace.m
@@ -147,7 +147,7 @@ static void RACExceptionHandler (NSException *ex) {
 
 + (void)load {
 	@autoreleasepool {
-		NSString *libraries = NSProcessInfo.processInfo.environment[@"DYLD_INSERT_LIBRARIES"];
+		NSString *libraries = [NSProcessInfo.processInfo.environment objectForKey:@"DYLD_INSERT_LIBRARIES"];
 
 		// Don't install our handlers if we're not actually intercepting function
 		// calls.


### PR DESCRIPTION
This fixes the crash on iOS 5. I know iOS 5 may not be supported, but the issue is still relevant. It crashes in the load method, which one cannot avoid even when not running any ReactiveCocoa code. Linking with ReactiveCocoa on projects with a iOS 5 deployment target is enough to make this crash on iOS 5 devices. This is relevant, if an application should still _run_ on iOS 5 (for example show some legacy UI or upgrade dialog or whatever) and at the same time be targeted for higher iOS versions.
