### PR TITLE
[UPD] we really don't want to call description without debug

### DIFF
--- a/ReactiveCocoa/NSObject+RACDescription.m
+++ b/ReactiveCocoa/NSObject+RACDescription.m
@@ -24,7 +24,11 @@
 @implementation NSValue (RACDescription)
 
 - (NSString *)rac_description {
-	return self.description;
+    if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
+        return self.description;
+    } else {
+        return @"(description skipped)";
+    }
 }
 
 @end
@@ -32,7 +36,11 @@
 @implementation NSString (RACDescription)
 
 - (NSString *)rac_description {
-	return self.description;
+    if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
+        return self.description;
+    } else {
+        return @"(description skipped)";
+    }
 }
 
 @end
@@ -40,7 +48,11 @@
 @implementation RACTuple (RACDescription)
 
 - (NSString *)rac_description {
-	return self.allObjects.description;
+    if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
+        return self.allObjects.description;
+    } else {
+        return @"(description skipped)";
+    }
 }
 
 @end

--- a/ReactiveCocoa/NSObject+RACDescription.m
+++ b/ReactiveCocoa/NSObject+RACDescription.m
@@ -24,11 +24,7 @@
 @implementation NSValue (RACDescription)
 
 - (NSString *)rac_description {
-    if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
-        return self.description;
-    } else {
-        return @"(description skipped)";
-    }
+	return self.description;
 }
 
 @end
@@ -36,11 +32,7 @@
 @implementation NSString (RACDescription)
 
 - (NSString *)rac_description {
-    if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
-        return self.description;
-    } else {
-        return @"(description skipped)";
-    }
+	return self.description;
 }
 
 @end
@@ -48,11 +40,11 @@
 @implementation RACTuple (RACDescription)
 
 - (NSString *)rac_description {
-    if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
-        return self.allObjects.description;
-    } else {
-        return @"(description skipped)";
-    }
+	if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
+		return self.allObjects.description;
+	} else {
+		return @"(description skipped)";
+	}
 }
 
 @end


### PR DESCRIPTION
rac_description is a debug method and its result is ignored when RAC_DEBUG_SIGNAL_NAMES is not defined.

But for tuples description is calculated anyway and then just ignored. If tuple contains arrays it may be a problem

And now implementation really do not call description if not asked.