### PR TITLE
Add then() SignalProducer

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -475,8 +475,9 @@ public func concat<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 				serialDisposableCompositeHandle.remove()
 				state.modify { (var state) in
 					state.latestSignalCompleted = true
-					let outerSignalIsComplete = completeIfAllowed(state)
-					if !outerSignalIsComplete && !state.queuedSignalProducers.isEmpty {
+					if state.queuedSignalProducers.isEmpty {
+						completeIfAllowed(state)
+					} else {
 						nextSignalProducer = state.queuedSignalProducers.removeAtIndex(0)
 					}
 					return state

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -476,9 +476,8 @@ public func concat<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 				state.modify { (var state) in
 					state.latestSignalCompleted = true
 					let outerSignalIsComplete = completeIfAllowed(state)
-					if !outerSignalIsComplete {
-						nextSignalProducer = state.queuedSignalProducers[0]
-						state.queuedSignalProducers.removeAtIndex(0)
+					if !outerSignalIsComplete && !state.queuedSignalProducers.isEmpty {
+						nextSignalProducer = state.queuedSignalProducers.removeAtIndex(0)
 					}
 					return state
 				}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -555,13 +555,33 @@ public func switchMap<T, U>(transform: T -> SignalProducer<U>)(producer: SignalP
 public func repeat<T>(count: Int)(producer: SignalProducer<T>) -> SignalProducer<T>
 public func retry<T>(count: Int)(producer: SignalProducer<T>) -> SignalProducer<T>
 public func takeUntilReplacement<T>(replacement: SignalProducer<T>)(producer: SignalProducer<T>) -> SignalProducer<T>
-public func then<T, U>(replacement: SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<U>
 public func zipWith<T, U>(otherSignalProducer: SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<(T, U)>
 
 public func single<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>?
 public func last<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>?
 public func wait<T, E>(producer: SignalProducer<T, E>) -> Result<(), E>
 */
+
+/// Forwards errors and completion only from `producer`, values are omitted.
+public func ignoreValues<T, U, E>(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
+	return SignalProducer { observer, disposable in
+		let producerDisposable = producer.start(error: { error in
+			sendError(observer, error)
+		}, completed: {
+			sendCompleted(observer)
+		})
+
+		disposable.addDisposable(producerDisposable)
+	}
+}
+
+/// Waits for completion of `producer`, *then* forwards all events from
+/// `replacement`. Any error sent from `producer` is forwarded immediately, in
+/// which case `replacement` will not be started, and none of its events will be
+/// be forwarded. All values sent from `producer` are ignored.
+public func then<T, U, E>(replacement: SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
+	return producer |> ignoreValues |> concat(replacement)
+}
 
 /// Starts the producer, then blocks, waiting for the first value.
 public func first<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -219,16 +219,62 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("then") {
-			pending("should start the subsequent signal after the completion of the original") {
+			it("should start the subsequent producer after the completion of the original") {
+				var sink: Signal<Int, NoError>.Observer!
+				let original = SignalProducer<Int, NoError> { observer, _ in
+					sink = observer
+				}
+
+				var subsequentStarted = false
+				let subsequent = SignalProducer<Int, NoError> { observer, _ in
+					subsequentStarted = true
+				}
+
+				let producer = original |> then(subsequent)
+
+				producer.start()
+				expect(subsequentStarted).to(beFalse())
+				sendCompleted(sink)
+				expect(subsequentStarted).to(beTrue())
 			}
 
-			pending("should forward errors from the original signal") {
+			it("should forward errors from the original producer") {
+				let original = SignalProducer<Int, TestError>(error: .Default)
+				let subsequent = SignalProducer<Int, TestError>.empty
+
+				let result = original |> then(subsequent) |> first
+				expect(result?.error).to(equal(TestError.Default))
 			}
 
-			pending("should forward errors from the subsequent signal") {
+			it("should forward errors from the subsequent producer") {
+				let original = SignalProducer<Int, TestError>.empty
+				let subsequent = SignalProducer<Int, TestError>(error: .Default)
+
+				let result = original |> then(subsequent) |> first
+				expect(result?.error).to(equal(TestError.Default))
 			}
 
-			pending("should complete when both inputs have completed") {
+			it("should complete when both inputs have completed") {
+				var originalSink: Signal<Int, NoError>.Observer!
+				let original = SignalProducer<Int, NoError> { observer, _ in
+					originalSink = observer
+				}
+				var subsequentSink: Signal<String, NoError>.Observer!
+				let subsequent = SignalProducer<String, NoError> { observer, _ in
+					subsequentSink = observer
+				}
+
+				let producer = original |> then(subsequent)
+
+				var completed = false
+				producer.start(completed: {
+					completed = true
+				})
+
+				sendCompleted(originalSink)
+				expect(completed).to(beFalse())
+				sendCompleted(subsequentSink)
+				expect(completed).to(beTrue())
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -218,29 +218,6 @@ class SignalProducerSpec: QuickSpec {
 			}
 		}
 
-		describe("ignoreValues") {
-			it("should not forward values from original producer") {
-				let producer: SignalProducer<Int, NoError> = SignalProducer<Int, NoError>(values: [ 1, 2 ]) |> ignoreValues
-				var valueObserved = false
-				producer.start(next: { _ in valueObserved = true })
-				expect(valueObserved).to(beFalse())
-			}
-
-			it("should forward errors from original producer") {
-				let producer: SignalProducer<Int, TestError> = SignalProducer<Int, TestError>(error: .Default) |> ignoreValues
-				var errorObserved = false
-				producer.start(error: { _ in errorObserved = true })
-				expect(errorObserved).to(beTrue())
-			}
-
-			it("should complete when original producer completes") {
-				let producer: SignalProducer<Int, NoError> = SignalProducer<Int, NoError>.empty |> ignoreValues
-				var completionObserved = false
-				producer.start(completed: { _ in completionObserved = true })
-				expect(completionObserved).to(beTrue())
-			}
-		}
-
 		describe("then") {
 			it("should start the subsequent producer after the completion of the original") {
 				var sink: Signal<Int, NoError>.Observer!

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -218,6 +218,29 @@ class SignalProducerSpec: QuickSpec {
 			}
 		}
 
+		describe("ignoreValues") {
+			it("should not forward values from original producer") {
+				let producer: SignalProducer<Int, NoError> = SignalProducer<Int, NoError>(values: [ 1, 2 ]) |> ignoreValues
+				var valueObserved = false
+				producer.start(next: { _ in valueObserved = true })
+				expect(valueObserved).to(beFalse())
+			}
+
+			it("should forward errors from original producer") {
+				let producer: SignalProducer<Int, TestError> = SignalProducer<Int, TestError>(error: .Default) |> ignoreValues
+				var errorObserved = false
+				producer.start(error: { _ in errorObserved = true })
+				expect(errorObserved).to(beTrue())
+			}
+
+			it("should complete when original producer completes") {
+				let producer: SignalProducer<Int, NoError> = SignalProducer<Int, NoError>.empty |> ignoreValues
+				var completionObserved = false
+				producer.start(completed: { _ in completionObserved = true })
+				expect(completionObserved).to(beTrue())
+			}
+		}
+
 		describe("then") {
 			it("should start the subsequent producer after the completion of the original") {
 				var sink: Signal<Int, NoError>.Observer!

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -220,10 +220,7 @@ class SignalProducerSpec: QuickSpec {
 
 		describe("then") {
 			it("should start the subsequent producer after the completion of the original") {
-				var sink: Signal<Int, NoError>.Observer!
-				let original = SignalProducer<Int, NoError> { observer, _ in
-					sink = observer
-				}
+				let (original, sink) = SignalProducer<Int, NoError>.buffer()
 
 				var subsequentStarted = false
 				let subsequent = SignalProducer<Int, NoError> { observer, _ in
@@ -231,9 +228,9 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				let producer = original |> then(subsequent)
-
 				producer.start()
 				expect(subsequentStarted).to(beFalse())
+
 				sendCompleted(sink)
 				expect(subsequentStarted).to(beTrue())
 			}
@@ -255,14 +252,8 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should complete when both inputs have completed") {
-				var originalSink: Signal<Int, NoError>.Observer!
-				let original = SignalProducer<Int, NoError> { observer, _ in
-					originalSink = observer
-				}
-				var subsequentSink: Signal<String, NoError>.Observer!
-				let subsequent = SignalProducer<String, NoError> { observer, _ in
-					subsequentSink = observer
-				}
+				let (original, originalSink) = SignalProducer<Int, NoError>.buffer()
+				let (subsequent, subsequentSink) = SignalProducer<String, NoError>.buffer()
 
 				let producer = original |> then(subsequent)
 
@@ -273,6 +264,7 @@ class SignalProducerSpec: QuickSpec {
 
 				sendCompleted(originalSink)
 				expect(completed).to(beFalse())
+
 				sendCompleted(subsequentSink)
 				expect(completed).to(beTrue())
 			}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -229,10 +229,10 @@ class SignalProducerSpec: QuickSpec {
 
 				let producer = original |> then(subsequent)
 				producer.start()
-				expect(subsequentStarted).to(beFalse())
+				expect(subsequentStarted).to(beFalsy())
 
 				sendCompleted(sink)
-				expect(subsequentStarted).to(beTrue())
+				expect(subsequentStarted).to(beTruthy())
 			}
 
 			it("should forward errors from the original producer") {
@@ -263,10 +263,10 @@ class SignalProducerSpec: QuickSpec {
 				})
 
 				sendCompleted(originalSink)
-				expect(completed).to(beFalse())
+				expect(completed).to(beFalsy())
 
 				sendCompleted(subsequentSink)
-				expect(completed).to(beTrue())
+				expect(completed).to(beTruthy())
 			}
 		}
 


### PR DESCRIPTION
Depends on #1714 ([Compare view](https://github.com/ReactiveCocoa/ReactiveCocoa/compare/concat-nada...then))

This adds `then()` for `SignalProducer`.

