### PR TITLE
Backport RACQueueScheduler lldb/swift fixes

### DIFF
--- a/ReactiveCocoa/RACQueueScheduler+Subclass.h
+++ b/ReactiveCocoa/RACQueueScheduler+Subclass.h
@@ -15,7 +15,11 @@
 @interface RACQueueScheduler ()
 
 /// The queue on which blocks are enqueued.
+#if OS_OBJECT_HAVE_OBJC_SUPPORT
 @property (nonatomic, strong, readonly) dispatch_queue_t queue;
+#else
+@property (nonatomic, assign, readonly) dispatch_queue_t queue;
+#endif
 
 /// Initializes the receiver with the name of the scheduler and the queue which
 /// the scheduler should use.

--- a/ReactiveCocoa/RACQueueScheduler+Subclass.h
+++ b/ReactiveCocoa/RACQueueScheduler+Subclass.h
@@ -18,7 +18,7 @@
 #if OS_OBJECT_HAVE_OBJC_SUPPORT
 @property (nonatomic, strong, readonly) dispatch_queue_t queue;
 #else
-// Swift targets are built with OS_OBJECT_HAVE_OBJC_SUPPORT=0 :(
+// Swift builds with OS_OBJECT_HAVE_OBJC_SUPPORT=0 for Playgrounds and LLDB :(
 @property (nonatomic, assign, readonly) dispatch_queue_t queue;
 #endif
 

--- a/ReactiveCocoa/RACQueueScheduler+Subclass.h
+++ b/ReactiveCocoa/RACQueueScheduler+Subclass.h
@@ -18,6 +18,7 @@
 #if OS_OBJECT_HAVE_OBJC_SUPPORT
 @property (nonatomic, strong, readonly) dispatch_queue_t queue;
 #else
+// Swift targets are built with OS_OBJECT_HAVE_OBJC_SUPPORT=0 :(
 @property (nonatomic, assign, readonly) dispatch_queue_t queue;
 #endif
 

--- a/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoa/RACQueueScheduler.m
@@ -33,7 +33,10 @@
 #if !OS_OBJECT_HAVE_OBJC_SUPPORT
 
 - (void)dealloc {
-	dispatch_release(_queue), _queue = nil;
+	if (_queue != NULL) {
+		dispatch_release(_queue);
+		_queue = NULL;
+	}
 }
 
 #endif

--- a/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoa/RACQueueScheduler.m
@@ -23,9 +23,20 @@
 	if (self == nil) return nil;
 
 	_queue = queue;
+#if !OS_OBJECT_HAVE_OBJC_SUPPORT
+	dispatch_retain(_queue);
+#endif
 
 	return self;
 }
+
+#if !OS_OBJECT_HAVE_OBJC_SUPPORT
+
+- (void)dealloc {
+	dispatch_release(_queue), _queue = nil;
+}
+
+#endif
 
 #pragma mark Date Conversions
 


### PR DESCRIPTION
Right now, if you use ReactiveCocoa 2.4.4 in an app that mixes Swift and Objective-C, and you want to use LLDB on a swift class… you’re gonna have trouble.

We fixed this on the `swift-development` branch in #1573, so this is just a cherry-pick of the same fixes.

