### PR TITLE
Preserve overall order in -groupBy:transform:

### DIFF
--- a/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaTests/RACSignalSpec.m
@@ -3664,7 +3664,7 @@ qck_describe(@"-groupBy:", ^{
 	});
 
 
-	qck_it(@"should send completed in the order grouped signaled were created.", ^{
+	qck_it(@"should send completed in the order grouped signals were created.", ^{
 		RACSubject *subject = [RACReplaySubject subject];
 
 		NSMutableArray *startedSignals = [NSMutableArray array];

--- a/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaTests/RACSignalSpec.m
@@ -3662,6 +3662,31 @@ qck_describe(@"-groupBy:", ^{
 
 		expect(@(erroneousGroupedSignalCount)).to(equal(@(groupedSignalCount)));
 	});
+
+
+	qck_it(@"should send completed in the order grouped signaled were created.", ^{
+		RACSubject *subject = [RACReplaySubject subject];
+
+		NSMutableArray *startedSignals = [NSMutableArray array];
+		NSMutableArray *completedSignals = [NSMutableArray array];
+		[[subject groupBy:^(NSNumber *number) {
+			return @(number.integerValue % 4);
+		}] subscribeNext:^(RACGroupedSignal *groupedSignal) {
+			[startedSignals addObject:groupedSignal];
+
+			[groupedSignal subscribeCompleted:^{
+				[completedSignals addObject:groupedSignal];
+			}];
+		}];
+
+		for (NSInteger i = 0; i < 20; i++)
+		{
+			[subject sendNext:@(i)];
+		}
+		[subject sendCompleted];
+
+		expect(completedSignals).to(equal(startedSignals));
+	});
 });
 
 qck_describe(@"starting signals", ^{


### PR DESCRIPTION
Given the following code:

```objective-c
RACSignal *numbers = [[[@"1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30" componentsSeparatedByString:@" "].rac_sequence
    map:^(NSString *string) {
        return @([string integerValue]);
    }]
    signal];

[[[numbers
    groupBy:^(NSNumber *number) {
        return @(number.integerValue % 3);
    }]
    flattenMap:^(RACSignal *signal) {
        return [signal collect];
    }]
    subscribeNext:^(NSArray *group) {
        NSLog(@"%@", group.firstObject);
    }];
```
I would expect to see “1, 2, 3” as my output. But instead I get “3, 1, 2”

Removing the `collect` and just watching all the signals makes the values all come through in the correct order. It’s the signal completion that’s happening out of order. This line’s the culprit:

```objective-c
[groups.allValues makeObjectsPerformSelector:@selector(sendCompleted)];
```

Which sends completions based on `NSArray`’s internal ordering.

This resolves that issue by also keeping an ordered list of the `RACGroupedSignal`s and sending completion based on that.