### PR TITLE
KVO via singleton proxy, redux

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07CD36E91A34B1DD00917FB6 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CD36E71A34B1DD00917FB6 /* RACKVOProxy.h */; };
+		07CD36EA1A34B1DD00917FB6 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CD36E71A34B1DD00917FB6 /* RACKVOProxy.h */; };
+		07CD36EB1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36E81A34B1DD00917FB6 /* RACKVOProxy.m */; };
+		07CD36EC1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36E81A34B1DD00917FB6 /* RACKVOProxy.m */; };
+		07CD36EE1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36ED1A34B20300917FB6 /* RACKVOProxySpec.m */; };
+		07CD36EF1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36ED1A34B20300917FB6 /* RACKVOProxySpec.m */; };
 		D01B7B6219EDD8FE00D26E01 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D05E662419EDD82000904ACA /* Nimble.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D01B7B6319EDD8FE00D26E01 /* Quick.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D037672B19EDA75D00A782A9 /* Quick.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D01B7B6419EDD94B00D26E01 /* ReactiveCocoa.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D047260C19E49F82006002AA /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -431,6 +437,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		07CD36E71A34B1DD00917FB6 /* RACKVOProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACKVOProxy.h; sourceTree = "<group>"; };
+		07CD36E81A34B1DD00917FB6 /* RACKVOProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxy.m; sourceTree = "<group>"; };
+		07CD36ED1A34B20300917FB6 /* RACKVOProxySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxySpec.m; sourceTree = "<group>"; };
 		D037642A19EDA41200A782A9 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		D037642B19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		D037642C19EDA41200A782A9 /* NSControl+RACCommandSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSControl+RACCommandSupport.h"; sourceTree = "<group>"; };
@@ -1168,6 +1177,7 @@
 				D04725F019E49ED7006002AA /* ReactiveCocoa.h in Headers */,
 				D037652019EDA41200A782A9 /* NSObject+RACLifting.h in Headers */,
 				D03764EC19EDA41200A782A9 /* NSControl+RACCommandSupport.h in Headers */,
+				07CD36E91A34B1DD00917FB6 /* RACKVOProxy.h in Headers */,
 				D037655C19EDA41200A782A9 /* RACChannel.h in Headers */,
 				D03765EE19EDA41200A782A9 /* RACSubscriber.h in Headers */,
 				D03765D219EDA41200A782A9 /* RACSignal.h in Headers */,
@@ -1228,6 +1238,7 @@
 				D037664519EDA41200A782A9 /* UISegmentedControl+RACSignalSupport.h in Headers */,
 				D037666419EDA43C00A782A9 /* ReactiveCocoa.h in Headers */,
 				D037652519EDA41200A782A9 /* NSObject+RACPropertySubscribing.h in Headers */,
+				07CD36EA1A34B1DD00917FB6 /* RACKVOProxy.h in Headers */,
 				D03765B119EDA41200A782A9 /* RACQueueScheduler.h in Headers */,
 				D037662519EDA41200A782A9 /* UIButton+RACCommandSupport.h in Headers */,
 				D037672819EDA63500A782A9 /* RACBehaviorSubject.h in Headers */,
@@ -1499,6 +1510,7 @@
 				D037651219EDA41200A782A9 /* NSObject+RACAppKitBindings.m in Sources */,
 				D037656619EDA41200A782A9 /* RACCompoundDisposable.m in Sources */,
 				D037655A19EDA41200A782A9 /* RACBlockTrampoline.m in Sources */,
+				07CD36EB1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */,
 				D037659019EDA41200A782A9 /* RACGroupedSignal.m in Sources */,
 				D037655E19EDA41200A782A9 /* RACChannel.m in Sources */,
 				D037657C19EDA41200A782A9 /* RACEagerSequence.m in Sources */,
@@ -1555,6 +1567,7 @@
 				D037670D19EDA60000A782A9 /* RACTestExampleScheduler.m in Sources */,
 				D03766ED19EDA60000A782A9 /* RACMulticastConnectionSpec.m in Sources */,
 				D03766E919EDA60000A782A9 /* RACKVOChannelSpec.m in Sources */,
+				07CD36EE1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */,
 				D03766FB19EDA60000A782A9 /* RACSignalSpec.m in Sources */,
 				D037670719EDA60000A782A9 /* RACSubscriberSpec.m in Sources */,
 				D03766EF19EDA60000A782A9 /* RACPropertySignalExamples.m in Sources */,
