### PR TITLE
Add an Interrupted event

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -63,19 +63,9 @@ public final class Action<Input, Output, Error: ErrorType> {
 		errorsObserver = eSink
 		errors = eSig
 
-		enabledIf.producer
+		_enabled <~ enabledIf.producer
 			|> combineLatestWith(executing.producer)
 			|> map(self.dynamicType.shouldBeEnabled)
-			// FIXME: Workaround for <~ being disabled on SignalProducers.
-			|> startWithSignal { signal, disposable in
-				let bindDisposable = self._enabled <~ signal
-
-				signal.observe(SinkOf { event in
-					if event.isTerminating {
-						bindDisposable.dispose()
-					}
-				})
-			}
 	}
 
 	/// Initializes an action that will be enabled by default, and create a

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -69,7 +69,12 @@ public final class Action<Input, Output, Error: ErrorType> {
 			// FIXME: Workaround for <~ being disabled on SignalProducers.
 			|> startWithSignal { signal, disposable in
 				let bindDisposable = self._enabled <~ signal
-				disposable.addDisposable(bindDisposable)
+
+				signal.observe(SinkOf { event in
+					if event.isTerminating {
+						bindDisposable.dispose()
+					}
+				})
 			}
 	}
 

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -93,12 +93,21 @@ public final class CompositeDisposable: Disposable {
 
 	/// Initializes a CompositeDisposable containing the given sequence of
 	/// disposables.
-	public init<S: SequenceType where S.Generator.Element == Disposable>(_ disposables: S) {
+	public convenience init<S: SequenceType where S.Generator.Element == Disposable>(_ disposables: S) {
+		let optionalDisposables = map(disposables) { Optional.Some($0) }
+		self.init(optionalDisposables)
+	}
+
+	/// Initializes a CompositeDisposable containing all non-nil disposables
+	/// from the given sequence.
+	public init<S: SequenceType where S.Generator.Element == Optional<Disposable>>(_ disposables: S) {
 		var bag: Bag<Disposable> = Bag()
 
 		var generator = disposables.generate()
-		while let disposable: Disposable = generator.next() {
-			bag.insert(disposable)
+		while let disposable: Disposable? = generator.next() {
+			if let disposable = disposable {
+				bag.insert(disposable)
+			}
 		}
 
 		self.disposables = Atomic(bag)
@@ -106,7 +115,7 @@ public final class CompositeDisposable: Disposable {
 
 	/// Initializes an empty CompositeDisposable.
 	public convenience init() {
-		self.init([])
+		self.init(Array<Disposable?>())
 	}
 
 	public func dispose() {

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -93,21 +93,12 @@ public final class CompositeDisposable: Disposable {
 
 	/// Initializes a CompositeDisposable containing the given sequence of
 	/// disposables.
-	public convenience init<S: SequenceType where S.Generator.Element == Disposable>(_ disposables: S) {
-		let optionalDisposables = map(disposables) { Optional.Some($0) }
-		self.init(optionalDisposables)
-	}
-
-	/// Initializes a CompositeDisposable containing all non-nil disposables
-	/// from the given sequence.
-	public init<S: SequenceType where S.Generator.Element == Optional<Disposable>>(_ disposables: S) {
+	public init<S: SequenceType where S.Generator.Element == Disposable>(_ disposables: S) {
 		var bag: Bag<Disposable> = Bag()
 
 		var generator = disposables.generate()
-		while let disposable: Disposable? = generator.next() {
-			if let disposable = disposable {
-				bag.insert(disposable)
-			}
+		while let disposable: Disposable = generator.next() {
+			bag.insert(disposable)
 		}
 
 		self.disposables = Atomic(bag)
@@ -115,7 +106,7 @@ public final class CompositeDisposable: Disposable {
 
 	/// Initializes an empty CompositeDisposable.
 	public convenience init() {
-		self.init(Array<Disposable?>())
+		self.init([])
 	}
 
 	public func dispose() {

--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -137,3 +137,8 @@ public func sendError<T, E>(sink: SinkOf<Event<T, E>>, error: E) {
 public func sendCompleted<T, E>(sink: SinkOf<Event<T, E>>) {
 	sink.put(Event<T, E>.Completed)
 }
+
+/// Puts a `Cancelled` event into the given sink.
+public func sendCancelled<T, E>(sink: SinkOf<Event<T, E>>) {
+	sink.put(Event<T, E>.Cancelled)
+}

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -49,3 +49,17 @@ extension NSURLSession {
 		}
 	}
 }
+
+/// Removes all nil values from the given sequence.
+internal func ignoreNil<T, S: SequenceType where S.Generator.Element == Optional<T>>(sequence: S) -> [T] {
+	var results: [T] = []
+	var generator = sequence.generate()
+
+	while let value: T? = generator.next() {
+		if let value = value {
+			results.append(value)
+		}
+	}
+
+	return results
+}

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -81,12 +81,16 @@ private func optionalize<T, E>(signal: Signal<T, E>) -> Signal<T?, E> {
 
 /// Creates a RACSignal that will start() the producer once for each
 /// subscription.
+///
+/// Any `Interrupted` events will be silently discarded.
 public func asRACSignal<T: AnyObject, E>(producer: SignalProducer<T, E>) -> RACSignal {
 	return asRACSignal(producer |> optionalize)
 }
 
 /// Creates a RACSignal that will start() the producer once for each
 /// subscription.
+///
+/// Any `Interrupted` events will be silently discarded.
 public func asRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RACSignal {
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start(next: { value in
@@ -104,11 +108,15 @@ public func asRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RAC
 }
 
 /// Creates a RACSignal that will observe the given signal.
+///
+/// Any `Interrupted` event will be silently discarded.
 public func asRACSignal<T: AnyObject, E>(signal: Signal<T, E>) -> RACSignal {
 	return asRACSignal(signal |> optionalize)
 }
 
 /// Creates a RACSignal that will observe the given signal.
+///
+/// Any `Interrupted` event will be silently discarded.
 public func asRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = signal.observe(next: { value in
@@ -120,7 +128,8 @@ public func asRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
 		})
 
 		return RACDisposable {
-			selfDisposable.dispose()
+			selfDisposable?.dispose()
+			return
 		}
 	}
 }
@@ -140,7 +149,12 @@ extension RACCommand {
 			// FIXME: Workaround for <~ being disabled on SignalProducers.
 			|> startWithSignal { signal, disposable in
 				let bindDisposable = enabledProperty <~ signal
-				disposable.addDisposable(bindDisposable)
+				
+				signal.observe(SinkOf { event in
+					if event.isTerminating {
+						bindDisposable.dispose()
+					}
+				})
 			}
 
 		return Action(enabledIf: enabledProperty) { (input: AnyObject?) -> SignalProducer<AnyObject?, NSError> in

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -346,7 +346,7 @@ public func dematerialize<T, E>(signal: Signal<Event<T, E>, NoError>) -> Signal<
 				observer.put(innerEvent.unbox)
 
 			case .Error:
-				assert(false)
+				fatalError()
 
 			case .Completed:
 				sendCompleted(observer)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -90,15 +90,15 @@ public final class Signal<T, E: ErrorType> {
 		let token = self.observers?.insert(sink)
 		lock.unlock()
 
-		if token == nil {
-			sink.put(.Interrupted)
-			return nil
-		} else {
+		if let token = token {
 			return ActionDisposable {
 				self.lock.lock()
-				self.observers?.removeValueForToken(token!)
+				self.observers?.removeValueForToken(token)
 				self.lock.unlock()
 			}
+		} else {
+			sink.put(.Interrupted)
+			return nil
 		}
 	}
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -34,13 +34,20 @@ public final class Signal<T, E: ErrorType> {
 			self.lock.lock()
 
 			if let observers = self.observers {
+				if event.isTerminating {
+					// Disallow any further events (e.g., any triggered
+					// recursively).
+					self.observers = nil
+				}
+
 				for sink in observers {
 					sink.put(event)
 				}
 
 				if event.isTerminating {
+					// Dispose only after notifying observers, so disposal logic
+					// is consistently the last thing to run.
 					generatorDisposable.dispose()
-					self.observers = nil
 				}
 			}
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -50,10 +50,10 @@ public final class Signal<T, E: ErrorType> {
 	}
 
 	/// A Signal that immediately cancels itself, so that it never sends
-	/// meaningful events to new observers.
+	/// meaningful events to observers.
 	public class var never: Signal {
 		return self { observer in
-			observer.put(.Cancelled)
+			sendCancelled(observer)
 			return nil
 		}
 	}

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -256,7 +256,7 @@ public func combineLatestWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal
 		let signalDisposable = signal |> observeWithStates(signalState, otherState, lock, onBothNext, onError, onBothCompleted, onInterrupted)
 		let otherDisposable = otherSignal |> observeWithStates(otherState, signalState, lock, onBothNext, onError, onBothCompleted, onInterrupted)
 
-		return CompositeDisposable([ signalDisposable, otherDisposable ])
+		return CompositeDisposable(ignoreNil([ signalDisposable, otherDisposable ]))
 	}
 }
 
@@ -409,7 +409,7 @@ public func sampleOn<T, E>(sampler: Signal<(), NoError>)(signal: Signal<T, E>) -
 			sendInterrupted(observer)
 		})
 
-		return CompositeDisposable([ signalDisposable, samplerDisposable ])
+		return CompositeDisposable(ignoreNil([ signalDisposable, samplerDisposable ]))
 	}
 }
 
@@ -428,7 +428,7 @@ public func takeUntil<T, E>(trigger: Signal<(), NoError>)(signal: Signal<T, E>) 
 			}
 		})
 
-		return CompositeDisposable([ signalDisposable, triggerDisposable ])
+		return CompositeDisposable(ignoreNil([ signalDisposable, triggerDisposable ]))
 	}
 }
 
@@ -545,7 +545,7 @@ public func takeUntilReplacement<T, E>(replacement: Signal<T, E>)(signal: Signal
 			observer.put(event)
 		})
 
-		return CompositeDisposable([ signalDisposable, replacementDisposable ])
+		return CompositeDisposable(ignoreNil([ signalDisposable, replacementDisposable ]))
 	}
 }
 
@@ -673,7 +673,7 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 			flush()
 		}, interrupted: onInterrupted)
 
