### PR TITLE
Add Promise.notify

### DIFF
--- a/ReactiveCocoa/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/ObjectiveCBridging.swift
@@ -157,11 +157,9 @@ extension Promise {
 	public func asReplayedRACSignal<U: AnyObject>(evidence: Promise<T> -> Promise<U>) -> RACSignal {
 		return RACSignal.createSignal { subscriber in
 			let evidencedSelf = evidence(self)
-			let selfDisposable = evidencedSelf.signal.observe { maybeResult in
-				if let result = maybeResult {
-					subscriber.sendNext(result)
-					subscriber.sendCompleted()
-				}
+			let selfDisposable = evidencedSelf.notify { result in
+				subscriber.sendNext(result)
+				subscriber.sendCompleted()
 			}
 
 			evidencedSelf.start()

--- a/ReactiveCocoa/Promise.swift
+++ b/ReactiveCocoa/Promise.swift
@@ -80,22 +80,35 @@ public final class Promise<T> {
 		return result
 	}
 
+	/// Performs the given action when the promise completes.
+	///
+	/// This method does not start the promise or block waiting for it.
+	///
+	/// Returns a Disposable that can be used to cancel the given action before
+	/// it occurs.
+	public func notify(action: T -> ()) -> Disposable {
+		let disposable = SerialDisposable()
+
+		disposable.innerDisposable = signal.observe { value in
+			if let value = value {
+				disposable.dispose()
+				action(value)
+			}
+		}
+
+		return disposable
+	}
+
 	/// Creates a Promise that will start the receiver, then run the given
 	/// action and forward the results.
 	public func then<U>(action: T -> Promise<U>) -> Promise<U> {
 		return Promise<U> { sink in
 			let disposable = SerialDisposable()
 
-			disposable.innerDisposable = self.signal.observe { maybeResult in
-				if maybeResult == nil {
-					return
-				}
-
-				let innerPromise = action(maybeResult!)
-				disposable.innerDisposable = innerPromise.signal.observe { maybeResult in
-					if let result = maybeResult {
-						sink.put(result)
-					}
+			disposable.innerDisposable = self.notify { result in
+				let innerPromise = action(result)
+				disposable.innerDisposable = innerPromise.notify { result in
+					sink.put(result)
 				}
 
 				innerPromise.start()


### PR DESCRIPTION
For use instead of `Promise.signal.observe`, which is obtuse and error-prone (because it'll send `nil` too). Also improved disposal semantics within the `Promise` class.