@@ -1632,6 +1645,7 @@
 				D037660F19EDA41200A782A9 /* RACUnarySequence.m in Sources */,
 				D03765FF19EDA41200A782A9 /* RACTargetQueueScheduler.m in Sources */,
 				D03765DF19EDA41200A782A9 /* RACSignalSequence.m in Sources */,
+				07CD36EC1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */,
 				D037656D19EDA41200A782A9 /* RACDelegateProxy.m in Sources */,
 				D037657519EDA41200A782A9 /* RACDynamicSequence.m in Sources */,
 				D037657119EDA41200A782A9 /* RACDisposable.m in Sources */,
@@ -1701,6 +1715,7 @@
 				D037670219EDA60000A782A9 /* RACSubclassObject.m in Sources */,
 				D03766CE19EDA60000A782A9 /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,
 				D037671619EDA60000A782A9 /* RACTupleSpec.m in Sources */,
+				07CD36EF1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */,
 				D03766C619EDA60000A782A9 /* NSObjectRACLiftingSpec.m in Sources */,
 				D03766D219EDA60000A782A9 /* NSURLConnectionRACSupportSpec.m in Sources */,
 				D03766F419EDA60000A782A9 /* RACSequenceAdditionsSpec.m in Sources */,

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,12 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		07CD36E91A34B1DD00917FB6 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CD36E71A34B1DD00917FB6 /* RACKVOProxy.h */; };
-		07CD36EA1A34B1DD00917FB6 /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CD36E71A34B1DD00917FB6 /* RACKVOProxy.h */; };
-		07CD36EB1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36E81A34B1DD00917FB6 /* RACKVOProxy.m */; };
-		07CD36EC1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36E81A34B1DD00917FB6 /* RACKVOProxy.m */; };
-		07CD36EE1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36ED1A34B20300917FB6 /* RACKVOProxySpec.m */; };
-		07CD36EF1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 07CD36ED1A34B20300917FB6 /* RACKVOProxySpec.m */; };
+		7A7065811A3F88B8001E8354 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */; };
+		7A7065821A3F88B8001E8354 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */; };
+		7A7065841A3F8967001E8354 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */; };
+		7A7065851A3F8967001E8354 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */; };
 		D01B7B6219EDD8FE00D26E01 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D05E662419EDD82000904ACA /* Nimble.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D01B7B6319EDD8FE00D26E01 /* Quick.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D037672B19EDA75D00A782A9 /* Quick.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D01B7B6419EDD94B00D26E01 /* ReactiveCocoa.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D047260C19E49F82006002AA /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -437,9 +435,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		07CD36E71A34B1DD00917FB6 /* RACKVOProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACKVOProxy.h; sourceTree = "<group>"; };
-		07CD36E81A34B1DD00917FB6 /* RACKVOProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxy.m; sourceTree = "<group>"; };
-		07CD36ED1A34B20300917FB6 /* RACKVOProxySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxySpec.m; sourceTree = "<group>"; };
+		7A70657D1A3F88B8001E8354 /* RACKVOProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACKVOProxy.h; sourceTree = "<group>"; };
+		7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxy.m; sourceTree = "<group>"; };
+		7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxySpec.m; sourceTree = "<group>"; };
 		D037642A19EDA41200A782A9 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		D037642B19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		D037642C19EDA41200A782A9 /* NSControl+RACCommandSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSControl+RACCommandSupport.h"; sourceTree = "<group>"; };
@@ -858,6 +856,8 @@
 				D037648219EDA41200A782A9 /* RACIndexSetSequence.m */,
 				D037648319EDA41200A782A9 /* RACKVOChannel.h */,
 				D037648419EDA41200A782A9 /* RACKVOChannel.m */,
+				7A70657D1A3F88B8001E8354 /* RACKVOProxy.h */,
+				7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */,
 				D037648519EDA41200A782A9 /* RACKVOTrampoline.h */,
 				D037648619EDA41200A782A9 /* RACKVOTrampoline.m */,
 				D037648719EDA41200A782A9 /* RACMulticastConnection.h */,
