### PR TITLE
New method for generating sequence iteratively

### DIFF
--- a/ReactiveCocoa/RACSequence.h
+++ b/ReactiveCocoa/RACSequence.h
@@ -144,6 +144,52 @@
 /// tail. `headBlock` must not be nil.
 + (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence *(^)(void))tailBlock;
 
+/// Generate sequence from start value and iterate block.
+///
+/// This method creates a sequence from an initial state and an
+/// interate block, which calculate the next state value. The
+/// predicate block test the state value and terminates the sequence
+/// if true. The state value is transformed to a result value if a
+/// transform block is given.
+///
+/// The method corresponds to Rx `IObservable.Generate`.
+///
+/// start     – Initial state value.
+/// until     – Invoke on state to test if the sequence ends. Optional.
+/// iterate   – Invoked on state to calculate the next state.
+/// transform – Invoked to map state to result value. Optional.
+///
+/// Returns a lazy sequence.
++ (instancetype)generateWithStart:(id)state iterate:(id (^)(id value))iterate map:(id (^)(id value))transform until:(BOOL (^)(id x))predicate;
+
+/// Generate a sequence from start value and iterate block.
+///
+/// This method is equivalent to
+/// `+generateWithStart:iterate:map:until:`, but doesn't transform the
+/// state values.
+///
+/// state     – Initial state value.
+/// until     – Invoke on state to test if the sequence ends. Optional.
+/// iterate   – Invoked on state to calculate the next state.
+///
+/// Returns a lazy sequence.
++ (instancetype)generateWithStart:(id)state iterate:(id (^)(id value))iterate until:(BOOL (^)(id x))predicate;
+
+/// Generate a sequence from start value and iterate block.
+///
+/// This method is equivalent to
+/// `+generateWithStart:iterate:map:until:`, but doesn't terminate the
+/// sequence nor transforms the state values.
+///
+/// The resulting sequence is inifinite and can be terminated by other
+/// means, i.e. `-take:` or `-takeUntilBlock:` if necessary.
+///
+/// state     – Initial state value.
+/// iterate   – Invoked on state to calculate the next state.
+///
+/// Returns a lazy sequence.
++ (instancetype)generateWithStart:(id)state iterate:(id (^)(id value))iterate;
+
 @end
 
 @interface RACSequence (Deprecated)

--- a/ReactiveCocoa/RACSequence.h
+++ b/ReactiveCocoa/RACSequence.h
@@ -144,42 +144,12 @@
 /// tail. `headBlock` must not be nil.
 + (RACSequence *)sequenceWithHeadBlock:(id (^)(void))headBlock tailBlock:(RACSequence *(^)(void))tailBlock;
 
-/// Generate sequence from start value and iterate block.
+/// Generate a sequence from start value and iterate block.
 ///
-/// This method creates a sequence from an initial state and an
-/// interate block, which calculate the next state value. The
-/// predicate block test the state value and terminates the sequence
-/// if true. The state value is transformed to a result value if a
-/// transform block is given.
+/// This method creates a sequence from an initial value and an
+/// iterate block, which calculate the next value.
 ///
 /// The method corresponds to Rx `IObservable.Generate`.
-///
-/// start     – Initial state value.
-/// until     – Invoke on state to test if the sequence ends. Optional.
-/// iterate   – Invoked on state to calculate the next state.
-/// transform – Invoked to map state to result value. Optional.
-///
-/// Returns a lazy sequence.
-+ (instancetype)generateWithStart:(id)state iterate:(id (^)(id value))iterate map:(id (^)(id value))transform until:(BOOL (^)(id x))predicate;
-
-/// Generate a sequence from start value and iterate block.
-///
-/// This method is equivalent to
-/// `+generateWithStart:iterate:map:until:`, but doesn't transform the
-/// state values.
-///
-/// state     – Initial state value.
-/// until     – Invoke on state to test if the sequence ends. Optional.
-/// iterate   – Invoked on state to calculate the next state.
-///
-/// Returns a lazy sequence.
-+ (instancetype)generateWithStart:(id)state iterate:(id (^)(id value))iterate until:(BOOL (^)(id x))predicate;
-
-/// Generate a sequence from start value and iterate block.
-///
-/// This method is equivalent to
-/// `+generateWithStart:iterate:map:until:`, but doesn't terminate the
-/// sequence nor transforms the state values.
 ///
 /// The resulting sequence is inifinite and can be terminated by other
 /// means, i.e. `-take:` or `-takeUntilBlock:` if necessary.

