### PR TITLE
Fix retain cycle in -didSubscribeWithDisposable:

### DIFF
--- a/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.m
+++ b/ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.m
@@ -99,9 +99,12 @@
 	RACCompoundDisposable *selfDisposable = self.disposable;
 	[selfDisposable addDisposable:otherDisposable];
 
+	@unsafeify(otherDisposable);
+
 	// If this subscription terminates, purge its disposable to avoid unbounded
 	// memory growth.
 	[otherDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+		@strongify(otherDisposable);
 		[selfDisposable removeDisposable:otherDisposable];
 	}]];
 }


### PR DESCRIPTION
`otherDisposable` can't create a cycle with itself, just in case it's never disposed of.

Fixes the retain cycle introduced & described in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1500#discussion_r17882872.