@@ -1002,6 +1002,7 @@
 				D037668F19EDA60000A782A9 /* RACDisposableSpec.m */,
 				D037669019EDA60000A782A9 /* RACEventSpec.m */,
 				D037669119EDA60000A782A9 /* RACKVOChannelSpec.m */,
+				7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */,
 				D037669219EDA60000A782A9 /* RACKVOWrapperSpec.m */,
 				D037669319EDA60000A782A9 /* RACMulticastConnectionSpec.m */,
 				D037669419EDA60000A782A9 /* RACPropertySignalExamples.h */,
@@ -1024,12 +1025,12 @@
 				D03766A719EDA60000A782A9 /* RACSubscriptingAssignmentTrampolineSpec.m */,
 				D03766A819EDA60000A782A9 /* RACTargetQueueSchedulerSpec.m */,
 				D03766B019EDA60000A782A9 /* RACTupleSpec.m */,
+				D037673819EDCA0E00A782A9 /* SwiftSpec.swift */,
 				D03766B219EDA60000A782A9 /* UIActionSheetRACSupportSpec.m */,
 				D03766B319EDA60000A782A9 /* UIAlertViewRACSupportSpec.m */,
 				D03766B419EDA60000A782A9 /* UIBarButtonItemRACSupportSpec.m */,
 				D03766B519EDA60000A782A9 /* UIButtonRACSupportSpec.m */,
 				D03766B719EDA60000A782A9 /* UIImagePickerControllerRACSupportSpec.m */,
-				D037673819EDCA0E00A782A9 /* SwiftSpec.swift */,
 			);
 			name = Specs;
 			sourceTree = "<group>";
@@ -1177,7 +1178,6 @@
 				D04725F019E49ED7006002AA /* ReactiveCocoa.h in Headers */,
 				D037652019EDA41200A782A9 /* NSObject+RACLifting.h in Headers */,
 				D03764EC19EDA41200A782A9 /* NSControl+RACCommandSupport.h in Headers */,
-				07CD36E91A34B1DD00917FB6 /* RACKVOProxy.h in Headers */,
 				D037655C19EDA41200A782A9 /* RACChannel.h in Headers */,
 				D03765EE19EDA41200A782A9 /* RACSubscriber.h in Headers */,
 				D03765D219EDA41200A782A9 /* RACSignal.h in Headers */,
@@ -1238,7 +1238,6 @@
 				D037664519EDA41200A782A9 /* UISegmentedControl+RACSignalSupport.h in Headers */,
 				D037666419EDA43C00A782A9 /* ReactiveCocoa.h in Headers */,
 				D037652519EDA41200A782A9 /* NSObject+RACPropertySubscribing.h in Headers */,
-				07CD36EA1A34B1DD00917FB6 /* RACKVOProxy.h in Headers */,
 				D03765B119EDA41200A782A9 /* RACQueueScheduler.h in Headers */,
 				D037662519EDA41200A782A9 /* UIButton+RACCommandSupport.h in Headers */,
 				D037672819EDA63500A782A9 /* RACBehaviorSubject.h in Headers */,
@@ -1510,12 +1509,12 @@
 				D037651219EDA41200A782A9 /* NSObject+RACAppKitBindings.m in Sources */,
 				D037656619EDA41200A782A9 /* RACCompoundDisposable.m in Sources */,
 				D037655A19EDA41200A782A9 /* RACBlockTrampoline.m in Sources */,
-				07CD36EB1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */,
 				D037659019EDA41200A782A9 /* RACGroupedSignal.m in Sources */,
 				D037655E19EDA41200A782A9 /* RACChannel.m in Sources */,
 				D037657C19EDA41200A782A9 /* RACEagerSequence.m in Sources */,
 				D037657819EDA41200A782A9 /* RACDynamicSignal.m in Sources */,
 				D037659419EDA41200A782A9 /* RACImmediateScheduler.m in Sources */,
+				7A7065811A3F88B8001E8354 /* RACKVOProxy.m in Sources */,
 				D037651619EDA41200A782A9 /* NSObject+RACDeallocating.m in Sources */,
 				D037658419EDA41200A782A9 /* RACEmptySignal.m in Sources */,
 				D037654619EDA41200A782A9 /* NSURLConnection+RACSupport.m in Sources */,
