### PR TITLE
Rename to SchedulerType and DateSchedulerType

### DIFF
--- a/ReactiveCocoa/Swift/ColdSignal.swift
+++ b/ReactiveCocoa/Swift/ColdSignal.swift
@@ -452,7 +452,7 @@ extension ColdSignal {
 
 	/// Yields all events on the given scheduler, instead of whichever
 	/// scheduler they originally arrived upon.
-	public func deliverOn(scheduler: Scheduler) -> ColdSignal {
+	public func deliverOn(scheduler: SchedulerType) -> ColdSignal {
 		return ColdSignal { (sink, disposable) in
 			self.startWithSink { selfDisposable in
 				disposable.addDisposable(selfDisposable)
@@ -474,7 +474,7 @@ extension ColdSignal {
 	///
 	/// Values may still be sent upon other schedulers—this merely affects how
 	/// the `start` method is invoked.
-	public func evaluateOn(scheduler: Scheduler) -> ColdSignal {
+	public func evaluateOn(scheduler: SchedulerType) -> ColdSignal {
 		return ColdSignal { (sink, disposable) in
 			let schedulerDisposable = scheduler.schedule {
 				self.startWithSink { selfDisposable in
@@ -493,7 +493,7 @@ extension ColdSignal {
 	/// them on the given scheduler.
 	///
 	/// `Error` events are always scheduled immediately.
-	public func delay(interval: NSTimeInterval, onScheduler scheduler: DateScheduler) -> ColdSignal {
+	public func delay(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> ColdSignal {
 		precondition(interval >= 0)
 
 		return ColdSignal { (sink, disposable) in
@@ -522,7 +522,7 @@ extension ColdSignal {
 
 	/// Yields `error` after the given interval if the receiver has not yet
 	/// completed by that point.
-	public func timeoutWithError(error: NSError, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateScheduler) -> ColdSignal {
+	public func timeoutWithError(error: NSError, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> ColdSignal {
 		precondition(interval >= 0)
 
 		return ColdSignal { (sink, disposable) in

--- a/ReactiveCocoa/Swift/HotSignal.swift
+++ b/ReactiveCocoa/Swift/HotSignal.swift
@@ -169,7 +169,7 @@ extension HotSignal {
 	/// The timer will automatically be destroyed when there are no more strong
 	/// references to the returned signal, and no Disposables returned from
 	/// observe() are still around.
-	public class func interval(interval: NSTimeInterval, onScheduler scheduler: DateScheduler) -> HotSignal<NSDate> {
+	public class func interval(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> HotSignal<NSDate> {
 		// Apple's "Power Efficiency Guide for Mac Apps" recommends a leeway of
 		// at least 10% of the timer interval.
 		return self.interval(interval, onScheduler: scheduler, withLeeway: interval * 0.1)
@@ -181,7 +181,7 @@ extension HotSignal {
 	/// The timer will automatically be destroyed when there are no more strong
 	/// references to the returned signal, and no Disposables returned from
 	/// observe() are still around.
-	public class func interval(interval: NSTimeInterval, onScheduler scheduler: DateScheduler, withLeeway leeway: NSTimeInterval) -> HotSignal<NSDate> {
+	public class func interval(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType, withLeeway leeway: NSTimeInterval) -> HotSignal<NSDate> {
 		precondition(interval >= 0)
 		precondition(leeway >= 0)
 
@@ -373,7 +373,7 @@ extension HotSignal {
 
 	/// Forwards all values on the given scheduler, instead of whichever
 	/// scheduler they originally arrived upon.
-	public func deliverOn(scheduler: Scheduler) -> HotSignal {
+	public func deliverOn(scheduler: SchedulerType) -> HotSignal {
 		return HotSignal { sink in
 			self.observe { value in
 				scheduler.schedule { sink.put(value) }
@@ -386,7 +386,7 @@ extension HotSignal {
 
 	/// Delays values by the given interval, forwarding them on the given
 	/// scheduler.
-	public func delay(interval: NSTimeInterval, onScheduler scheduler: DateScheduler) -> HotSignal {
+	public func delay(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> HotSignal {
 		precondition(interval >= 0)
 
 		return HotSignal { sink in
@@ -406,7 +406,7 @@ extension HotSignal {
 	///
 	/// If multiple values are received before the interval has elapsed, the
 	/// latest value is the one that will be passed on.
-	public func throttle(interval: NSTimeInterval, onScheduler scheduler: DateScheduler) -> HotSignal {
+	public func throttle(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> HotSignal {
 		precondition(interval >= 0)
 
 		let previousDate = Atomic<NSDate?>(nil)

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -9,7 +9,7 @@
 import LlamaKit
 
 extension RACDisposable: Disposable {}
-extension RACScheduler: DateScheduler {
+extension RACScheduler: DateSchedulerType {
 	public var currentDate: NSDate {
 		return NSDate()
 	}

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -7,7 +7,7 @@
 //
 
 /// Represents a serial queue of work items.
-public protocol Scheduler {
+public protocol SchedulerType {
 	/// Enqueues an action on the scheduler.
 	///
 	/// When the work is executed depends on the scheduler in use.
@@ -19,7 +19,7 @@ public protocol Scheduler {
 
 /// A particular kind of scheduler that supports enqueuing actions at future
 /// dates.
-public protocol DateScheduler: Scheduler {
+public protocol DateSchedulerType: SchedulerType {
 	/// The current date, as determined by this scheduler.
 	///
 	/// This can be implemented to deterministic return a known date (e.g., for
@@ -41,7 +41,7 @@ public protocol DateScheduler: Scheduler {
 }
 
 /// A scheduler that performs all work synchronously.
-public final class ImmediateScheduler: Scheduler {
+public final class ImmediateScheduler: SchedulerType {
 	public init() {}
 
 	public func schedule(action: () -> ()) -> Disposable? {
@@ -55,7 +55,7 @@ public final class ImmediateScheduler: Scheduler {
 /// If the caller is already running on the main thread when an action is
 /// scheduled, it may be run synchronously. However, ordering between actions
 /// will always be preserved.
-public final class UIScheduler: Scheduler {
+public final class UIScheduler: SchedulerType {
 	private var queueLength: Int32 = 0
 
 	public init() {}
@@ -85,7 +85,7 @@ public final class UIScheduler: Scheduler {
 }
 
 /// A scheduler backed by a serial GCD queue.
-public final class QueueScheduler: DateScheduler {
+public final class QueueScheduler: DateSchedulerType {
 	internal let queue = dispatch_queue_create("org.reactivecocoa.ReactiveCocoa.QueueScheduler", DISPATCH_QUEUE_SERIAL)
 
 	private struct MainQueueSingleton {
@@ -190,7 +190,7 @@ public final class QueueScheduler: DateScheduler {
 }
 
 /// A scheduler that implements virtualized time, for use in testing.
-public final class TestScheduler: DateScheduler {
+public final class TestScheduler: DateSchedulerType {
 	private final class ScheduledAction {
 		let date: NSDate
 		let action: () -> ()


### PR DESCRIPTION
This matches the naming conventions for protocols in the Swift standard library.

Resolves #1661.