### PR TITLE
Fix, test, and refactor concat()

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -530,7 +530,7 @@ private struct ConcatState<T, E: ErrorType> {
 	/// Indicates whether the most recently processed inner signal has completed yet.
 	var latestSignalCompleted = true
 
-	/// Determination `concat` completion in its entirety.
+	/// Determines `concat` completion in its entirety.
 	var isComplete: Bool {
 		return selfCompleted && latestSignalCompleted
 	}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -463,22 +463,12 @@ private final class ConcatState<T, E: ErrorType> {
 	/// The top level disposable of a started `concat` producer.
 	let disposable: CompositeDisposable
 
-	var spinlock = OS_SPINLOCK_INIT
+	/// The signals waiting to be started.
+	var queuedSignalProducers: [SignalProducer<T, E>] = []
 
 	init(observer: Signal<T, E>.Observer, disposable: CompositeDisposable) {
 		self.observer = observer
 		self.disposable = disposable
-	}
-
-	/// The signals waiting to be started.
-	var queuedSignalProducers: [SignalProducer<T, E>] = []
-
-	func lock() {
-		withUnsafeMutablePointer(&spinlock, OSSpinLockLock)
-	}
-
-	func unlock() {
-		withUnsafeMutablePointer(&spinlock, OSSpinLockUnlock)
 	}
 
 	func enqueueSignalProducer(producer: SignalProducer<T, E>) {
@@ -522,6 +512,10 @@ private final class ConcatState<T, E: ErrorType> {
 			}
 		})
 	}
+
+	var spinlock = OS_SPINLOCK_INIT
+	func lock() { withUnsafeMutablePointer(&spinlock, OSSpinLockLock) }
+	func unlock() { withUnsafeMutablePointer(&spinlock, OSSpinLockUnlock) }
 }
 
 /// `concat`s `next` onto `producer`.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -458,7 +458,7 @@ public func concat<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 	}
 }
 