@@ -1567,8 +1566,8 @@
 				D037670D19EDA60000A782A9 /* RACTestExampleScheduler.m in Sources */,
 				D03766ED19EDA60000A782A9 /* RACMulticastConnectionSpec.m in Sources */,
 				D03766E919EDA60000A782A9 /* RACKVOChannelSpec.m in Sources */,
-				07CD36EE1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */,
 				D03766FB19EDA60000A782A9 /* RACSignalSpec.m in Sources */,
+				7A7065841A3F8967001E8354 /* RACKVOProxySpec.m in Sources */,
 				D037670719EDA60000A782A9 /* RACSubscriberSpec.m in Sources */,
 				D03766EF19EDA60000A782A9 /* RACPropertySignalExamples.m in Sources */,
 				D03766D519EDA60000A782A9 /* RACBacktraceSpec.m in Sources */,
@@ -1645,7 +1644,6 @@
 				D037660F19EDA41200A782A9 /* RACUnarySequence.m in Sources */,
 				D03765FF19EDA41200A782A9 /* RACTargetQueueScheduler.m in Sources */,
 				D03765DF19EDA41200A782A9 /* RACSignalSequence.m in Sources */,
-				07CD36EC1A34B1DD00917FB6 /* RACKVOProxy.m in Sources */,
 				D037656D19EDA41200A782A9 /* RACDelegateProxy.m in Sources */,
 				D037657519EDA41200A782A9 /* RACDynamicSequence.m in Sources */,
 				D037657119EDA41200A782A9 /* RACDisposable.m in Sources */,
@@ -1682,6 +1680,7 @@
 				D037652F19EDA41200A782A9 /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
 				D037662719EDA41200A782A9 /* UIButton+RACCommandSupport.m in Sources */,
 				D037652719EDA41200A782A9 /* NSObject+RACPropertySubscribing.m in Sources */,
+				7A7065821A3F88B8001E8354 /* RACKVOProxy.m in Sources */,
 				D037658D19EDA41200A782A9 /* RACEvent.m in Sources */,
 				D03765B319EDA41200A782A9 /* RACQueueScheduler.m in Sources */,
 				D037655319EDA41200A782A9 /* RACBacktrace.m in Sources */,
@@ -1715,7 +1714,7 @@
 				D037670219EDA60000A782A9 /* RACSubclassObject.m in Sources */,
 				D03766CE19EDA60000A782A9 /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,
 				D037671619EDA60000A782A9 /* RACTupleSpec.m in Sources */,
-				07CD36EF1A34B20300917FB6 /* RACKVOProxySpec.m in Sources */,
+				7A7065851A3F8967001E8354 /* RACKVOProxySpec.m in Sources */,
 				D03766C619EDA60000A782A9 /* NSObjectRACLiftingSpec.m in Sources */,
 				D03766D219EDA60000A782A9 /* NSURLConnectionRACSupportSpec.m in Sources */,
 				D03766F419EDA60000A782A9 /* RACSequenceAdditionsSpec.m in Sources */,

--- a/ReactiveCocoa/RACKVOProxy.h
+++ b/ReactiveCocoa/RACKVOProxy.h
@@ -1,0 +1,43 @@
+//
+//  RACKVOProxy.h
+//  ReactiveCocoa
+//
+//  Created by Richard Speyer on 4/10/14.
+//  Copyright (c) 2014 GitHub, Inc. All rights reserved.
+//
+
+// A private singleton proxy object known only to RACKVOTrampoline
+// The purpose of this class is to act as a proxy between a KVO-observation
+// and the RAC subscriber in order to protect against various crashes
+// that can occur when observation is occuring on a different thread
+// than the value is being changed
+//
+// When someone creates a RACObserve, RACKVOTrampoline will
+// pass RACKVOProxy.instance as the observer to KVO rather than itself,
+// and then will register themselves with the proxy
+
+#import <Foundation/Foundation.h>
+
+@interface RACKVOProxy : NSObject
++ (RACKVOProxy *)instance;
+
+// Registers an observer (RACKVOTrampoline) with the proxy, such that
+// when the proxy receives a KVO change with the given context, it forwards
+// it to the observer
+//
+// observer - True observer of the KVO change
+// context  - Arbitrary context object used to differentiate multiple
+//            observations of the same keypath.
+//            Must be unique; cannot be nil
+- (void)addObserver:(NSObject *)observer forContext:(void *)context;
+
+// Remove an existing observer (RACKVOTrampoline) from the proxy. This
+// is done when the trampoline is being disposed. Parameters must
+// match those passed to addObserver:forContext:
+//
+// observer - True observer of the KVO change
+// context  - Arbitrary context object used to differentiate multiple
+//            observations of the same keypath.
+//            Must be unique; cannot be nil
+- (void)removeObserver:(NSObject *)observer forContext:(void *)context;
+@end

