### PR TITLE
Add takeUntilReplacement to Signal

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -418,7 +418,7 @@ public func concat<T, E>(nextSignal: Signal<T, E>)(signal: Signal<T, E>) -> Sign
 		serialDisposable.innerDisposable = signal.observe(next: { value in
 			sendNext(observer, value)
 		}, error: { error in
-			sendNext(observer, error)
+			sendError(observer, error)
 		}, completed: {
 			serialDisposable.innerDisposable = nextSignal.observe(observer)
 		})


### PR DESCRIPTION
Adds `takeUntilReplacement`, ~~and by necessity, `concat`~~. These are direct conversions of the objc versions.

~~Note that `concat` wasn’t listed in the `Signal`’s TODO. Was this just an omission, or is there another way that `takeUntilReplacement` should be implemented?~~