### PR TITLE
timeoutWithError() swift implementation

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -693,9 +693,9 @@ public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInter
 
 		let signalDisposable = signal.observe(observer)
 
-		let dis = CompositeDisposable([ signalDisposable ])
-		dis.addDisposable(schedulerDisposable)
-		return dis
+		let disposable = CompositeDisposable([ signalDisposable ])
+		disposable.addDisposable(schedulerDisposable)
+		return disposable
 	}
 }
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -682,8 +682,7 @@ public func tryMap<T, U, E>(operation: T -> Result<U, E>)(signal: Signal<T, E>) 
 
 /// Forwards events from `signal` until `interval`. Then if signal isn't completed yet,
 /// errors with `error` on `scheduler`.
-public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E>
-{
+public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E> {
 	precondition(interval > 0)
 
 	var completed = false

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -685,19 +685,13 @@ public func tryMap<T, U, E>(operation: T -> Result<U, E>)(signal: Signal<T, E>) 
 public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E> {
 	precondition(interval >= 0)
 
-	var completed = false
 	return Signal { observer in
 		let date = scheduler.currentDate.dateByAddingTimeInterval(interval)
 		let schedulerDisposable = scheduler.scheduleAfter(date) {
-			if !completed {
-				sendError(observer, error)
-			}
+			sendError(observer, error)
 		}
 
 		let signalDisposable = signal.observe(Signal.Observer { event in
-			if event.isTerminating {
-				completed = true
-			}
 			observer.put(event)
 		})
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -683,7 +683,7 @@ public func tryMap<T, U, E>(operation: T -> Result<U, E>)(signal: Signal<T, E>) 
 /// Forwards events from `signal` until `interval`. Then if signal isn't completed yet,
 /// errors with `error` on `scheduler`.
 public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E> {
-	precondition(interval > 0)
+	precondition(interval >= 0)
 
 	var completed = false
 	return Signal { observer in

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -691,9 +691,7 @@ public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInter
 			sendError(observer, error)
 		}
 
-		let signalDisposable = signal.observe(Signal.Observer { event in
-			observer.put(event)
-		})
+		let signalDisposable = signal.observe(observer)
 
 		let dis = CompositeDisposable([ signalDisposable ])
 		dis.addDisposable(schedulerDisposable)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -682,6 +682,9 @@ public func tryMap<T, U, E>(operation: T -> Result<U, E>)(signal: Signal<T, E>) 
 
 /// Forwards events from `signal` until `interval`. Then if signal isn't completed yet,
 /// errors with `error` on `scheduler`.
+///
+/// If the interval is 0, the timeout will be scheduled immediately. The signal
+/// must complete synchronously (or on a faster scheduler) to avoid the timeout.
 public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E> {
 	precondition(interval >= 0)
 


### PR DESCRIPTION
Here is my (first) take on it. Fixes #1752.

I think we could let disposables do the work, and let cancel sending error event, without introducing `completed` variable. But since `scheduleAfter()` returns optional `Disposable` I kept that variable, and condition.

Maybe make `scheduleAfter()` return `Disposable`, not `Disposable?`?