### PR TITLE
Remove references to "ReactiveCocoaFramework" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,17 +547,7 @@ are some resources related to FRP:
 [Framework Overview]: Documentation/FrameworkOverview.md
 [Functional Reactive Programming]: http://en.wikipedia.org/wiki/Functional_reactive_programming
 [GroceryList]:  https://github.com/jspahrsummers/GroceryList
-[Memory Management]: Documentation/MemoryManagement.md
-[NSObject+RACLifting]: ReactiveCocoa/NSObject+RACLifting.h
-[RACDisposable]: ReactiveCocoa/RACDisposable.h
-[RACEvent]: ReactiveCocoa/RACEvent.h
-[RACMulticastConnection]: ReactiveCocoa/RACMulticastConnection.h
-[RACScheduler]: ReactiveCocoa/RACScheduler.h
 [RACSequence]: ReactiveCocoa/RACSequence.h
-[RACSignal+Operations]: ReactiveCocoa/RACSignal+Operations.h
 [RACSignal]: ReactiveCocoa/RACSignal.h
-[RACStream]: ReactiveCocoa/RACStream.h
-[RACSubscriber]: ReactiveCocoa/RACSubscriber.h
-[RAC]: ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h
 [futures and promises]: http://en.wikipedia.org/wiki/Futures_and_promises
 [C-41]: https://github.com/AshFurrow/C-41

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ To add RAC to your application:
  1. Add the ReactiveCocoa repository as a submodule of your application's
     repository.
  1. Run `script/bootstrap` from within the ReactiveCocoa folder.
- 1. Drag and drop `ReactiveCocoaFramework/ReactiveCocoa.xcodeproj` into your
+ 1. Drag and drop `ReactiveCocoa.xcodeproj` into your
     application's Xcode project or workspace.
  1. On the "Build Phases" tab of your application target, add RAC to the "Link
     Binary With Libraries" phase.
@@ -517,7 +517,7 @@ which are real iOS apps written using ReactiveCocoa.
 
 ## Standalone Development
 
-If you’re working on RAC in isolation instead of integrating it into another project, you’ll want to open `ReactiveCocoaFramework/ReactiveCocoa.xcworkspace` and not the `.xcodeproj`.
+If you’re working on RAC in isolation instead of integrating it into another project, you’ll want to open `ReactiveCocoa.xcworkspace` and not the `.xcodeproj`.
 
 ## More Info
 
@@ -548,16 +548,16 @@ are some resources related to FRP:
 [Functional Reactive Programming]: http://en.wikipedia.org/wiki/Functional_reactive_programming
 [GroceryList]:  https://github.com/jspahrsummers/GroceryList
 [Memory Management]: Documentation/MemoryManagement.md
-[NSObject+RACLifting]: ReactiveCocoaFramework/ReactiveCocoa/NSObject+RACLifting.h
-[RACDisposable]: ReactiveCocoaFramework/ReactiveCocoa/RACDisposable.h
-[RACEvent]: ReactiveCocoaFramework/ReactiveCocoa/RACEvent.h
-[RACMulticastConnection]: ReactiveCocoaFramework/ReactiveCocoa/RACMulticastConnection.h
-[RACScheduler]: ReactiveCocoaFramework/ReactiveCocoa/RACScheduler.h
-[RACSequence]: ReactiveCocoaFramework/ReactiveCocoa/RACSequence.h
-[RACSignal+Operations]: ReactiveCocoaFramework/ReactiveCocoa/RACSignal+Operations.h
-[RACSignal]: ReactiveCocoaFramework/ReactiveCocoa/RACSignal.h
-[RACStream]: ReactiveCocoaFramework/ReactiveCocoa/RACStream.h
-[RACSubscriber]: ReactiveCocoaFramework/ReactiveCocoa/RACSubscriber.h
-[RAC]: ReactiveCocoaFramework/ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h
+[NSObject+RACLifting]: ReactiveCocoa/NSObject+RACLifting.h
+[RACDisposable]: ReactiveCocoa/RACDisposable.h
+[RACEvent]: ReactiveCocoa/RACEvent.h
+[RACMulticastConnection]: ReactiveCocoa/RACMulticastConnection.h
+[RACScheduler]: ReactiveCocoa/RACScheduler.h
+[RACSequence]: ReactiveCocoa/RACSequence.h
+[RACSignal+Operations]: ReactiveCocoa/RACSignal+Operations.h
+[RACSignal]: ReactiveCocoa/RACSignal.h
+[RACStream]: ReactiveCocoa/RACStream.h
+[RACSubscriber]: ReactiveCocoa/RACSubscriber.h
+[RAC]: ReactiveCocoa/RACSubscriptingAssignmentTrampoline.h
 [futures and promises]: http://en.wikipedia.org/wiki/Futures_and_promises
 [C-41]: https://github.com/AshFurrow/C-41

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to learn more, we recommend these resources, roughly in order:
  1. [When to use ReactiveCocoa](#when-to-use-reactivecocoa)
  1. [Framework Overview][]
  1. [Basic Operators][]
- 1. [Header documentation](ReactiveCocoaFramework/ReactiveCocoa)
+ 1. [Header documentation](ReactiveCocoa)
  1. Previously answered [Stack Overflow](https://github.com/ReactiveCocoa/ReactiveCocoa/wiki)
     questions and [GitHub issues](https://github.com/ReactiveCocoa/ReactiveCocoa/issues?labels=question&state=closed)
  1. The rest of the [Documentation][] folder


### PR DESCRIPTION
Just going through the to-do list for newcomers to RAC, noticed that one of the links returns a 404. I went back to the commit where it was added, and I'm pretty sure that it will now go to the correct place.

Before, the "Header Documentation" link would go to the `ReactiveCocoaFramework/ReactiveCocoa` directory, which I now believe has been moved to simply `ReactiveCocoa`.