### PR TITLE
Make file, function, and line properties internal

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -36,13 +36,13 @@ public final class Action<Input, Output> {
 	public let errors: HotSignal<NSError>
 
 	/// The file in which this action was defined, if known.
-	public let file: String?
+	internal let file: String?
 
 	/// The function in which this action was defined, if known.
-	public let function: String?
+	internal let function: String?
 
 	/// The line number upon which this action was defined, if known.
-	public let line: Int?
+	internal let line: Int?
 
 	/// Initializes an action that will be conditionally enabled, and create
 	/// a ColdSignal for each execution.

--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -129,13 +129,13 @@ public struct ColdSignal<T> {
 	public typealias Generator = (SinkOf<Element>, CompositeDisposable) -> ()
 
 	/// The file in which this signal was defined, if known.
-	public let file: String?
+	internal let file: String?
 
 	/// The function in which this signal was defined, if known.
-	public let function: String?
+	internal let function: String?
 
 	/// The line number upon which this signal was defined, if known.
-	public let line: Int?
+	internal let line: Int?
 
 	private let generator: Generator
 

--- a/ReactiveCocoa/Swift/HotSignal.swift
+++ b/ReactiveCocoa/Swift/HotSignal.swift
@@ -15,13 +15,13 @@ public final class HotSignal<T> {
 	private var disposable: Disposable?
 
 	/// The file in which this signal was defined, if known.
-	public let file: String?
+	internal let file: String?
 
 	/// The function in which this signal was defined, if known.
-	public let function: String?
+	internal let function: String?
 
 	/// The line number upon which this signal was defined, if known.
-	public let line: Int?
+	internal let line: Int?
 
 	/// Initializes a signal that will immediately perform the given action to
 	/// begin generating its values.

--- a/ReactiveCocoa/Swift/ObservableProperty.swift
+++ b/ReactiveCocoa/Swift/ObservableProperty.swift
@@ -15,13 +15,13 @@ public final class ObservableProperty<T> {
 	private var sinks = Bag<SinkOf<Event<T>>>()
 
 	/// The file in which this property was defined, if known.
-	public let file: String?
+	internal let file: String?
 
 	/// The function in which this property was defined, if known.
-	public let function: String?
+	internal let function: String?
 
 	/// The line number upon which this property was defined, if known.
-	public let line: Int?
+	internal let line: Int?
 
 	/// The current value of the property.
 	///


### PR DESCRIPTION
Consumers shouldn’t really need these, they’ll pollute any published documentation, and we shouldn’t need to worry about backwards compatibility for them.
