### PR TITLE
merge and mergeMap for SignalProducers

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -554,7 +554,7 @@ public func concatMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: S
 /// as they arrive.
 public func merge<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> SignalProducer<T, E> {
 	return SignalProducer<T, E> { relayObserver, relayDisposable in
-		let inFlight = Atomic(0)
+		let inFlight = Atomic(1)
 		
 		let decrementInFlight: () -> () = {
 			let orig = inFlight.modify { $0 - 1 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -543,12 +543,60 @@ public func concat<T, E>(next: SignalProducer<T, E>)(producer: SignalProducer<T,
 	return SignalProducer(values: [producer, next]) |> concat
 }
 
+/// Merges a `producer` of SignalProducers down into a single producer, biased toward the producers
+/// added earlier. Returns a SignalProducer that will forward signals from the original producers
+/// as they arrive.
+public func merge<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> SignalProducer<T, E> {
+	return SignalProducer<T, E> { relayObserver, relayDisposable in
+		let inFlight = Atomic(0)
+		
+		let decrementInFlight: () -> () = {
+			let orig = inFlight.modify { $0 - 1 }
+			if orig == 1 {
+				sendCompleted(relayObserver)
+			}
+		}
+		
+		producer.startWithSignal { producerSignal, producerDisposable in
+			relayDisposable.addDisposable(producerDisposable)
+			
+			producerSignal.observe(next: { innerProducer in
+				innerProducer.startWithSignal { innerProducerSignal, innerProducerDisposable in
+					inFlight.modify { $0 + 1 }
+					
+					let innerProducerHandle = relayDisposable.addDisposable(innerProducerDisposable)
+					
+					innerProducerSignal.observe(Signal<T,E>.Observer { event in
+						if event.isTerminating {
+							innerProducerHandle.remove()
+						}
+						
+						switch event {
+						case .Completed:
+							decrementInFlight()
+							
+						default:
+							relayObserver.put(event)
+						}
+					})
+				}
+			}, error: { error in
+				sendError(relayObserver, error)
+			}, completed: {
+				decrementInFlight()
+			})
+		}
+	}
+}
+
+public func mergeMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
+	return producer |> map(transform) |> merge
+}
+
 /*
 TODO
 
 public func concatMap<T, U>(transform: T -> SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<U>
-public func merge<T>(producer: SignalProducer<SignalProducer<T>>) -> SignalProducer<T>
-public func mergeMap<T, U>(transform: T -> SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<U>
 public func switch<T>(producer: SignalProducer<SignalProducer<T>>) -> SignalProducer<T>
 public func switchMap<T, U>(transform: T -> SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<U>
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -595,6 +595,8 @@ public func merge<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> Si
 	}
 }
 
+/// Maps each event from `producer` to a new producer, then
+/// `merge`s the resulting producers together.
 public func mergeMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
 	return producer |> map(transform) |> merge
 }

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -305,6 +305,8 @@ class SignalProducerSpec: QuickSpec {
 					completed: {
 						outerCompleted = true
 					})
+					
+					sendCompleted(outerSink)
 				}
 				
 				it("should forward values from any inner signals") {
@@ -318,6 +320,7 @@ class SignalProducerSpec: QuickSpec {
 				
 				it("should complete when all signals have completed") {
 					completeA()
+					expect(outerCompleted).to(beFalsy())
 					completeB()
 					expect(outerCompleted).to(beTruthy())
 				}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -300,9 +300,7 @@ class SignalProducerSpec: QuickSpec {
 					
 					merge(outerProducer).start(next: { i in
 						recv.append(i)
-					},
-					error: { _ in () },
-					completed: {
+					}, error: { _ in () }, completed: {
 						outerCompleted = true
 					})
 					

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -271,16 +271,81 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("merge") {
-			pending("should forward values from any inner signals") {
+			describe("behavior") {
+				var completeA: (Void -> Void)!
+				var sendA: (Void -> Void)!
+				var completeB: (Void -> Void)!
+				var sendB: (Void -> Void)!
+				
+				var outerCompleted = false
+				
+				var recv = [Int]()
+				
+				beforeEach {
+					let (outerProducer, outerSink) = SignalProducer<SignalProducer<Int, NoError>, NoError>.buffer()
+					let (producerA, sinkA) = SignalProducer<Int, NoError>.buffer()
+					let (producerB, sinkB) = SignalProducer<Int, NoError>.buffer()
+					
+					completeA = { sendCompleted(sinkA) }
+					completeB = { sendCompleted(sinkB) }
+					
+					var a = 0
+					sendA = { sendNext(sinkA, a++) }
+					
+					var b = 100
+					sendB = { sendNext(sinkB, b++) }
+					
+					sendNext(outerSink, producerA)
+					sendNext(outerSink, producerB)
+					
+					merge(outerProducer).start(next: { i in
+						recv.append(i)
+					},
+					error: { _ in () },
+					completed: {
+						outerCompleted = true
+					})
+				}
+				
+				it("should forward values from any inner signals") {
+					sendA()
+					sendA()
+					sendB()
+					sendA()
+					sendB()
+					expect(recv).to(equal([0, 1, 100, 2, 101]))
+				}
+				
+				it("should complete when all signals have completed") {
+					completeA()
+					completeB()
+					expect(outerCompleted).to(beTruthy())
+				}
 			}
-
-			pending("should forward an error from an inner signal") {
-			}
-
-			pending("should forward an error from the outer signal") {
-			}
-
-			pending("should complete when all signals have completed") {
+			
+			describe("error handling") {
+				it("should forward an error from an inner signal") {
+					let errorProducer = SignalProducer<Int, TestError>(error: TestError.Default)
+					let outerProducer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: errorProducer)
+					
+					var error: TestError?
+					merge(outerProducer).start(error: { e in
+						error = e
+					})
+					expect(error).to(equal(TestError.Default))
+				}
+				
+				it("should forward an error from the outer signal") {
+					let (outerProducer, outerSink) = SignalProducer<SignalProducer<Int, TestError>, TestError>.buffer()
+					
+					var error: TestError?
+					merge(outerProducer).start(error: { e in
+						error = e
+					})
+					
+					sendError(outerSink, TestError.Default)
+					expect(error).to(equal(TestError.Default))
+				}
 			}
 		}
 


### PR DESCRIPTION
Implements https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1749.


To do:
- [x] Implement `merge` specs in `SignalProducerSpec` to verify behavior