--- a/ReactiveCocoa/RACKVOProxy.h
+++ b/ReactiveCocoa/RACKVOProxy.h
@@ -6,38 +6,29 @@
 //  Copyright (c) 2014 GitHub, Inc. All rights reserved.
 //
 
-// A private singleton proxy object known only to RACKVOTrampoline
-// The purpose of this class is to act as a proxy between a KVO-observation
-// and the RAC subscriber in order to protect against various crashes
-// that can occur when observation is occuring on a different thread
-// than the value is being changed
-//
-// When someone creates a RACObserve, RACKVOTrampoline will
-// pass RACKVOProxy.instance as the observer to KVO rather than itself,
-// and then will register themselves with the proxy
-
 #import <Foundation/Foundation.h>
 
+/// A singleton that can act as a proxy between a KVO observation and a RAC
+/// subscriber, in order to protect against KVO lifetime issues.
 @interface RACKVOProxy : NSObject
-+ (RACKVOProxy *)instance;
 
-// Registers an observer (RACKVOTrampoline) with the proxy, such that
-// when the proxy receives a KVO change with the given context, it forwards
-// it to the observer
-//
-// observer - True observer of the KVO change
-// context  - Arbitrary context object used to differentiate multiple
-//            observations of the same keypath.
-//            Must be unique; cannot be nil
-- (void)addObserver:(NSObject *)observer forContext:(void *)context;
+/// Returns the singleton KVO proxy object.
++ (instancetype)sharedProxy;
 
-// Remove an existing observer (RACKVOTrampoline) from the proxy. This
-// is done when the trampoline is being disposed. Parameters must
-// match those passed to addObserver:forContext:
-//
-// observer - True observer of the KVO change
-// context  - Arbitrary context object used to differentiate multiple
-//            observations of the same keypath.
-//            Must be unique; cannot be nil
+/// Registers an observer with the proxy, such that when the proxy receives a
+/// KVO change with the given context, it forwards it to the observer.
+///
+/// observer - True observer of the KVO change. Must not be nil.
+/// context  - Arbitrary context object used to differentiate multiple
+///            observations of the same keypath. Must be unique, cannot be nil.
+- (void)addObserver:(__weak NSObject *)observer forContext:(void *)context;
+
+/// Removes an observer from the proxy. Parameters must match those passed to
+/// addObserver:forContext:.
+///
+/// observer - True observer of the KVO change. Must not be nil.
+/// context  - Arbitrary context object used to differentiate multiple
+///            observations of the same keypath. Must be unique, cannot be nil.
 - (void)removeObserver:(NSObject *)observer forContext:(void *)context;
+
 @end