--- a/ReactiveCocoa/RACSequence.m
+++ b/ReactiveCocoa/RACSequence.m
@@ -365,38 +365,16 @@
 }
 
 + (instancetype)generateWithStart:(id)state
-                          iterate:(id (^)(id value))iterate
-                              map:(id (^)(id value))transform
-                            until:(BOOL (^)(id x))predicate
+						  iterate:(id (^)(id value))iterate
 {
 	NSCParameterAssert(iterate != NULL);
 
-    RACSequence *sequence;
-
-    if(predicate != NULL && predicate(state)) {
-        sequence = [RACSequence empty];
-    } else {
-        sequence = [RACSequence sequenceWithHeadBlock: ^{
-            return transform != NULL ? transform(state) : state;
-        } tailBlock: ^{
-            return [RACSequence generateWithStart:iterate(state)
-                                          iterate:iterate
-                                              map:transform
-                                            until:predicate];
-        }];
-    }
-
-    return sequence;
-}
-
-+ (instancetype)generateWithStart:(id)start iterate:(id (^)(id value))iterate until:(BOOL (^)(id x))predicate
-{
-    return [self generateWithStart:start iterate:iterate map:NULL until:predicate];
-}
-
-+ (instancetype)generateWithStart:(id)start iterate:(id (^)(id value))iterate
-{
-    return [self generateWithStart:start iterate:iterate map:NULL until:NULL];
+	return [RACSequence sequenceWithHeadBlock: ^{
+			return state;
+		} tailBlock: ^{
+			return [RACSequence generateWithStart:iterate(state)
+										  iterate:iterate];
+		}];
 }
 
 @end

--- a/ReactiveCocoa/RACSequence.m
+++ b/ReactiveCocoa/RACSequence.m
@@ -364,6 +364,41 @@
 	return (seq.head == nil);
 }
 
++ (instancetype)generateWithStart:(id)state
+                          iterate:(id (^)(id value))iterate
+                              map:(id (^)(id value))transform
+                            until:(BOOL (^)(id x))predicate
+{
+	NSCParameterAssert(iterate != NULL);
+
+    RACSequence *sequence;
+
+    if(predicate != NULL && predicate(state)) {
+        sequence = [RACSequence empty];
+    } else {
+        sequence = [RACSequence sequenceWithHeadBlock: ^{
+            return transform != NULL ? transform(state) : state;
+        } tailBlock: ^{
+            return [RACSequence generateWithStart:iterate(state)
+                                          iterate:iterate
+                                              map:transform
+                                            until:predicate];
+        }];
+    }
+
+    return sequence;
+}
+
++ (instancetype)generateWithStart:(id)start iterate:(id (^)(id value))iterate until:(BOOL (^)(id x))predicate
+{
+    return [self generateWithStart:start iterate:iterate map:NULL until:predicate];
+}
+
++ (instancetype)generateWithStart:(id)start iterate:(id (^)(id value))iterate
+{
+    return [self generateWithStart:start iterate:iterate map:NULL until:NULL];
+}
+
 @end
 
 @implementation RACSequence (Deprecated)

--- a/ReactiveCocoaTests/RACSequenceSpec.m
+++ b/ReactiveCocoaTests/RACSequenceSpec.m
@@ -96,6 +96,51 @@ qck_describe(@"+sequenceWithHeadBlock:tailBlock:", ^{
 	});
 });
 