-private final class ConcatState<T, E: ErrorType> {
+private struct ConcatState<T, E: ErrorType> {
 	/// The observer of a started `concat` producer.
 	let observer: Signal<T, E>.Observer
 
@@ -466,7 +466,7 @@ private final class ConcatState<T, E: ErrorType> {
 	let disposable: CompositeDisposable
 
 	/// The active producer, if any, and the producers waiting to be started.
-	var queuedSignalProducers: Atomic<[SignalProducer<T, E>]> = Atomic([])
+	let queuedSignalProducers: Atomic<[SignalProducer<T, E>]> = Atomic([])
 
 	init(observer: Signal<T, E>.Observer, disposable: CompositeDisposable) {
 		self.observer = observer

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -465,7 +465,7 @@ private final class ConcatState<T, E: ErrorType> {
 	/// The top level disposable of a started `concat` producer.
 	let disposable: CompositeDisposable
 
-	/// The signals waiting to be started.
+	/// The active producer, if any, and the producers waiting to be started.
 	var queuedSignalProducers: Atomic<[SignalProducer<T, E>]> = Atomic([])
 
 	init(observer: Signal<T, E>.Observer, disposable: CompositeDisposable) {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -475,8 +475,9 @@ public func concat<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 				serialDisposableCompositeHandle.remove()
 				state.modify { (var state) in
 					state.latestSignalCompleted = true
-					let outerSignalIsComplete = completeIfAllowed(state)
-					if !outerSignalIsComplete && !state.queuedSignalProducers.isEmpty {
+					if state.queuedSignalProducers.isEmpty {
+						completeIfAllowed(state)
+					} else {
 						nextSignalProducer = state.queuedSignalProducers.removeAtIndex(0)
 					}
 					return state

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -458,7 +458,7 @@ public func concat<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 	}
 }
 
-private struct ConcatState<T, E: ErrorType> {
+private final class ConcatState<T, E: ErrorType> {
 	/// The observer of a started `concat` producer.
 	let observer: Signal<T, E>.Observer
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -477,8 +477,8 @@ private final class ConcatState<T, E: ErrorType> {
 		var shouldStart = true
 
 		queuedSignalProducers.modify { (var queue) in
-			// An empty queue means the concat is idle, ready & waiting to start the
-			// next producer given.
+			// An empty queue means the concat is idle, ready & waiting to start
+			// the next producer.
 			shouldStart = queue.isEmpty
 			queue.append(producer)
 			return queue
@@ -493,9 +493,9 @@ private final class ConcatState<T, E: ErrorType> {
 		var nextSignalProducer: SignalProducer<T, E>?
 
 		queuedSignalProducers.modify { (var queue) in
-			// Active producers are left in the queue until completion. Dequeueing
-			// only happens when the last active producer has completed, so it can
-			// be removed from the queue.
+			// Active producers remain in the queue until completed. Since
+			// dequeueing happens at completion of the active producer, the
+			// first producer in the queue can be removed.
 			queue.removeAtIndex(0)
 			nextSignalProducer = queue.first
 			return queue

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -477,6 +477,8 @@ private final class ConcatState<T, E: ErrorType> {
 		var shouldStart = true
 
 		lock()
+		// An empty queue means the concat is idle, ready & waiting to start the
+		// next producer given.
 		shouldStart = self.queuedSignalProducers.isEmpty
 		self.queuedSignalProducers.append(producer)
 		unlock()
@@ -490,6 +492,9 @@ private final class ConcatState<T, E: ErrorType> {
 		var nextSignalProducer: SignalProducer<T, E>?
 
 		lock()
+		// Active producers are left in the queue until completion. Dequeueing
+		// only happens when the last active producer has completed, so it can
+		// be removed from the queue.
 		self.queuedSignalProducers.removeAtIndex(0)
 		nextSignalProducer = self.queuedSignalProducers.first
 		unlock()

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -476,9 +476,8 @@ public func concat<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 				state.modify { (var state) in
 					state.latestSignalCompleted = true
 					let outerSignalIsComplete = completeIfAllowed(state)
-					if !outerSignalIsComplete {
-						nextSignalProducer = state.queuedSignalProducers[0]
-						state.queuedSignalProducers.removeAtIndex(0)
+					if !outerSignalIsComplete && !state.queuedSignalProducers.isEmpty {
+						nextSignalProducer = state.queuedSignalProducers.removeAtIndex(0)
 					}
 					return state
 				}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -468,13 +468,7 @@ private func startNextSignalProducer<T, E>(signalProducer: SignalProducer<T, E>,
 	}, completed: {
 		serialDisposableCompositeHandle.remove()
 
-		var nextSignalProducer: SignalProducer<T, E>?
-		state.atomic.modify {
-			state.queuedSignalProducers.removeAtIndex(0)
-			nextSignalProducer = state.queuedSignalProducers.first
-		}
-		
-		if let nextSignalProducer = nextSignalProducer {
+		if let nextSignalProducer = state.dequeueSignalProducer() {
 			startNextSignalProducer(nextSignalProducer, state)
 		}
 	})
@@ -507,6 +501,16 @@ private final class ConcatState<T, E: ErrorType> {
 		if shouldStart {
 			startNextSignalProducer(producer, self)
 		}
+	}
+
+	func dequeueSignalProducer() -> SignalProducer<T, E>? {
+		var nextSignalProducer: SignalProducer<T, E>?
+		atomic.modify {
+			self.queuedSignalProducers.removeAtIndex(0)
+			nextSignalProducer = self.queuedSignalProducers.first
+		}
+
+		return nextSignalProducer
 	}
 }
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -158,12 +158,12 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("concat") {
-			context("sequencing") {
 				var outerSink: Signal<SignalProducer<Int, NoError>, NoError>.Observer!
 				var outerProducer: SignalProducer<SignalProducer<Int, NoError>, NoError>!
 
 				var previousSink: Signal<Int, NoError>.Observer!
 				var previousProducer: SignalProducer<Int, NoError>!
+			describe("sequencing") {
 
 				var subsequentSink: Signal<Int, NoError>.Observer!
 				var subsequentProducer: SignalProducer<Int, NoError>!
@@ -239,7 +239,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(error).to(equal(TestError.Default))
 			}
 
-			context("completion") {
+			describe("completion") {
 				var outerSink: Signal<SignalProducer<Int, NoError>, NoError>.Observer!
 				var outerProducer: SignalProducer<SignalProducer<Int, NoError>, NoError>!
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -164,7 +164,19 @@ class SignalProducerSpec: QuickSpec {
 			pending("should forward an error from an inner signal") {
 			}
 
-			pending("should forward an error from the outer signal") {
+			it("should forward an error from the outer producer") {
+				var sink: Signal<SignalProducer<Int, TestError>, TestError>.Observer!
+				let outerProducer = SignalProducer { observer, _ in
+					sink = observer
+				}
+
+				var error: TestError?
+				concat(outerProducer).start(error: { e in
+					error = e
+				})
+
+				sendError(sink, TestError.Default)
+				expect(error).to(equal(TestError.Default))
 			}
 
 			pending("should complete when all signals have completed") {

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -185,25 +185,25 @@ class SignalProducerSpec: QuickSpec {
 				it("should immediately start subsequent inner producer if previous inner producer has already completed") {
 					completePrevious()
 					sendSubsequent()
-					expect(subsequentStarted).to(beTrue())
+					expect(subsequentStarted).to(beTruthy())
 				}
 
 				context("with queued producers") {
 					beforeEach {
 						// Place the subsequent producer into `concat`'s queue.
 						sendSubsequent()
-						expect(subsequentStarted).to(beFalse())
+						expect(subsequentStarted).to(beFalsy())
 					}
 
 					it("should start subsequent inner producer upon completion of previous inner producer") {
 						completePrevious()
-						expect(subsequentStarted).to(beTrue())
+						expect(subsequentStarted).to(beTruthy())
 					}
 
 					it("should start subsequent inner producer upon completion of previous inner producer and completion of outer producer") {
 						completeOuter()
 						completePrevious()
-						expect(subsequentStarted).to(beTrue())
+						expect(subsequentStarted).to(beTruthy())
 					}
 				}
 			}
@@ -254,18 +254,18 @@ class SignalProducerSpec: QuickSpec {
 
 				it("should complete when inner producers complete, then outer producer completes") {
 					completeInner()
-					expect(completed).to(beFalse())
+					expect(completed).to(beFalsy())
 
 					completeOuter()
-					expect(completed).to(beTrue())
+					expect(completed).to(beTruthy())
 				}
 
 				it("should complete when outer producers completes, then inner producers complete") {
 					completeOuter()
-					expect(completed).to(beFalse())
+					expect(completed).to(beFalsy())
 
 					completeInner()
-					expect(completed).to(beTrue())
+					expect(completed).to(beTruthy())
 				}
 			}
 		}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -161,7 +161,15 @@ class SignalProducerSpec: QuickSpec {
 			pending("should start subsequent inner signals upon completion") {
 			}
 
-			pending("should forward an error from an inner signal") {
+			it("should forward an error from an inner producer") {
+				let errorProducer = SignalProducer<Int, TestError>(error: TestError.Default)
+				let outerProducer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: errorProducer)
+
+				var error: TestError?
+				concat(outerProducer).start(error: { e in
+					error = e
+				})
+				expect(error).to(equal(TestError.Default))
 			}
 
 			it("should forward an error from the outer producer") {


### PR DESCRIPTION
This fixes a crash in a `concat()` in cases where a signals completes before following signals are added to the queue. The crash happens while attempting to dequeue from the empty queue. This arose when doing a binary `concat` with the first signal being `empty`, which completes synchronously before the second signal is handled on the outer signal.

EDIT: Turned into a bunch of refactoring. See https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1714#issuecomment-73197857 for description.

cc @andymatuschak 