--- a/ReactiveCocoa/RACKVOProxy.m
+++ b/ReactiveCocoa/RACKVOProxy.m
@@ -1,0 +1,62 @@
+//
+//  RACKVOProxy.m
+//  ReactiveCocoa
+//
+//  Created by Richard Speyer on 4/10/14.
+//  Copyright (c) 2014 GitHub, Inc. All rights reserved.
+//
+
+#import "RACKVOProxy.h"
+
+@interface RACKVOProxy()
+@property(strong, nonatomic, readonly) NSMapTable *trampolines;
+@end
+
+@implementation RACKVOProxy
+
++ (RACKVOProxy *)instance {
+    static RACKVOProxy *proxy;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        proxy = [[RACKVOProxy alloc] init];
+    });
+    
+    return proxy;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self == nil) return nil;
+    _trampolines = [NSMapTable strongToWeakObjectsMapTable];
+    return self;
+}
+
+- (void)addObserver:(NSObject *)observer forContext:(void *)context {
+    NSValue *valueContext = [NSValue valueWithPointer:context];
+    @synchronized (self) {
+        [self.trampolines setObject:observer forKey:valueContext];
+    }
+}
+
+- (void)removeObserver:(NSObject *)observer forContext:(void *)context {
+    NSValue *valueContext = [NSValue valueWithPointer:context];
+    @synchronized (self) {
+        [self.trampolines removeObjectForKey:valueContext];
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+    NSValue *valueContext = [NSValue valueWithPointer:context];
+    NSObject *trueObserver;
+    @synchronized (self) {
+        trueObserver = [self.trampolines objectForKey:valueContext];
+    }
+    if (trueObserver) {
+        [trueObserver observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
+    else {
+        NSLog(@"observer of \"%@\" on %@ is gone", keyPath, object);
+    }
+}
+
+@end

--- a/ReactiveCocoa/RACKVOTrampoline.m
+++ b/ReactiveCocoa/RACKVOTrampoline.m
@@ -46,10 +46,9 @@
 	_unsafeTarget = strongTarget;
 	_observer = observer;
 
-	RACKVOProxy *proxy = RACKVOProxy.instance;
-	[proxy addObserver:self forContext:(__bridge void *)self];
+	[RACKVOProxy.sharedProxy addObserver:self forContext:(__bridge void *)self];
+	[strongTarget addObserver:RACKVOProxy.sharedProxy forKeyPath:self.keyPath options:options context:(__bridge void *)self];
 
-	[strongTarget addObserver:proxy forKeyPath:self.keyPath options:options context:(__bridge void *)self];
 	[strongTarget.rac_deallocDisposable addDisposable:self];
 	[self.observer.rac_deallocDisposable addDisposable:self];
 
@@ -83,10 +82,8 @@
 	[target.rac_deallocDisposable removeDisposable:self];
 	[observer.rac_deallocDisposable removeDisposable:self];
 
-	RACKVOProxy *proxy = RACKVOProxy.instance;
-	[proxy removeObserver:self forContext:(__bridge void *)self];
-
-	[target removeObserver:proxy forKeyPath:self.keyPath context:(__bridge void *)self];
+	[target removeObserver:RACKVOProxy.sharedProxy forKeyPath:self.keyPath context:(__bridge void *)self];
+	[RACKVOProxy.sharedProxy removeObserver:self forContext:(__bridge void *)self];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {

--- a/ReactiveCocoaTests/RACKVOProxySpec.m
+++ b/ReactiveCocoaTests/RACKVOProxySpec.m
@@ -20,9 +20,7 @@
 
 @interface TestObject : NSObject
 
-@property (assign, nonatomic) int testInt;
-@property (copy, nonatomic) NSString *testString;
-@property (strong, nonatomic) TestObject *childObject;
+@property (assign, atomic) int testInt;
 
 @end
 
@@ -165,7 +163,7 @@ qck_describe(@"RACKVOProxy", ^{
 				[[disposable swapInDisposable:newDisposable] dispose];
 
 				dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-					testObject.testInt++;
+					testObject.testInt = (int)index;
 				});
 			});
 

--- a/ReactiveCocoaTests/RACKVOProxySpec.m
+++ b/ReactiveCocoaTests/RACKVOProxySpec.m
@@ -18,13 +18,32 @@
 #import "RACScheduler.h"
 #import "RACSubject.h"
 
-@interface TestObject : NSObject
+@interface TestObject : NSObject {
+	volatile int _testInt;
+}
 
 @property (assign, atomic) int testInt;
 
 @end
 
 @implementation TestObject
+
+- (int)testInt {
+	return _testInt;
+}
+
+// Use manual KVO notifications to avoid any possible race conditions within the
+// automatic KVO implementation.
+- (void)setTestInt:(int)value {
+	[self willChangeValueForKey:@keypath(self.testInt)];
+	_testInt = value;
+	[self didChangeValueForKey:@keypath(self.testInt)];
+}
+
++ (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {
+	return NO;
+}
+
 @end
 
 QuickSpecBegin(RACKVOProxySpec)

--- a/ReactiveCocoaTests/RACKVOProxySpec.m
+++ b/ReactiveCocoaTests/RACKVOProxySpec.m
@@ -1,0 +1,192 @@
+//
+//  RACKVOProxySpec.m
+//  ReactiveCocoa
+//
+//  Created by Richard Speyer on 4/24/14.
+//  Copyright (c) 2014 GitHub, Inc. All rights reserved.
+//
+
+#import "RACKVOProxy.h"
+
+#import "NSObject+RACKVOWrapper.h"
+#import "NSObject+RACPropertySubscribing.h"
+#import "RACDisposable.h"
+#import "RACSignal+Operations.h"
+#import "RACScheduler.h"
+#import "RACSubject.h"
+
+@interface TestObject : NSObject
+@property(nonatomic) int testInt;
+@property(strong, nonatomic) NSString *testString;
+@property(strong, nonatomic) TestObject *childObject;
+@end
+
+@implementation TestObject
+@end
+
+SpecBegin(RACKVOProxy)
+describe(@"racproxyobserve", ^{
+	__block TestObject *testObject;
+	
+	beforeEach(^{
+		testObject = [[TestObject alloc] init];
+	});
+	
+	afterEach(^{
+		testObject = nil;
+	});
+	
+	describe(@"basic", ^{
+		it (@"should handle multiple observations on the same value", ^{
+			__block int observedValue1 = 0;
+			__block int observedValue2 = 0;
+			[[[RACObserve(testObject, testInt)
+				skip:1]
+				take:1]
+				subscribeNext:^(NSNumber *wrappedInt) {
+					observedValue1 = wrappedInt.intValue;
+				}];
+			
+			[[[RACObserve(testObject, testInt)
+				skip:1]
+				take:1]
+				subscribeNext:^(NSNumber *wrappedInt) {
+					observedValue2 = wrappedInt.intValue;
+				}];
+			
+			testObject.testInt = 2;
+			
+			EXP_expect(observedValue1).will.equal(testObject.testInt);
+			EXP_expect(observedValue2).will.equal(testObject.testInt);
+		});
+		
+		it (@"can remove individual observation", ^{
+			__block int observedValue1 = 0;
+			__block int observedValue2 = 0;
+			RACDisposable *disposable1 = [RACObserve(testObject, testInt)
+										  subscribeNext:^(NSNumber *wrappedInt) {
+											  observedValue1 = wrappedInt.intValue;
+										  }];
+			
+			[RACObserve(testObject, testInt)
+			 subscribeNext:^(NSNumber *wrappedInt) {
+				 observedValue2 = wrappedInt.intValue;
+			 }];
+			
+			testObject.testInt = 2;
+			
+			EXP_expect(observedValue1).will.equal(testObject.testInt);
+			EXP_expect(observedValue2).will.equal(testObject.testInt);
+			
+			[disposable1 dispose];
+			
+			testObject.testInt = 3;
+			
+			EXP_expect(observedValue2).will.equal(testObject.testInt);
+			EXP_expect(observedValue1).toNot.equal(testObject.testInt);
+			
+		});
+	});
+	
+	describe(@"async", ^{
+		it(@"should handle changes being made on another queue", ^AsyncBlock{
+			__block int observedValue = 0;
+			[[[RACObserve(testObject, testInt)
+				skip:1]
+				take:1]
+				subscribeNext:^(NSNumber *wrappedInt) {
+					observedValue = wrappedInt.intValue;
+				}];
+			
+			dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+				testObject.testInt = 2;
+				EXP_expect(observedValue).will.equal(testObject.testInt);
+				done();
+			});
+		});
+		
+		it(@"should handle changes being made on another queue using deliverOn", ^AsyncBlock{
+			__block int observedValue = 0;
+			[[[[RACObserve(testObject, testInt)
+				skip:1]
+				take:1]
+				deliverOn:[RACScheduler mainThreadScheduler]]
+				subscribeNext:^(NSNumber *wrappedInt) {
+					observedValue = wrappedInt.intValue;
+				}];
+			
+			dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+				testObject.testInt = 2;
+				
+				EXP_expect(observedValue).will.equal(testObject.testInt);
+				done();
+			});
+		});
+		
+		it(@"async disposal of target", ^AsyncBlock{
+			__block int observedValue;
+			[[RACObserve(testObject, testInt)
+				deliverOn:RACScheduler.mainThreadScheduler]
+				subscribeNext:^(NSNumber *wrappedInt) {
+					observedValue = wrappedInt.intValue;
+				}];
+			
+			dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+				testObject.testInt = 2;
+				testObject = nil;
+				done();
+			});
+		});
+	});
+	
+	describe(@"stress", ^{
+		int numIterations = 5000;
+		it(@"async disposal of observer reactivecocoa/1122", ^{
+			__block int observedValue;
+			__block RACDisposable *dispose;
+			for (int i=0; i< numIterations; ++i) {
+				dispatch_async(dispatch_get_main_queue(), ^{
+					[dispose dispose];
+					dispose = nil;
+					
+					dispose = [RACObserve(testObject, testInt)
+							   subscribeNext:^(NSNumber *wrappedInt) {
+								   observedValue = wrappedInt.intValue;
+							   }];
+					
+					dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+						testObject.testInt++;
+					});
+				});
+			}
+		});
+		
+		it(@"async disposal of signal with in-flight changes", ^AsyncBlock{
+			RACSubject *teardown = [RACSubject subject];
+			
+			RACSignal *isEvenSignal = [RACSignal defer:^{
+				return [RACObserve(testObject, testInt)
+						map:^id(NSNumber *wrappedInt) {
+							return @((wrappedInt.intValue % 2) == 0);
+						}];
+			}];
+			
+			[[[isEvenSignal
+				deliverOn:RACScheduler.mainThreadScheduler]
+				takeUntil:teardown]
+				subscribeCompleted:^{
+					done();
+				}];
+			
+			dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+				for (int i=0; i<numIterations; ++i) {
+					testObject.testInt = rand();
+				}
+				
+				[teardown sendNext:nil];
+			});
+		});
+	});
+});
+
+SpecEnd

