### PR TITLE
Replace MainScheduler with UIScheduler and QueueScheduler.mainQueueScheduler

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -228,7 +228,7 @@ public final class CocoaAction: NSObject {
 	private func startSignalOnMainThread<T: Equatable>(signal: ColdSignal<T>, next: T -> ()) {
 		let signalDisposable = signal
 			.skipRepeats(identity)
-			.deliverOn(MainScheduler())
+			.deliverOn(UIScheduler())
 			.start(next: next)
 
 		self.disposable.addDisposable(signalDisposable)

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -33,7 +33,7 @@ extension ImmediateScheduler {
 	}
 }
 
-extension MainScheduler {
+extension UIScheduler {
 	public func asRACScheduler() -> RACScheduler {
 		return RACScheduler.mainThreadScheduler()
 	}

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -88,6 +88,20 @@ public final class UIScheduler: Scheduler {
 public final class QueueScheduler: DateScheduler {
 	internal let queue = dispatch_queue_create("org.reactivecocoa.ReactiveCocoa.QueueScheduler", DISPATCH_QUEUE_SERIAL)
 
+	private struct MainQueueSingleton {
+		static let mainQueueScheduler = QueueScheduler(dispatch_get_main_queue())
+	}
+
+	/// A singleton QueueScheduler that always targets the main thread's GCD
+	/// queue.
+	///
+	/// Unlike UIScheduler, this scheduler supports scheduling for a future
+	/// date, and will always schedule asynchronously (even if already running
+	/// on the main thread).
+	public class var mainQueueScheduler: QueueScheduler {
+		return MainQueueSingleton.mainQueueScheduler
+	}
+
 	public var currentDate: NSDate {
 		return NSDate()
 	}

--- a/ReactiveCocoaTests/Swift/SchedulerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SchedulerSpec.swift
@@ -24,7 +24,7 @@ class SchedulerSpec: QuickSpec {
 			}
 		}
 
-		describe("MainScheduler") {
+		describe("UIScheduler") {
 			func dispatchSyncInBackground(action: () -> ()) {
 				let group = dispatch_group_create()
 				dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), action)
@@ -32,7 +32,7 @@ class SchedulerSpec: QuickSpec {
 			}
 
 			it("should run actions immediately when on the main thread") {
-				let scheduler = MainScheduler()
+				let scheduler = UIScheduler()
 				var values: [Int] = []
 				expect(NSThread.isMainThread()).to(beTruthy())
 
@@ -54,7 +54,7 @@ class SchedulerSpec: QuickSpec {
 			}
 
 			it("should enqueue actions scheduled from the background") {
-				let scheduler = MainScheduler()
+				let scheduler = UIScheduler()
 				var values: [Int] = []
 
 				dispatchSyncInBackground {
@@ -88,7 +88,7 @@ class SchedulerSpec: QuickSpec {
 			}
 
 			it("should run actions enqueued from the main thread after those from the background") {
-				let scheduler = MainScheduler()
+				let scheduler = UIScheduler()
 				var values: [Int] = []
 
 				dispatchSyncInBackground {
@@ -112,35 +112,6 @@ class SchedulerSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 				expect(values).toEventually(equal([ 0, 1, 2 ]))
-			}
-
-			it("should run enqueued actions after a given date") {
-				var didRun = false
-				MainScheduler().scheduleAfter(NSDate()) {
-					didRun = true
-					expect(NSThread.isMainThread()).to(beTruthy())
-				}
-
-				expect(didRun).to(beFalsy())
-				expect{didRun}.toEventually(beTruthy())
-			}
-
-			it("should repeatedly run actions after a given date") {
-				let disposable = SerialDisposable()
-
-				var count = 0
-				let timesToRun = 3
-
-				disposable.innerDisposable = MainScheduler().scheduleAfter(NSDate(), repeatingEvery: 0.01, withLeeway: 0) {
-					expect(NSThread.isMainThread()).to(beTruthy())
-
-					if ++count == timesToRun {
-						disposable.dispose()
-					}
-				}
-
-				expect(count).to(equal(0))
-				expect{count}.toEventually(equal(timesToRun))
 			}
 		}
 


### PR DESCRIPTION
This is _sort of_ a port of #1425/#1618 to Swift, except executed very differently.

I figured, if we're going to have immediate scheduling on the main thread as a feature, why not just make it the default? It seems cleaner and simpler to me than offering such a confusing choice to consumers.

Note that if you explicitly _want_ a scheduler hop, you can still use `delay(0)` to get that effect. Other than that, I don't _think_ there are any negative ramifications to this, but I'd love to hear thoughts from @jlawton @epatey @ReactiveCocoa/reactivecocoa.

Resolves #1619.