### PR TITLE
Add `Result` overload for `try`, allow default errors to be specified

### DIFF
--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -581,6 +581,14 @@ extension ColdSignal {
 		return tryMap { (value, error) in f(value, error) ? value : nil }
 	}
 
+	/// Performs the given action upon each value in the receiver, bailing out
+	/// if the returned Result is an error.
+	public func try(f: T -> Result<()>) -> ColdSignal {
+		return tryMap { value -> Result<T> in
+			return f(value).map { _ in value }
+		}
+	}
+
 	/// Attempts to map each value in the receiver, bailing out with an error if
 	/// a given mapping is `nil`.
 	public func tryMap<U>(f: (T, NSErrorPointer) -> U?) -> ColdSignal<U> {

--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -577,14 +577,8 @@ extension ColdSignal {
 
 	/// Performs the given action upon each value in the receiver, bailing out
 	/// with an error if it returns `false`.
-	public func try(defaultError: NSError = RACError.Empty.error, _ f: (T, NSErrorPointer) -> Bool) -> ColdSignal {
-		return tryMap(defaultError: defaultError) { (value, error) -> T? in
-			if f(value, error) {
-				return value
-			} else {
-				return nil
-			}
-		}
+	public func try(f: (T, NSErrorPointer) -> Bool) -> ColdSignal {
+		return tryMap { (value, error) in f(value, error) ? value : nil }
 	}
 
 	/// Performs the given action upon each value in the receiver, bailing out
@@ -597,7 +591,7 @@ extension ColdSignal {
 
 	/// Attempts to map each value in the receiver, bailing out with an error if
 	/// a given mapping is `nil`.
-	public func tryMap<U>(defaultError: NSError = RACError.Empty.error, _ f: (T, NSErrorPointer) -> U?) -> ColdSignal<U> {
+	public func tryMap<U>(f: (T, NSErrorPointer) -> U?) -> ColdSignal<U> {
 		return tryMap { value -> Result<U> in
 			var error: NSError?
 			let maybeValue = f(value, &error)
@@ -605,7 +599,7 @@ extension ColdSignal {
 			if let v = maybeValue {
 				return .Success(Box(v))
 			} else {
-				return .Failure(error.orDefault(defaultError))
+				return .Failure(error.orDefault(RACError.Empty.error))
 			}
 		}
 	}

--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -577,8 +577,14 @@ extension ColdSignal {
 
 	/// Performs the given action upon each value in the receiver, bailing out
 	/// with an error if it returns `false`.
-	public func try(f: (T, NSErrorPointer) -> Bool) -> ColdSignal {
-		return tryMap { (value, error) in f(value, error) ? value : nil }
+	public func try(defaultError: NSError = RACError.Empty.error, _ f: (T, NSErrorPointer) -> Bool) -> ColdSignal {
+		return tryMap(defaultError: defaultError) { (value, error) -> T? in
+			if f(value, error) {
+				return value
+			} else {
+				return nil
+			}
+		}
 	}
 
 	/// Performs the given action upon each value in the receiver, bailing out
@@ -591,7 +597,7 @@ extension ColdSignal {
 
 	/// Attempts to map each value in the receiver, bailing out with an error if
 	/// a given mapping is `nil`.
-	public func tryMap<U>(f: (T, NSErrorPointer) -> U?) -> ColdSignal<U> {
+	public func tryMap<U>(defaultError: NSError = RACError.Empty.error, _ f: (T, NSErrorPointer) -> U?) -> ColdSignal<U> {
 		return tryMap { value -> Result<U> in
 			var error: NSError?
 			let maybeValue = f(value, &error)
@@ -599,7 +605,7 @@ extension ColdSignal {
 			if let v = maybeValue {
 				return .Success(Box(v))
 			} else {
-				return .Failure(error.orDefault(RACError.Empty.error))
+				return .Failure(error.orDefault(defaultError))
 			}
 		}
 	}


### PR DESCRIPTION
These are a couple of things that sometimes prevented me from using `try` and `tryMap` in Carthage, where they would otherwise make a lot of sense.