-		return CompositeDisposable([ signalDisposable, otherDisposable ])
+		return CompositeDisposable(ignoreNil([ signalDisposable, otherDisposable ]))
 	}
 }
 
@@ -864,10 +864,7 @@ public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInter
 		}
 
 		let signalDisposable = signal.observe(observer)
-
-		let disposable = CompositeDisposable([ signalDisposable ])
-		disposable.addDisposable(schedulerDisposable)
-		return disposable
+		return CompositeDisposable(ignoreNil([ signalDisposable, schedulerDisposable ]))
 	}
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -895,7 +895,7 @@ public func last<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
 /// Starts the producer, then blocks, waiting for completion.
 public func wait<T, E>(producer: SignalProducer<T, E>) -> Result<(), E> {
 	let result = producer |> then(SignalProducer(value: ())) |> last
-	return result!
+	return result ?? success(())
 }
 
 /// SignalProducer.startWithSignal() as a free function, for easier use with |>.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -194,7 +194,8 @@ public struct SignalProducer<T, E: ErrorType> {
 		if !disposable.disposed {
 			// Create a composite disposable that will automatically be torn
 			// down when the signal terminates.
-			let compositeDisposable = CompositeDisposable(disposable)
+			let compositeDisposable = CompositeDisposable()
+			compositeDisposable.addDisposable(disposable)
 
 			signal.observe(SinkOf { event in
 				if event.isTerminating {
@@ -608,7 +609,7 @@ public func first<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
 }
 
 /// SignalProducer.startWithSignal() as a free function, for easier use with |>.
-public func startWithSignal<T, E>(setUp: (Signal<T, E>, CompositeDisposable) -> ())(producer: SignalProducer<T, E>) -> () {
+public func startWithSignal<T, E>(setUp: (Signal<T, E>, Disposable) -> ())(producer: SignalProducer<T, E>) -> () {
 	return producer.startWithSignal(setUp)
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -197,13 +197,15 @@ public struct SignalProducer<T, E: ErrorType> {
 			let compositeDisposable = CompositeDisposable()
 			compositeDisposable.addDisposable(disposable)
 
-			signal.observe(SinkOf { event in
+			let wrapperObserver = Signal<T, E>.Observer { event in
+				observer.put(event)
+
 				if event.isTerminating {
 					compositeDisposable.dispose()
 				}
-			})
+			}
 
-			startHandler(observer, compositeDisposable)
+			startHandler(wrapperObserver, compositeDisposable)
 		}
 	}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -39,6 +39,9 @@ class SignalProducerSpec: QuickSpec {
 			pending("should dispose of added disposables upon error") {
 			}
 
+			pending("should dispose of added disposables upon interruption") {
+			}
+
 			pending("should dispose of added disposables upon start() disposal") {
 			}
 		}
@@ -154,13 +157,19 @@ class SignalProducerSpec: QuickSpec {
 			pending("should invoke the closure before any effects or events") {
 			}
 
-			pending("should interrupt effects and stop sending events if disposed") {
+			pending("should dispose of added disposables if disposed") {
+			}
+
+			pending("should send interrupted if disposed") {
 			}
 
 			pending("should release signal observers if disposed") {
 			}
 
 			pending("should not trigger effects if disposed before closure return") {
+			}
+
+			pending("should send interrupted if disposed before closure return") {
 			}
 
 			pending("should dispose of added disposables upon completion") {
@@ -174,7 +183,7 @@ class SignalProducerSpec: QuickSpec {
 			pending("should immediately begin sending events") {
 			}
 
-			pending("should interrupt effects and stop sending events if disposed") {
+			pending("should send interrupted if disposed") {
 			}
 
 			pending("should release sink when disposed") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -30,10 +30,10 @@ class SignalSpec: QuickSpec {
 				expect(didRunGenerator).to(beTruthy())
 			}
 
-			it("should keep signal alive if not terminated") {
+			it("should not keep signal alive indefinitely") {
 				weak var signal: Signal<AnyObject, NoError>? = Signal.never
 				
-				expect(signal).toNot(beNil())
+				expect(signal).to(beNil())
 			}
 
 			it("should deallocate after erroring") {
@@ -157,11 +157,10 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("Signal.pipe") {
-			
-			it("should keep signal alive if not terminated") {
+			it("should not keep signal alive indefinitely") {
 				weak var signal = Signal<(), NoError>.pipe().0
 				
-				expect(signal).toNot(beNil())
+				expect(signal).to(beNil())
 			}
 
 			it("should deallocate after erroring") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -640,7 +640,7 @@ class SignalSpec: QuickSpec {
 				expect(completed).to(beTruthy())
 			}
 
-			it("should complete when 0") {
+			it("should interrupt when 0") {
 				let numbers = [ 1, 2, 4, 4, 5 ]
 				var testScheduler = TestScheduler()
 				
@@ -654,22 +654,20 @@ class SignalSpec: QuickSpec {
 				}
 				
 				var result: [Int] = []
-				var completed = false
+				var interrupted = false
 				
 				signal
 				|> take(0)
 				|> observe(next: { number in
-						result.append(number)
-					}, completed: {
-						completed = true
-					})
+					result.append(number)
+				}, interrupted: {
+					interrupted = true
+				})
 				
-				expect(completed).to(beFalsy())
+				expect(interrupted).to(beTruthy())
 				
 				testScheduler.run()
-				
 				expect(result).to(beEmpty())
-				expect(completed).to(beTruthy())
 			}
 		}
 


### PR DESCRIPTION
One possible resolution for #1700 and #1701.

By sending an `Interrupted` event when `SignalProducer.start` is disposed of, we allow each `Signal` in the chain to perform teardown tasks. Downstream `Signal`s would otherwise leak, because disposal fundamentally only goes _upstream_ toward the producer. Events go _downstream_ toward the consumer, allowing cancellation to propagate through the chain.

This also happens to resolve @andymatuschak's concern in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1688#issuecomment-71301825 that `Signal`s which have _already_ terminated can still be observed but simply will never generate events. Now, we can immediately generate an `Interrupted` event and detach the new observer.

I've done a lot more thinking about this than I could hope to write in the body of a PR, so please ask any questions you have and I'll dump my thoughts into an answer.

**To do:**

 - [x] Update tests as necessary
 - [x] Add new lifetime tests
 - [x] Merge from `swift-development`
 - [x] Fix unstated compiler error (lol)