### PR TITLE
fixing memory leak issue #1691

### DIFF
--- a/ReactiveCocoa/RACScheduler.m
+++ b/ReactiveCocoa/RACScheduler.m
@@ -199,7 +199,9 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 	RACScheduler *previousScheduler = RACScheduler.currentScheduler;
 	NSThread.currentThread.threadDictionary[RACSchedulerCurrentSchedulerKey] = self;
 
-	block();
+	@autoreleasepool {
+		block();
+	}
 
 	if (previousScheduler != nil) {
 		NSThread.currentThread.threadDictionary[RACSchedulerCurrentSchedulerKey] = previousScheduler;


### PR DESCRIPTION
add autorelease guard around a scheduled block.

I know that dispatch_async() will manage autorelease pool themselves.
But GCD has no guarantees as when those pools are drained.

https://developer.apple.com/library/ios/documentation/General/Conceptual/ConcurrencyProgrammingGuide/OperationQueues/OperationQueues.html