### PR TITLE
Add ColdSignal.try constructors for lazy operations

### DIFF
--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -198,6 +198,25 @@ extension ColdSignal {
 			return .error(error)
 		}
 	}
+
+	/// Creates a signal that will execute the given closure when started, then
+	/// yield the resulting value upon success, or the error upon failure.
+	public static func try(f: @autoclosure () -> Result<T>) -> ColdSignal {
+		return lazy { .fromResult(f()) }
+	}
+
+	/// Creates a signal that will execute the given closure when started, then
+	/// yield the non-nil value upon success, or the error upon `nil`.
+	public static func try(defaultError: NSError = RACError.Empty.error, f: NSErrorPointer -> T?) -> ColdSignal {
+		return lazy {
+			var error: NSError?
+			if let value = f(&error) {
+				return .single(value)
+			} else {
+				return .error(error ?? defaultError)
+			}
+		}
+	}
 }
 
 /// Transformative operators.

--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -207,13 +207,13 @@ extension ColdSignal {
 
 	/// Creates a signal that will execute the given closure when started, then
 	/// yield the non-nil value upon success, or the error upon `nil`.
-	public static func try(defaultError: NSError = RACError.Empty.error, f: NSErrorPointer -> T?) -> ColdSignal {
+	public static func try(f: NSErrorPointer -> T?) -> ColdSignal {
 		return try {
 			var error: NSError?
 			if let value = f(&error) {
 				return success(value)
 			} else {
-				return failure(error ?? defaultError)
+				return failure(error ?? RACError.Empty)
 			}
 		}
 	}

--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -208,12 +208,12 @@ extension ColdSignal {
 	/// Creates a signal that will execute the given closure when started, then
 	/// yield the non-nil value upon success, or the error upon `nil`.
 	public static func try(defaultError: NSError = RACError.Empty.error, f: NSErrorPointer -> T?) -> ColdSignal {
-		return lazy {
+		return try {
 			var error: NSError?
 			if let value = f(&error) {
-				return .single(value)
+				return success(value)
 			} else {
-				return .error(error ?? defaultError)
+				return failure(error ?? defaultError)
 			}
 		}
 	}

--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -201,7 +201,7 @@ extension ColdSignal {
 
 	/// Creates a signal that will execute the given closure when started, then
 	/// yield the resulting value upon success, or the error upon failure.
-	public static func try(f: @autoclosure () -> Result<T>) -> ColdSignal {
+	public static func try(f: () -> Result<T>) -> ColdSignal {
 		return lazy { .fromResult(f()) }
 	}
 

--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -213,7 +213,7 @@ extension ColdSignal {
 			if let value = f(&error) {
 				return success(value)
 			} else {
-				return failure(error ?? RACError.Empty)
+				return failure(error ?? RACError.Empty.error)
 			}
 		}
 	}


### PR DESCRIPTION
Same motivation as #1653, but a logically distinct change that probably deserves some discussion on its own.