--- a/ReactiveCocoaTests/RACKVOProxySpec.m
+++ b/ReactiveCocoaTests/RACKVOProxySpec.m
@@ -60,8 +60,8 @@ qck_describe(@"racproxyobserve", ^{
 
 			testObject.testInt = 2;
 
-			expect(@(observedValue1)).toEventually(equal(@(testObject.testInt)));
-			expect(@(observedValue2)).toEventually(equal(@(testObject.testInt)));
+			expect(@(observedValue1)).toEventually(equal(@2));
+			expect(@(observedValue2)).toEventually(equal(@2));
 		});
 
 		qck_it(@"can remove individual observation", ^{
@@ -79,15 +79,15 @@ qck_describe(@"racproxyobserve", ^{
 
 			testObject.testInt = 2;
 
-			expect(@(observedValue1)).toEventually(equal(@(testObject.testInt)));
-			expect(@(observedValue2)).toEventually(equal(@(testObject.testInt)));
+			expect(@(observedValue1)).toEventually(equal(@2));
+			expect(@(observedValue2)).toEventually(equal(@2));
 
 			[disposable1 dispose];
 
 			testObject.testInt = 3;
 
-			expect(@(observedValue1)).toEventuallyNot(equal(@(testObject.testInt)));
-			expect(@(observedValue2)).toEventually(equal(@(testObject.testInt)));
+			expect(@(observedValue1)).toEventuallyNot(equal(@3));
+			expect(@(observedValue2)).toEventually(equal(@3));
 		});
 	});
 
