### PR TITLE
implementations of <~ for producers and poperties

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -132,16 +132,11 @@ public func <~ <T>(property: MutableProperty<T>, signal: Signal<T, NoError>) -> 
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the created signal sends a `Completed` event.
 public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T, NoError>) -> Disposable {
-	let disposable = CompositeDisposable()
-	let propertyDisposable = property.producer.start(completed: {
-		disposable.dispose()
-	})
-	
-	disposable.addDisposable(propertyDisposable)
+	var disposable: Disposable!
 	
 	producer.startWithSignal { signal, signalDisposable in
-		disposable.addDisposable(signalDisposable)
 		property <~ signal
+		disposable = signalDisposable
 	}
 	
 	return disposable

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -137,6 +137,10 @@ public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T, NoE
 	producer.startWithSignal { signal, signalDisposable in
 		property <~ signal
 		disposable = signalDisposable
+		
+		property.producer.start(completed: {
+			signalDisposable.dispose()
+		})
 	}
 	
 	return disposable

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -124,8 +124,6 @@ public func <~ <T>(property: MutableProperty<T>, signal: Signal<T, NoError>) -> 
 	return disposable
 }
 
-/*
-FIXME: DISABLED DUE TO COMPILER BUG
 
 /// Creates a signal from the given producer, which will be immediately bound to
 /// the given property, updating the property's value to the latest value sent
@@ -138,46 +136,22 @@ public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T, NoE
 	let propertyDisposable = property.producer.start(completed: {
 		disposable.dispose()
 	})
-
+	
 	disposable.addDisposable(propertyDisposable)
-
+	
 	producer.startWithSignal { signal, signalDisposable in
 		disposable.addDisposable(signalDisposable)
-
-		signal.observe(next: { [weak property] value in
-			property?.value = value
-			return
-		}, completed: {
-			disposable.dispose()
-		})
+		property <~ signal
 	}
-
+	
 	return disposable
 }
+
 
 /// Binds `destinationProperty` to the latest values of `sourceProperty`.
 ///
 /// The binding will automatically terminate when either property is
 /// deinitialized.
 public func <~ <T, P: PropertyType where P.Value == T>(destinationProperty: MutableProperty<T>, sourceProperty: P) -> Disposable {
-	let disposable = CompositeDisposable()
-	let destinationDisposable = destinationProperty.producer.start(completed: {
-		disposable.dispose()
-	})
-
-	disposable.addDisposable(destinationDisposable)
-
-	sourceProperty.producer.startWithSignal { signal, sourceDisposable in
-		disposable.addDisposable(sourceDisposable)
-
-		signal.observe(next: { [weak destinationProperty] value in
-			destinationProperty?.value = value
-			return
-		}, completed: {
-			disposable.dispose()
-		})
-	}
-
-	return disposable
+	return destinationProperty <~ sourceProperty.producer
 }
-*/

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -136,98 +136,98 @@ class PropertySpec: QuickSpec {
 
 			describe("from a SignalProducer") {
 				pending("should start a signal and update the property with its values") {
-//					let signalValues = [initialPropertyValue, subsequentPropertyValue]
-//					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
-//
-//					let mutableProperty = MutableProperty(initialPropertyValue)
-//
-//					mutableProperty <~ signalProducer
-//
-//					expect(mutableProperty.value).to(equal(signalValues.last!))
+					let signalValues = [initialPropertyValue, subsequentPropertyValue]
+					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
+
+					let mutableProperty = MutableProperty(initialPropertyValue)
+
+					mutableProperty <~ signalProducer
+
+					expect(mutableProperty.value).to(equal(signalValues.last!))
 				}
 
 				pending("should tear down the binding when disposed") {
-//					let signalValues = [initialPropertyValue, subsequentPropertyValue]
-//					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
-//
-//					let mutableProperty = MutableProperty(initialPropertyValue)
-//
-//					let disposable = mutableProperty <~ signalProducer
-//
-//					disposable.dispose()
-//					// TODO: Assert binding was teared-down?
+					let signalValues = [initialPropertyValue, subsequentPropertyValue]
+					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
+
+					let mutableProperty = MutableProperty(initialPropertyValue)
+
+					let disposable = mutableProperty <~ signalProducer
+
+					disposable.dispose()
+					// TODO: Assert binding was teared-down?
 				}
 
 				pending("should tear down the binding when the property deallocates") {
-//					let signalValues = [initialPropertyValue, subsequentPropertyValue]
-//					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
-//
-//					var mutableProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
-//
-//					let disposable = mutableProperty! <~ signalProducer
-//
-//					mutableProperty = nil
-//					expect(disposable.disposed).to(beTruthy())
+					let signalValues = [initialPropertyValue, subsequentPropertyValue]
+					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
+
+					var mutableProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
+
+					let disposable = mutableProperty! <~ signalProducer
+
+					mutableProperty = nil
+					expect(disposable.disposed).to(beTruthy())
 				}
 			}
 
 			describe("from another property") {
 				pending("should take the source property's current value") {
-//					let sourceProperty = ConstantProperty(initialPropertyValue)
-//
-//					let destinationProperty = MutableProperty("")
-//
-//					destinationProperty <~ sourceProperty.producer
-//
-//					expect(destinationProperty.value).to(equal(initialPropertyValue))
+					let sourceProperty = ConstantProperty(initialPropertyValue)
+
+					let destinationProperty = MutableProperty("")
+
+					destinationProperty <~ sourceProperty.producer
+
+					expect(destinationProperty.value).to(equal(initialPropertyValue))
 				}
 
 			pending("should update with changes to the source property's value") {
-//					let sourceProperty = MutableProperty(initialPropertyValue)
-//
-//					let destinationProperty = MutableProperty("")
-//
-//					destinationProperty <~ sourceProperty.producer
-//
-//					destinationProperty.value = subsequentPropertyValue
-//					expect(destinationProperty.value).to(equal(subsequentPropertyValue))
+					let sourceProperty = MutableProperty(initialPropertyValue)
+
+					let destinationProperty = MutableProperty("")
+
+					destinationProperty <~ sourceProperty.producer
+
+					destinationProperty.value = subsequentPropertyValue
+					expect(destinationProperty.value).to(equal(subsequentPropertyValue))
 				}
 
 				pending("should tear down the binding when disposed") {
-//					let sourceProperty = MutableProperty(initialPropertyValue)
-//
-//					let destinationProperty = MutableProperty("")
-//
-//					let bindingDisposable = destinationProperty <~ sourceProperty.producer
-//					bindingDisposable.dispose()
-//
-//					sourceProperty.value = subsequentPropertyValue
-//
-//					expect(destinationProperty.value).to(equal(initialPropertyValue))
+					let sourceProperty = MutableProperty(initialPropertyValue)
+
+					let destinationProperty = MutableProperty("")
+
+					let bindingDisposable = destinationProperty <~ sourceProperty.producer
+					bindingDisposable.dispose()
+
+					sourceProperty.value = subsequentPropertyValue
+
+					expect(destinationProperty.value).to(equal(initialPropertyValue))
 				}
 
 				pending("should tear down the binding when the source property deallocates") {
-//					var sourceProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
-//
-//					let destinationProperty = MutableProperty("")
-//
-//					let bindingDisposable = destinationProperty <~ sourceProperty!.producer
-//
-//					sourceProperty = nil
-//
-//					expect(bindingDisposable.disposed).to(beTruthy())
+					var sourceProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
+
+					let destinationProperty = MutableProperty("")
+
+					let bindingDisposable = destinationProperty <~ sourceProperty!.producer
+
+					sourceProperty = nil
+
+					expect(bindingDisposable.disposed).to(beTruthy())
 				}
 
 				pending("should tear down the binding when the destination property deallocates") {
-//					let sourceProperty = MutableProperty(initialPropertyValue)
-//
-//					var destinationProperty: MutableProperty<String>? = MutableProperty("")
-//
-//					let bindingDisposable = destinationProperty! <~ sourceProperty.producer
-//
-//					destinationProperty = nil
-//
-//					expect(bindingDisposable.disposed).to(beTruthy())
+					let sourceProperty = MutableProperty(initialPropertyValue)
+
+					var destinationProperty: MutableProperty<String>? = MutableProperty("")
+
+					let bindingDisposable = destinationProperty! <~ sourceProperty.producer
+
+					destinationProperty = nil
+
+					expect(bindingDisposable.disposed).to(beTruthy())
 				}
 			}
 		}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -135,7 +135,7 @@ class PropertySpec: QuickSpec {
 			}
 
 			describe("from a SignalProducer") {
-				pending("should start a signal and update the property with its values") {
+				it("should start a signal and update the property with its values") {
 					let signalValues = [initialPropertyValue, subsequentPropertyValue]
 					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
 
@@ -146,7 +146,7 @@ class PropertySpec: QuickSpec {
 					expect(mutableProperty.value).to(equal(signalValues.last!))
 				}
 
-				pending("should tear down the binding when disposed") {
+				it("should tear down the binding when disposed") {
 					let signalValues = [initialPropertyValue, subsequentPropertyValue]
 					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
 
@@ -158,7 +158,7 @@ class PropertySpec: QuickSpec {
 					// TODO: Assert binding was teared-down?
 				}
 
-				pending("should tear down the binding when the property deallocates") {
+				it("should tear down the binding when the property deallocates") {
 					let signalValues = [initialPropertyValue, subsequentPropertyValue]
 					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
 
@@ -172,7 +172,7 @@ class PropertySpec: QuickSpec {
 			}
 
 			describe("from another property") {
-				pending("should take the source property's current value") {
+				it("should take the source property's current value") {
 					let sourceProperty = ConstantProperty(initialPropertyValue)
 
 					let destinationProperty = MutableProperty("")
@@ -182,7 +182,7 @@ class PropertySpec: QuickSpec {
 					expect(destinationProperty.value).to(equal(initialPropertyValue))
 				}
 
-			pending("should update with changes to the source property's value") {
+				it("should update with changes to the source property's value") {
 					let sourceProperty = MutableProperty(initialPropertyValue)
 
 					let destinationProperty = MutableProperty("")
@@ -193,7 +193,7 @@ class PropertySpec: QuickSpec {
 					expect(destinationProperty.value).to(equal(subsequentPropertyValue))
 				}
 
-				pending("should tear down the binding when disposed") {
+				it("should tear down the binding when disposed") {
 					let sourceProperty = MutableProperty(initialPropertyValue)
 
 					let destinationProperty = MutableProperty("")
@@ -206,7 +206,7 @@ class PropertySpec: QuickSpec {
 					expect(destinationProperty.value).to(equal(initialPropertyValue))
 				}
 
-				pending("should tear down the binding when the source property deallocates") {
+				it("should tear down the binding when the source property deallocates") {
 					var sourceProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
 
 					let destinationProperty = MutableProperty("")
@@ -218,7 +218,7 @@ class PropertySpec: QuickSpec {
 					expect(bindingDisposable.disposed).to(beTruthy())
 				}
 
-				pending("should tear down the binding when the destination property deallocates") {
+				it("should tear down the binding when the destination property deallocates") {
 					let sourceProperty = MutableProperty(initialPropertyValue)
 
 					var destinationProperty: MutableProperty<String>? = MutableProperty("")


### PR DESCRIPTION
This is my attempt to fix the <~ Operator. As you can see I simply reuse the signal version of the operator. This implementation doesn't crash the compiler. 

I hope I handled disposal right. :)