### PR TITLE
RFC: Overload operators for NoError

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -174,10 +174,10 @@ public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 			if taken < count {
 				taken++
 				sendNext(observer, value)
+			}
 
-				if taken == count {
-					sendCompleted(observer)
-				}
+			if taken == count {
+				sendCompleted(observer)
 			}
 		}, error: { error in
 			sendError(observer, error)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -174,7 +174,8 @@ public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 			if taken < count {
 				taken++
 				sendNext(observer, value)
-			} else {
+			}
+			if taken == count {
 				sendCompleted(observer)
 			}
 		}, error: { error in

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -174,9 +174,10 @@ public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 			if taken < count {
 				taken++
 				sendNext(observer, value)
-			}
-			if taken == count {
-				sendCompleted(observer)
+
+				if taken == count {
+					sendCompleted(observer)
+				}
 			}
 		}, error: { error in
 			sendError(observer, error)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -175,15 +175,16 @@ public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T
 public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 	precondition(count >= 0)
 
+	if count == 0 {
+		return Signal.empty
+	}
+
 	return Signal { observer in
 		var taken = 0
 
 		return signal.observe(next: { value in
-			if taken < count {
-				taken++
-				sendNext(observer, value)
-			}
-			if taken == count {
+			sendNext(observer, value)
+			if ++taken == count {
 				sendCompleted(observer)
 			}
 		}, error: { error in

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -56,6 +56,14 @@ public final class Signal<T, E: ErrorType> {
 		}
 	}
 
+	/// A Signal that completes immediately.
+	public class var empty: Signal {
+		return self {
+			sendCompleted($0)
+			return nil
+		}
+	}
+
 	/// A Signal that never sends any events.
 	public class var never: Signal {
 		return self { _ in nil }

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -56,14 +56,6 @@ public final class Signal<T, E: ErrorType> {
 		}
 	}
 
-	/// A Signal that completes immediately.
-	public class var empty: Signal {
-		return self {
-			sendCompleted($0)
-			return nil
-		}
-	}
-
 	/// A Signal that never sends any events.
 	public class var never: Signal {
 		return self { _ in nil }
@@ -175,16 +167,15 @@ public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T
 public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 	precondition(count >= 0)
 
-	if count == 0 {
-		return Signal.empty
-	}
-
 	return Signal { observer in
 		var taken = 0
 
 		return signal.observe(next: { value in
-			sendNext(observer, value)
-			if ++taken == count {
+			if taken < count {
+				taken++
+				sendNext(observer, value)
+			}
+			if taken == count {
 				sendCompleted(observer)
 			}
 		}, error: { error in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -561,24 +561,7 @@ public func zipWith<T, U>(otherSignalProducer: SignalProducer<U>)(producer: Sign
 
 /// Starts the producer, then blocks, waiting for the first value.
 public func first<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
-	let semaphore = dispatch_semaphore_create(0)
-	var result: Result<T, E>?
-
-	producer
-		|> take(1)
-		|> start(next: { value in
-			result = success(value)
-			dispatch_semaphore_signal(semaphore)
-		}, error: { error in
-			result = failure(error)
-			dispatch_semaphore_signal(semaphore)
-		}, completed: {
-			dispatch_semaphore_signal(semaphore)
-			return
-		})
-
-	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
-	return result
+	return producer |> take(1) |> single
 }
 
 /// Starts the producer, then blocks, waiting for events: Next and Completed.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -596,7 +596,7 @@ public func single<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
 
 /// Starts the producer, then blocks, waiting for the last value.
 public func last<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
-	return producer |> takeLast(1) |> first
+	return producer |> takeLast(1) |> single
 }
 
 /// Starts the producer, then blocks, waiting for completion.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -618,19 +618,8 @@ public func last<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
 
 /// Starts the producer, then blocks, waiting for completion.
 public func wait<T, E>(producer: SignalProducer<T, E>) -> Result<(), E> {
-	let semaphore = dispatch_semaphore_create(0)
-	var result: Result<(), E>!
-
-	producer.start(error: { error in
-		result = failure(error)
-		dispatch_semaphore_signal(semaphore)
-	}, completed: {
-		result = success(())
-		dispatch_semaphore_signal(semaphore)
-	})
-
-	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
-	return result
+	let result = producer |> map { _ in () } |> last
+	return result ?? success(())
 }
 
 /// SignalProducer.startWithSignal() as a free function, for easier use with |>.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -613,24 +613,7 @@ public func single<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
 
 /// Starts the producer, then blocks, waiting for the last value.
 public func last<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
-	let semaphore = dispatch_semaphore_create(0)
-	var result: Result<T, E>?
-
-	producer
-		|> takeLast(1)
-		|> start(next: { value in
-			result = success(value)
-			dispatch_semaphore_signal(semaphore)
-		}, error: { error in
-			result = failure(error)
-			dispatch_semaphore_signal(semaphore)
-		}, completed: {
-			dispatch_semaphore_signal(semaphore)
-			return
-		})
-
-	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
-	return result
+	return producer |> takeLast(1) |> first
 }
 
 /// Starts the producer, then blocks, waiting for completion.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -633,6 +633,7 @@ public func last<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
 	return result
 }
 
+/// Starts the producer, then blocks, waiting for completion.
 public func wait<T, E>(producer: SignalProducer<T, E>) -> Result<(), E> {
 	let semaphore = dispatch_semaphore_create(0)
 	var result: Result<(), E>!

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -335,10 +335,27 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("wait") {
-			pending("should start a signal then block until completion") {
+			it("should start a signal then block until completion") {
+				var sink: Signal<Int, NoError>.Observer!
+				let producer = SignalProducer<Int, NoError> { observer, _ in
+					sink = observer
+				}
+				expect(sink).to(beNil())
+
+				var result: Result<(), NoError>?
+				dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+					result = producer |> wait
+				}
+				expect(sink).toEventuallyNot(beNil())
+				expect(result).to(beNil())
+
+				sendCompleted(sink)
+				expect(result?.value).toNot(beNil())
 			}
 			
-			pending("should return an error if one occurs") {
+			it("should return an error if one occurs") {
+				let result = SignalProducer<Int, TestError>(error: .Default) |> wait
+				expect(result.error).to(equal(TestError.Default))
 			}
 		}
 	}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -233,13 +233,32 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("first") {
-			pending("should start a signal then block on the first value") {
+			it("should start a signal then block on the first value") {
+				var sink: Signal<Int, NoError>.Observer!
+				let producer = SignalProducer<Int, NoError> { observer, _ in
+					sink = observer
+				}
+				expect(sink).to(beNil())
+
+				var result: Result<Int, NoError>?
+				dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+					result = producer |> first
+				}
+				expect(sink).toEventuallyNot(beNil())
+				expect(result).to(beNil())
+
+				sendNext(sink, 1)
+				expect(result?.value).to(equal(1))
 			}
 
-			pending("should return a nil result if no values are sent before completion") {
+			it("should return a nil result if no values are sent before completion") {
+				let result = SignalProducer<Int, NoError>.empty |> first
+				expect(result).to(beNil())
 			}
 
-			pending("should return an error if one occurs before the first value") {
+			it("should return an error if one occurs before the first value") {
+				let result = SignalProducer<Int, TestError>(error: .Default) |> first
+				expect(result?.error).to(equal(TestError.Default))
 			}
 		}
 


### PR DESCRIPTION
Depends on #1710 ([Compare](https://github.com/ReactiveCocoa/ReactiveCocoa/compare/producer-sync...noerror-sync-funcs))

What do we think about operators being overloaded for `NoError`? Is the convenience “easy” at the cost of “simple”?

This pull request has some examples for the blocking methods in #1710 `{first,single,last,wait}`, but there may be other cases where overloading for `NoError` will make for calling code with less type system appeasing.

For example:

```swift
func first<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>?
// and
func first<T, E: ErrorType>(producer: SignalProducer<T, NoError>) -> T?
```