### PR TITLE
Update to the latest LlamaKit

### DIFF
--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -165,7 +165,7 @@ extension ColdSignal {
 			return .single(value.unbox)
 
 		case let .Failure(error):
-			return .error(error)
+			return .error(error as NSError)
 		}
 	}
 }
@@ -541,7 +541,7 @@ extension ColdSignal {
 					return .single(box.unbox)
 
 				case let .Failure(error):
-					return .error(error)
+					return .error(error as NSError)
 				}
 			}
 			.merge(identity)


### PR DESCRIPTION
The latest LlamaKit .Error uses ErrorType protocol instead of straight NSError.

Should we have a precondition (or something?) that ensures the object is actually an NSError?