### PR TITLE
Update requirements to iOS 8.0 and OS X 10.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ RACSequence *results = [[strings.rac_sequence
 
 ## System Requirements
 
-ReactiveCocoa supports OS X 10.8+ and iOS 6.0+.
+ReactiveCocoa supports OS X 10.8+ and iOS 8.0+.
 
 ## Importing ReactiveCocoa
 


### PR DESCRIPTION
It looks like the Xcode project specifies a minimum or OS X 10.8 SDK, and uses iOS 6.0+ only features (strong properties with a type of `dispatch_queue_t`) but specifies iOS 8.0 for the dynamic framework. If nobody is developing RAC against iOS 7.x, it's not really supported anymore, is it?
