### PR TITLE
Implement switchToLatest and switchMap

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -570,7 +570,7 @@ public func latest<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 			let latestInnerDisposable = SerialDisposable()
 			disposable.addDisposable(latestInnerDisposable)
 			
-			let state = Atomic(LatestState<T, E>.initial)
+			let state = Atomic(LatestState<T, E>())
 			let updateState = { (action: LatestState<T, E> -> LatestState<T, E>) -> () in
 				state.modify(action)
 				if state.value.isComplete {
@@ -607,14 +607,8 @@ public func latest<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 }
 
 private struct LatestState<T, E: ErrorType> {
-	let outerSignalComplete: Bool
-	let latestInnerSignal: LatestStateInnerSignal<T, E>
-
-	static var initial: LatestState {
-		return LatestState(
-			outerSignalComplete: false,
-			latestInnerSignal: .Complete)
-	}
+	private let outerSignalComplete = false
+	private let latestInnerSignal = LatestStateInnerSignal<T, E>.Complete
 	
 	func completeOuterSignal() -> LatestState<T, E> {
 		return LatestState(

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -617,24 +617,20 @@ private struct LatestState<T, E: ErrorType> {
 	}
 	
 	func addInnerSignal(signal: Signal<T, E>) -> LatestState<T, E> {
-		if isComplete {
-			return self
-		} else {
-			return LatestState(
+		return isComplete
+			? self
+			: LatestState(
 				outerSignalComplete: outerSignalComplete,
 				latestInnerSignal: .Incomplete(signal))
-		}
 	}
 	
 	func completeInnerSignal(signal: Signal<T, E>) -> LatestState<T, E> {
-		if isIncompleteLatestInnerSignal(signal) {
-			return LatestState(
+		return isIncompleteLatestInnerSignal(signal)
+			? LatestState(
 				outerSignalComplete: outerSignalComplete,
 				latestInnerSignal: .Complete)
-		} else {
-			return self
-		}
-	}
+			: self
+}
 	
 	func isIncompleteLatestInnerSignal(signal: Signal<T, E>) -> Bool {
 		switch latestInnerSignal {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -554,14 +554,14 @@ public func concatMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: S
     return producer |> map(transform) |> concat
 }
 
-/// Returns a signal that forwards values from the latest signal sent on
-/// `producer`, ignoring values sent on previous inner signals.
+/// Returns a producer that forwards values from the latest producer sent on
+/// `producer`, ignoring values sent on previous inner producers.
 ///
-/// An error sent on `producer` or the latest inner signal will be sent on the
-/// returned signal.
+/// An error sent on `producer` or the latest inner producer will be sent on the
+/// returned producer.
 ///
-/// The returned signal completes when `producer` and the latest inner signal
-/// have both completed.
+/// The returned producer completes when `producer` and the latest inner 
+/// producer have both completed.
 public func latest<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> SignalProducer<T, E> {
 	return SignalProducer<T, E> { sink, disposable in
 		producer.startWithSignal { outerSignal, outerDisposable in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -565,11 +565,9 @@ public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, 
 					}
 					
 					return
-				},
-				error: { error in
+				}, error: { error in
 					sendError(sink, error)
-				},
-				completed: {
+				}, completed: {
 					producerCompleted.value = true
 					completeIfNecessary()
 				})

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -527,6 +527,15 @@ public func concat<T, E>(next: SignalProducer<T, E>)(producer: SignalProducer<T,
 	return SignalProducer(values: [producer, next]) |> concat
 }
 
+
+/// Returns a signal that forwards values from the latest signal sent on
+/// `producer`, ignoring values sent on previous inner signals.
+///
+/// An error sent on `producer` or the latest inner signal will be sent on the
+/// returned signal.
+///
+/// The returned signal completes when `producer` and the latest inner signal
+/// have both completed.
 public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> SignalProducer<T, E> {
 	return SignalProducer<T, E> { sink, disposable in
 		let producerCompleted = Atomic(false)

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -583,13 +583,16 @@ public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, 
 	}
 }
 
+public func switchMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
+	return producer |> map(transform) |> switchToLatest
+}
+
 /*
 TODO
 
 public func concatMap<T, U>(transform: T -> SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<U>
 public func merge<T>(producer: SignalProducer<SignalProducer<T>>) -> SignalProducer<T>
 public func mergeMap<T, U>(transform: T -> SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<U>
-public func switchMap<T, U>(transform: T -> SignalProducer<U>)(producer: SignalProducer<T>) -> SignalProducer<U>
 
 public func repeat<T>(count: Int)(producer: SignalProducer<T>) -> SignalProducer<T>
 public func retry<T>(count: Int)(producer: SignalProducer<T>) -> SignalProducer<T>

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -604,6 +604,8 @@ public func latest<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> S
 	}
 }
 
+/// Maps each value from `producer` to a signal, the `latest`s the resulting
+/// signal of signals.
 public func latestMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
 	return producer |> map(transform) |> latest
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -552,7 +552,7 @@ public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, 
 					signal.startWithSignal { signal, signalDisposable in
 						latestDisposable.innerDisposable = signalDisposable
 						
-						materialize(signal).observe { event in
+						signal.observe(SinkOf { event in
 							switch event {
 							case .Completed:
 								latestCompleted.value = true
@@ -561,7 +561,7 @@ public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, 
 							default:
 								sink.put(event)
 							}
-						}
+						})
 					}
 					
 					return

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -546,7 +546,6 @@ public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, 
 			
 			signal.observe(
 				next: { signal in
-					latestDisposable.innerDisposable = nil
 					latestCompleted.value = false
 					
 					signal.startWithSignal { signal, signalDisposable in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -536,7 +536,7 @@ public func concat<T, E>(next: SignalProducer<T, E>)(producer: SignalProducer<T,
 ///
 /// The returned signal completes when `producer` and the latest inner signal
 /// have both completed.
-public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> SignalProducer<T, E> {
+public func latest<T, E>(producer: SignalProducer<SignalProducer<T, E>, E>) -> SignalProducer<T, E> {
 	return SignalProducer<T, E> { sink, disposable in
 		let producerCompleted = Atomic(false)
 		let latestCompleted = Atomic(false)
@@ -583,8 +583,8 @@ public func switchToLatest<T, E>(producer: SignalProducer<SignalProducer<T, E>, 
 	}
 }
 
-public func switchMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
-	return producer |> map(transform) |> switchToLatest
+public func latestMap<T, U, E>(transform: T -> SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<U, E> {
+	return producer |> map(transform) |> latest
 }
 
 /*

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -418,7 +418,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 		}
 
-		describe("switchToLatest") {
+		describe("latest") {
 			it("should forward values from the latest inner signal") {
 				let (outer, outerSink) = SignalProducer<SignalProducer<Int, TestError>, TestError>.buffer()
 				let (firstInner, firstInnerSink) = SignalProducer<Int, TestError>.buffer()

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -486,6 +486,17 @@ class SignalProducerSpec: QuickSpec {
 				
 				expect(completed).to(beTruthy())
 			}
+			
+			it("should complete when the outer signal completes before sending any signals") {
+				let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>.empty
+
+				var completed = false
+				latest(outer).start(completed: {
+					completed = true
+				})
+				
+				expect(completed).to(beTruthy())
+			}
 		}
 
 		describe("times") {

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -360,7 +360,7 @@ class SignalProducerSpec: QuickSpec {
 				var errored = false
 				var completed = false
 				
-				switchToLatest(outer).start(
+				latest(outer).start(
 					next: {
 						receivedValues.append($0)
 					},
@@ -395,14 +395,14 @@ class SignalProducerSpec: QuickSpec {
 			it("should forward an error from an inner signal") {
 				let inner = SignalProducer<Int, TestError>(error: .Default)
 				let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: inner)
-				let result = outer |> switchToLatest |> first
+				let result = outer |> latest |> first
 				
 				expect(result?.error).to(equal(TestError.Default))
 			}
 
 			it("should forward an error from the outer signal") {
 				let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(error: .Default)
-				let result = outer |> switchToLatest |> first
+				let result = outer |> latest |> first
 				
 				expect(result?.error).to(equal(TestError.Default))
 			}
@@ -412,7 +412,7 @@ class SignalProducerSpec: QuickSpec {
 				let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: inner)
 				
 				var completed = false
-				switchToLatest(outer).start(completed: {
+				latest(outer).start(completed: {
 					completed = true
 				})
 				

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -339,13 +339,31 @@ class SignalProducerSpec: QuickSpec {
 				expect(completed).to(beTruthy())
 			}
 
-			pending("should forward an error from an inner signal") {
+			it("should forward an error from an inner signal") {
+				let inner = SignalProducer<Int, TestError>(error: .Default)
+				let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: inner)
+				let result = outer |> switchToLatest |> first
+				
+				expect(result?.error).to(equal(TestError.Default))
 			}
 
-			pending("should forward an error from the outer signal") {
+			it("should forward an error from the outer signal") {
+				let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(error: .Default)
+				let result = outer |> switchToLatest |> first
+				
+				expect(result?.error).to(equal(TestError.Default))
 			}
 
-			pending("should complete when the original and latest signals have completed") {
+			it("should complete when the original and latest signals have completed") {
+				let inner = SignalProducer<Int, TestError>.empty
+				let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: inner)
+				
+				var completed = false
+				switchToLatest(outer).start(completed: {
+					completed = true
+				})
+				
+				expect(completed).to(beTruthy())
 			}
 		}
 


### PR DESCRIPTION
Towards #1750.

Tested:
- [x] should forward values from the latest inner signal
- [x] should forward an error from an inner signal
- [x] should forward an error from the outer signal
- [x] should complete when the original and latest signals have completed

TODO:
- [x] Refactor specs with `SignalProducer.buffer`
- [x] Implement switchMap