### PR TITLE
Implement stubbed takeWhile() tests

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -526,7 +526,7 @@ public func takeUntilReplacement<T, E>(replacement: Signal<T, E>)(signal: Signal
 
 /// Waits until `signal` completes and then forwards the final `count` values
 /// on the returned signal.
-public func takeLast<T,E>(count: Int)(signal: Signal<T,E>) -> Signal<T,E> {
+public func takeLast<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 	return Signal { observer in
 		var buffer = [T]()
 		buffer.reserveCapacity(count)
@@ -553,7 +553,7 @@ public func takeLast<T,E>(count: Int)(signal: Signal<T,E>) -> Signal<T,E> {
 
 /// Forwards any values from `signal` until `predicate` returns false,
 /// at which point the returned signal will complete.
-public func takeWhile<T,E>(predicate: T -> Bool)(signal: Signal<T,E>) -> Signal<T,E> {
+public func takeWhile<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T, E> {
 	return Signal { observer in
 		return signal.observe(next: { value in
 			if predicate(value) {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -551,10 +551,27 @@ public func takeLast<T,E>(count: Int)(signal: Signal<T,E>) -> Signal<T,E> {
 	}
 }
 
+/// Forwards any values from `signal` until `predicate` returns false,
+/// at which point the returned signal will complete.
+public func takeWhile<T,E>(predicate: T -> Bool)(signal: Signal<T,E>) -> Signal<T,E> {
+	return Signal { observer in
+		return signal.observe(next: { value in
+			if predicate(value) {
+				sendNext(observer, value)
+			} else {
+				sendCompleted(observer)
+			}
+		}, error: { error in
+			sendError(observer, error)
+		}, completed: {
+			sendCompleted(observer)
+		})
+	}
+}
+
 /*
 TODO
 
-public func takeWhile<T>(predicate: T -> Bool)(signal: Signal<T>) -> Signal<T>
 public func throttle<T>(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T>) -> Signal<T>
 public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E>
 public func try<T, E>(operation: T -> Result<(), E>)(signal: Signal<T, E>) -> Signal<T, E>

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -152,9 +152,11 @@ class SignalSpec: QuickSpec {
 					completed = true
 				})
 
-				sendNext(observer, 4)
-				expect(latestValue).to(equal(4))
-				expect(completed).to(beFalse())
+				for value in -1...4 {
+					sendNext(observer, value)
+					expect(latestValue).to(equal(value))
+					expect(completed).to(beFalse())
+				}
 
 				sendNext(observer, 5)
 				expect(latestValue).to(equal(4))

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -162,13 +162,17 @@ class SignalSpec: QuickSpec {
 			}
 
 			it("should complete if the predicate starts false") {
+				var latestValue: Int?
 				var completed = false
 
-				signal.observe(completed: {
+				signal.observe(next: { value in
+					latestValue = value
+				}, completed: {
 					completed = true
 				})
 
 				sendNext(observer, 5)
+				expect(latestValue).to(beNil())
 				expect(completed).to(beTrue())
 			}
 		}

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -133,10 +133,43 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("takeWhile") {
-			pending("should take while the predicate is true") {
+			var signal: Signal<Int, NoError>!
+			var observer: Signal<Int, NoError>.Observer!
+
+			beforeEach {
+				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				signal = baseSignal |> takeWhile { $0 <= 4 }
+				observer = sink
 			}
 
-			pending("should complete if the predicate starts false") {
+			it("should take while the predicate is true") {
+				var latestValue: Int!
+				var completed = false
+
+				signal.observe(next: { value in
+					latestValue = value
+				}, completed: {
+					completed = true
+				})
+
+				sendNext(observer, 4)
+				expect(latestValue).to(equal(4))
+				expect(completed).to(beFalse())
+
+				sendNext(observer, 5)
+				expect(latestValue).to(equal(4))
+				expect(completed).to(beTrue())
+			}
+
+			it("should complete if the predicate starts false") {
+				var completed = false
+
+				signal.observe(completed: {
+					completed = true
+				})
+
+				sendNext(observer, 5)
+				expect(completed).to(beTrue())
 			}
 		}
 


### PR DESCRIPTION
Depends on #1717 

As mentioned in #1717, these tests use `observe()` as a method, because the free function `observe()` crashes swiftc.