### PR TITLE
Allow promises to resolve even after the promise itself deallocates

### DIFF
--- a/ReactiveCocoa/Promise.swift
+++ b/ReactiveCocoa/Promise.swift
@@ -46,27 +46,22 @@ public final class Promise<T> {
 	/// Starts the promise (if necessary), then blocks indefinitely on the
 	/// result.
 	public func await() -> T {
-		let cond = NSCondition()
-		cond.name = "com.github.ReactiveCocoa.Promise.await"
+		let semaphore = dispatch_semaphore_create(0)
+		let disposable = SerialDisposable()
 
-		let disposable = signal.observe { _ in
-			cond.lock()
-			cond.signal()
-			cond.unlock()
+		var observedValue: T? = nil
+		disposable.innerDisposable = signal.observe { value in
+			if let value = value {
+				observedValue = value
+				dispatch_semaphore_signal(semaphore)
+				disposable.dispose()
+			}
 		}
 
 		start()
+		dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
 
-		cond.lock()
-		while signal.current == nil {
-			cond.wait()
-		}
-
-		let result = signal.current!
-		cond.unlock()
-
-		disposable.dispose()
-		return result
+		return observedValue!
 	}
 
 	/// Performs the given action when the promise completes.


### PR DESCRIPTION
This way, you can pull out its `signal`, and fully expect it to provide a value in the future, even if the original `Promise` has since disappeared.

Also fixed a deadlock in `Promise.await()`.
