### PR TITLE
Swift PropertySpec

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -131,12 +131,9 @@ FIXME: DISABLED DUE TO COMPILER BUG
 /// the given property, updating the property's value to the latest value sent
 /// by the signal.
 ///
-/// The created signal MUST NOT send an error. The behavior of doing so is
-/// undefined.
-///
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the created signal sends a `Completed` event.
-public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T>) -> Disposable {
+public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T, NoError>) -> Disposable {
 	let disposable = CompositeDisposable()
 	let propertyDisposable = property.producer.start(completed: {
 		disposable.dispose()
@@ -150,8 +147,6 @@ public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T>) ->
 		signal.observe(next: { [weak property] value in
 			property?.value = value
 			return
-		}, error: { error in
-			fatalError("Unhandled error in MutableProperty <~ SignalProducer binding: \(error)")
 		}, completed: {
 			disposable.dispose()
 		})

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -34,14 +34,14 @@ public struct PropertyOf<T>: PropertyType {
 }
 
 /// A property that never changes.
-internal struct ConstantProperty<T>: PropertyType {
+public struct ConstantProperty<T>: PropertyType {
 	typealias Value = T
 
-	let value: T
-	let producer: SignalProducer<T, NoError>
+	public let value: T
+	public let producer: SignalProducer<T, NoError>
 
 	/// Initializes the property to have the given value.
-	init(_ value: T) {
+	public init(_ value: T) {
 		self.value = value
 		self.producer = SignalProducer(value: value)
 	}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -25,17 +25,17 @@ class PropertySpec: QuickSpec {
 				let propertyValue = "StringValue"
 				let constantProperty = ConstantProperty(propertyValue)
 
-				var valueSent: String?
+				var sentValue: String?
 				var signalCompleted = false
 
 				constantProperty.producer.start(next: { value in
-					valueSent = value
+					sentValue = value
 				},
 				completed: {
 					signalCompleted = true
 				})
 
-				expect(valueSent).to(equal(propertyValue))
+				expect(sentValue).to(equal(propertyValue))
 				expect(signalCompleted).to(beTruthy())
 			}
 		}
@@ -54,22 +54,22 @@ class PropertySpec: QuickSpec {
 
 				let mutableProperty = MutableProperty(initialValue)
 
-				var valueSent: String?
+				var sentValue: String?
 				var signalCompleted = false
 
 				mutableProperty.producer.start(next: { value in
-					valueSent = value
+					sentValue = value
 				},
 				completed: {
 					signalCompleted = true
 				})
 
-				expect(valueSent).to(equal(initialValue))
+				expect(sentValue).to(equal(initialValue))
 				expect(signalCompleted).to(beFalsy())
 
 				mutableProperty.value = subsequentValue
 
-				expect(valueSent).to(equal(subsequentValue))
+				expect(sentValue).to(equal(subsequentValue))
 				expect(signalCompleted).to(beFalsy())
 			}
 
@@ -97,13 +97,13 @@ class PropertySpec: QuickSpec {
 				let constantProperty = ConstantProperty(propertyValue)
 				let propertyOf = PropertyOf(constantProperty)
 
-				var valueSent: String?
+				var sentValue: String?
 
 				propertyOf.producer.start(next: { value in
-					valueSent = value
+					sentValue = value
 				})
 
-				expect(valueSent).to(equal(propertyValue))
+				expect(sentValue).to(equal(propertyValue))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -14,66 +14,258 @@ import ReactiveCocoa
 class PropertySpec: QuickSpec {
 	override func spec() {
 		describe("ConstantProperty") {
-			pending("should have the value given at initialization") {
+			it("should have the value given at initialization") {
+				let propertyValue = "StringValue"
+				let constantProperty = ConstantProperty(propertyValue)
+
+				expect(constantProperty.value).to(equal(propertyValue))
 			}
 
-			pending("should yield a producer that sends the current value then completes") {
+			it("should yield a producer that sends the current value then completes") {
+				let propertyValue = "StringValue"
+				let constantProperty = ConstantProperty(propertyValue)
+
+				var valueSent: String?
+				var signalCompleted = false
+
+				constantProperty.producer.start(next: { value in
+					valueSent = value
+				},
+				completed: {
+					signalCompleted = true
+				})
+
+				expect(valueSent).to(equal(propertyValue))
+				expect(signalCompleted).to(beTruthy())
 			}
 		}
 
 		describe("MutableProperty") {
-			pending("should have the value given at initialization") {
+			it("should have the value given at initialization") {
+				let propertyValue = "StringValue"
+				let mutableProperty = MutableProperty(propertyValue)
+
+				expect(mutableProperty.value).to(equal(propertyValue))
 			}
 
-			pending("should yield a producer that sends the current value then all changes") {
+			it("should yield a producer that sends the current value then all changes") {
+				let initialValue = "StringValue"
+				let subsequentValue = "NewStringValue"
+
+				let mutableProperty = MutableProperty(initialValue)
+
+				var valueSent: String?
+				var signalCompleted = false
+
+				mutableProperty.producer.start(next: { value in
+					valueSent = value
+				},
+				completed: {
+					signalCompleted = true
+				})
+
+				expect(valueSent).to(equal(initialValue))
+				expect(signalCompleted).to(beFalsy())
+
+				mutableProperty.value = subsequentValue
+
+				expect(valueSent).to(equal(subsequentValue))
+				expect(signalCompleted).to(beFalsy())
 			}
 
-			pending("should complete its producer when deallocated") {
+			it("should complete its producer when deallocated") {
+				let propertyValue = "StringValue"
+				var mutableProperty: MutableProperty? = MutableProperty(propertyValue)
+
+				var signalCompleted = false
+
+				mutableProperty?.producer.start(next: { value in
+				},
+				completed: {
+					signalCompleted = true
+				})
+
+				mutableProperty = nil
+				expect(signalCompleted).to(beTruthy())
 			}
 		}
 
 		describe("PropertyOf") {
-			pending("should pass through behaviors of the input property") {
+			it("should pass through behaviors of the input property") {
+				let propertyValue = "StringValue"
+
+				let constantProperty = ConstantProperty(propertyValue)
+				let propertyOf = PropertyOf(constantProperty)
+
+				var valueSent: String?
+
+				propertyOf.producer.start(next: { value in
+					valueSent = value
+				})
+
+				expect(valueSent).to(equal(propertyValue))
 			}
 		}
 
 		describe("binding") {
 			describe("from a Signal") {
-				pending("should update the property with values sent from the signal") {
+				it("should update the property with values sent from the signal") {
+					let finalPropertyValue = 815
+					var signalObserver: SinkOf<Event<Int, NoError>>?
+
+					let sendPropertyUpdate = {
+						sendNext(signalObserver!, finalPropertyValue)
+					}
+
+					let signal = Signal<Int, NoError>({ observer in
+						signalObserver = observer
+
+						return SimpleDisposable()
+					})
+
+					let mutableProperty = MutableProperty<Int>(0)
+
+					mutableProperty <~ signal
+
+					sendPropertyUpdate()
+					expect(mutableProperty.value).to(equal(finalPropertyValue))
 				}
 
-				pending("should tear down the binding when disposed") {
+				it("should tear down the binding when disposed") {
+					let signalDisposable = SimpleDisposable()
+
+					let signal = Signal<Int, NoError>({ observer in
+						return signalDisposable
+					})
+
+					let mutableProperty = MutableProperty<Int>(0)
+
+					let bindingDisposable = mutableProperty <~ signal
+					bindingDisposable.dispose()
+
+					// This test is failing: disposing the binding isn't disposing the signal, or am I doing something wrong?
+					expect(signalDisposable.disposed).to(beTruthy())
 				}
 
-				pending("should tear down the binding when the property deallocates") {
+				it("should tear down the binding when the property deallocates") {
+					let signal = Signal<Int, NoError>({ observer in
+						return SimpleDisposable()
+					})
+
+					var mutableProperty: MutableProperty<Int>? = MutableProperty(0)
+
+					let bindingDisposable = mutableProperty! <~ signal
+
+					mutableProperty = nil
+					expect(bindingDisposable.disposed).to(beTruthy())
 				}
 			}
 
 			describe("from a SignalProducer") {
 				pending("should start a signal and update the property with its values") {
+//					let signalValues = [1, 2, 3]
+//					let signalProducer = SignalProducer<Int, NoError>(values: signalValues)
+//
+//					let mutableProperty = MutableProperty<Int>(0)
+//
+//					mutableProperty <~ signalProducer
+//
+//					expect(mutableProperty.value).to(equal(signalValues.last!))
 				}
 
 				pending("should tear down the binding when disposed") {
+//					let signalValues = [1, 2, 3]
+//					let signalProducer = SignalProducer<Int, NoError>(values: signalValues)
+//
+//					let mutableProperty: MutableProperty<Int> = MutableProperty(0)
+//
+//					let disposable = mutableProperty <~ signalProducer
+//
+//					disposable.dispose()
+//					// TODO: Assert binding was teared-down?
 				}
 
 				pending("should tear down the binding when the property deallocates") {
+//					let signalValues = [1, 2, 3]
+//					let signalProducer = SignalProducer<Int, NoError>(values: signalValues)
+//
+//					var mutableProperty: MutableProperty<Int>? = MutableProperty(0)
+//
+//					let disposable = mutableProperty! <~ signalProducer
+//
+//					mutableProperty = nil
+//					expect(disposable.disposed).to(beTruthy())
 				}
 			}
 
 			describe("from another property") {
 				pending("should take the source property's current value") {
+//					let sourceValue = "StringValue"
+//					let sourceProperty = ConstantProperty(sourceValue)
+//
+//					let destinationProperty = MutableProperty("")
+//
+//					destinationProperty <~ sourceProperty.producer
+//
+//					expect(destinationProperty.value).to(equal(sourceValue))
 				}
 
-				pending("should update with changes to the source property's value") {
+			pending("should update with changes to the source property's value") {
+//					let sourceInitialValue = "StringValue"
+//					let sourceFinalValue = "NewValue"
+//
+//					let sourceProperty = MutableProperty(sourceInitialValue)
+//
+//					let destinationProperty = MutableProperty("")
+//
+//					destinationProperty <~ sourceProperty.producer
+//
+//					destinationProperty.value = sourceFinalValue
+//					expect(destinationProperty.value).to(equal(sourceFinalValue))
 				}
 
 				pending("should tear down the binding when disposed") {
+//					let sourceInitialValue = "StringValue"
+//					let sourceFinalValue = "NewValue"
+//
+//					let sourceProperty = MutableProperty(sourceInitialValue)
+//
+//					let destinationProperty = MutableProperty("")
+//
+//					let bindingDisposable = destinationProperty <~ sourceProperty.producer
+//					bindingDisposable.dispose()
+//
+//					sourceProperty.value = sourceFinalValue
+//
+//					expect(destinationProperty.value).to(equal(sourceInitialValue))
 				}
 
 				pending("should tear down the binding when the source property deallocates") {
+//					let sourcePropertyValue = "StringValue"
+//
+//					var sourceProperty: MutableProperty<String>? = MutableProperty(sourcePropertyValue)
+//
+//					let destinationProperty = MutableProperty("")
+//
+//					let bindingDisposable = destinationProperty <~ sourceProperty!.producer
+//
+//					sourceProperty = nil
+//
+//					expect(bindingDisposable.disposed).to(beTruthy())
 				}
 
 				pending("should tear down the binding when the destination property deallocates") {
+//					let sourcePropertyValue = "StringValue"
+//
+//					let sourceProperty = MutableProperty(sourcePropertyValue)
+//
+//					var destinationProperty: MutableProperty<String>? = MutableProperty("")
+//
+//					let bindingDisposable = destinationProperty! <~ sourceProperty.producer
+//
+//					destinationProperty = nil
+//
+//					expect(bindingDisposable.disposed).to(beTruthy())
 				}
 			}
 		}


### PR DESCRIPTION
Tests that rely on binding SignalProducers to Properties are commented out because the <~ is not enabled due to the Swift compiler crash.

### TODO
- [x] Fix test that verifies the Signal binding is teared down when disposed