@@ -105,7 +105,7 @@ qck_describe(@"racproxyobserve", ^{
 				testObject.testInt = 2;
 			});
 
-			expect(@(observedValue)).toEventually(equal(@(testObject.testInt)));
+			expect(@(observedValue)).toEventually(equal(@2));
 		});
 
 		qck_it(@"should handle changes being made on another queue using deliverOn", ^{
@@ -122,7 +122,7 @@ qck_describe(@"racproxyobserve", ^{
 				testObject.testInt = 2;
 			});
 
-			expect(@(observedValue)).toEventually(equal(@(testObject.testInt)));
+			expect(@(observedValue)).toEventually(equal(@2));
 		});
 
 		qck_it(@"async disposal of target", ^{


### PR DESCRIPTION
Continuing @rspeyer's KVO proxy implementation from #1276 

Firstly, this pull request is to bring @rspeyer's changes up to date with `master`. This will mainly be updating the tests from Specta to Quick. Beyond that, perhaps `RACKVOProxy` and `RACKVOTrampoline` will be unified.

- [x] ~~Break out separate pull request to handle crash in (see https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1627#discussion_r22028875)~~
- [x] Refactor tests originally written using Specta's `AsyncBlock`
- [x] ~~Combine `RACKVOProxy` and `RACKVOTrampoline` (optional)~~

cc @epatey @modocache