+qck_describe(@"-generateWithStart:iterate:map:until:", ^{
+    qck_it(@"should generate and terminate sequence", ^{
+        RACSequence *sequence = [RACSequence generateWithStart:@1
+                                                       iterate: ^ (NSNumber *number) {
+                                                           return @(number.integerValue * 2);
+                                                       } map: ^ (NSNumber *input) {
+                                                           return @(input.integerValue + 1);
+                                                       } until: ^ BOOL (NSNumber *number) {
+                                                           return number.integerValue > 10;
+                                                       }];
+
+        NSArray *result = [sequence array];
+
+        expect(result).to(equal(@[@2, @3, @5, @9]));
+    });
+});
+
+qck_describe(@"-generateWithStart:iterate:until:", ^{
+    qck_it(@"should generate and terminate sequence", ^{
+        RACSequence *sequence = [RACSequence generateWithStart:@1
+                                                       iterate: ^ (NSNumber *number) {
+                                                           return @(number.integerValue * 2);
+                                                       } until: ^ BOOL (NSNumber *number) {
+                                                           return number.integerValue > 10;
+                                                       }];
+
+        NSArray *result = [sequence array];
+
+        expect(result).to(equal(@[@1, @2, @4, @8]));
+    });
+});
+
+qck_describe(@"-generateWithStart:iterate:", ^{
+    qck_it(@"should generate sequence", ^{
+        RACSequence *sequence = [RACSequence generateWithStart:@1
+                                                       iterate: ^ (NSNumber *number) {
+                                                           return @(number.integerValue * 2);
+                                                       }];
+
+        NSArray *result = [[sequence take:6] array];
+
+        expect(result).to(equal(@[@1, @2, @4, @8, @16, @32]));
+    });
+});
+
 qck_describe(@"empty sequences", ^{
 	qck_itBehavesLike(RACSequenceExamples, ^{
 		return @{

--- a/ReactiveCocoaTests/RACSequenceSpec.m
+++ b/ReactiveCocoaTests/RACSequenceSpec.m
@@ -96,38 +96,6 @@ qck_describe(@"+sequenceWithHeadBlock:tailBlock:", ^{
 	});
 });
 
-qck_describe(@"-generateWithStart:iterate:map:until:", ^{
-    qck_it(@"should generate and terminate sequence", ^{
-        RACSequence *sequence = [RACSequence generateWithStart:@1
-                                                       iterate: ^ (NSNumber *number) {
-                                                           return @(number.integerValue * 2);
-                                                       } map: ^ (NSNumber *input) {
-                                                           return @(input.integerValue + 1);
-                                                       } until: ^ BOOL (NSNumber *number) {
-                                                           return number.integerValue > 10;
-                                                       }];
-
-        NSArray *result = [sequence array];
-
-        expect(result).to(equal(@[@2, @3, @5, @9]));
-    });
-});
-
-qck_describe(@"-generateWithStart:iterate:until:", ^{
-    qck_it(@"should generate and terminate sequence", ^{
-        RACSequence *sequence = [RACSequence generateWithStart:@1
-                                                       iterate: ^ (NSNumber *number) {
-                                                           return @(number.integerValue * 2);
-                                                       } until: ^ BOOL (NSNumber *number) {
-                                                           return number.integerValue > 10;
-                                                       }];
-
-        NSArray *result = [sequence array];
-
-        expect(result).to(equal(@[@1, @2, @4, @8]));
-    });
-});
-
 qck_describe(@"-generateWithStart:iterate:", ^{
     qck_it(@"should generate sequence", ^{
         RACSequence *sequence = [RACSequence generateWithStart:@1


### PR DESCRIPTION
I want to suggest to add a method

```objc
+ (instancetype)generateWithStart:(id)state iterate:(id (^)(id value))iterate;
```

to RACSequence. This method is modelled on IObservable.Generate, and also inspired by list comprehension in other languages.

C#.NET Rx has the method:

```
public static IObservable<TResult> Generate<TState, TResult>(
  TState initialState, 
  Func<TState, bool> condition, 
  Func<TState, TState> iterate, 
  Func<TState, TResult> resultSelector)
```

This offers the advantage that no constructor needs to be called. Here
is a C# usage example:

```
public static IObservable<int> Range(int start, int count)
{
  var max = start + count;
  return Observable.Generate(
    start, 
    value => value < max, 
    value => value + 1, 
    value => value);
}
```
(This example is from the [Rx online Book](http://www.introtorx.com/content/v1.0.10621.0/04_CreatingObservableSequences.html#ObservableGenerate) by Lee Campbell.)

Here the C# docs: [Observable.Generate](https://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.generate.aspx)

It also feels intuitive when you know sequence generation based on function application in other functional languages. Arbitrary example from Clojure:

```clojure
user=> (take 5 (iterate inc 5))
(5 6 7 8 9)
```

See the docs of [clojure.core/iterate](https://clojuredocs.org/clojure.core/iterate) for details and examples.

The proposed change would make generating of a sequence based on a functional block more succinct. Consider this code from the test case:

```objc
RACSequence *sequence = [RACSequence generateWithStart:@1
    iterate: ^ (NSNumber *number) {
        return @(number.integerValue * 2);
    }];
```

Without this change, it's quite a bit more involved to create a sequence (and I hope I'm not overlooking something much simpler :). Complex recursive block usage and memory class headaches are easily all part of it.

This is the slimmed down version of the change, which I originally did more along the lines of the C# Rx interface. That includes a predicate for termination and a map transformation from sequence state to result values. The design guidelines of this project suggest to prefer operators for stream over extensions, though, and as `-map:`, `-take:` and `takeUntilBlock:` make these modifications straightforward I tend to leave them out, too. (Have a look at the febeling/ReactiveCocoa@sequence-generate branch for comparison in case anyone is curious.)

I wished for this method a number of times in real projects. Does it make sense?
