### PR TITLE
Use DISPATCH_TIME_NOW-based timer for reschedule

### DIFF
--- a/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoa/RACQueueScheduler.m
@@ -95,7 +95,7 @@
 	uint64_t intervalInNanoSecs = (uint64_t)(interval * NSEC_PER_SEC);
 	uint64_t leewayInNanoSecs = (uint64_t)(leeway * NSEC_PER_SEC);
 
-	dispatch_time_t startDateDelay = (date.timeIntervalSince1970 - NSDate.date.timeIntervalSince1970) * NSEC_PER_SEC;
+	int64_t startDateDelay = (int64_t)((date.timeIntervalSince1970 - NSDate.date.timeIntervalSince1970) * NSEC_PER_SEC);
 	dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.queue);
 	dispatch_source_set_timer(timer, dispatch_time(DISPATCH_TIME_NOW, startDateDelay), intervalInNanoSecs, leewayInNanoSecs);
 	dispatch_source_set_event_handler(timer, block);

--- a/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoa/RACQueueScheduler.m
@@ -95,8 +95,9 @@
 	uint64_t intervalInNanoSecs = (uint64_t)(interval * NSEC_PER_SEC);
 	uint64_t leewayInNanoSecs = (uint64_t)(leeway * NSEC_PER_SEC);
 
+	dispatch_time_t startDateDelay = (date.timeIntervalSince1970 - NSDate.date.timeIntervalSince1970) * NSEC_PER_SEC;
 	dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.queue);
-	dispatch_source_set_timer(timer, [self.class wallTimeWithDate:date], intervalInNanoSecs, leewayInNanoSecs);
+	dispatch_source_set_timer(timer, dispatch_time(DISPATCH_TIME_NOW, startDateDelay), intervalInNanoSecs, leewayInNanoSecs);
 	dispatch_source_set_event_handler(timer, block);
 	dispatch_resume(timer);
 


### PR DESCRIPTION
The current method using the system wall clock stops sending when the system clock is moved backwards to a time before the initial date.
I see that you are using walltime to avoid skew when the computer goes to sleep, I don't know if this method would have the same problem, I'm not sure how to test it.

I also just started using ReactiveCocoa, so I don't know how to add tests for this, or if this issue has already been discussed.