### PR TITLE
UITextField -rac_textSignal and -rac_newTextChannel send values on all e...

### DIFF
--- a/ReactiveCocoa/UITextField+RACSignalSupport.h
+++ b/ReactiveCocoa/UITextField+RACSignalSupport.h
@@ -14,15 +14,15 @@
 @interface UITextField (RACSignalSupport)
 
 /// Creates and returns a signal for the text of the field. It always starts with
-/// the current text. The signal sends next when the UIControlEventEditingChanged
-/// or UIControlEventEditingDidBegin control event is fired on the control.
+/// the current text. The signal sends next when the UIControlEventAllEditingEvents
+/// control event is fired on the control.
 - (RACSignal *)rac_textSignal;
 
 /// Creates a new RACChannel-based binding to the receiver.
 ///
 /// Returns a RACChannelTerminal that sends the receiver's text whenever the
-/// UIControlEventEditingChanged or UIControlEventEditingDidBegin control event 
-/// is fired, and sets the text to the values it receives.
+/// UIControlEventAllEditingEvents control event is fired, and sets the text
+/// to the values it receives.
 - (RACChannelTerminal *)rac_newTextChannel;
 
 @end

--- a/ReactiveCocoa/UITextField+RACSignalSupport.m
+++ b/ReactiveCocoa/UITextField+RACSignalSupport.m
@@ -24,7 +24,7 @@
 			@strongify(self);
 			return [RACSignal return:self];
 		}]
-		concat:[self rac_signalForControlEvents:UIControlEventEditingChanged | UIControlEventEditingDidBegin]]
+		concat:[self rac_signalForControlEvents:UIControlEventAllEditingEvents]]
 		map:^(UITextField *x) {
 			return x.text;
 		}]
@@ -33,7 +33,7 @@
 }
 
 - (RACChannelTerminal *)rac_newTextChannel {
-	return [self rac_channelForControlEvents:UIControlEventEditingChanged | UIControlEventEditingDidBegin key:@keypath(self.text) nilValue:@""];
+	return [self rac_channelForControlEvents:UIControlEventAllEditingEvents key:@keypath(self.text) nilValue:@""];
 }
 
 @end


### PR DESCRIPTION
...diting events

Sending values on <code>UIControlEventAllEditingEvents</code> as opposed to <code>UIControlEventEditingDidBegin</code> and <code>UIControlEventEditingDidBegin</code> would resolve following issue:

1. edit text field
2. press return key, while auto completion changes text
3. resignFirstResponder
```objc
- (BOOL) textFieldShouldReturn:(UITextField *)textField {
    [textField resignFirstResponder];
    return YES;
}
```
then new value is not send via <code>-rac_textSignal</code>.

I am aware, that proposed solution has disadvantage of sending (in most cases) last value twice, but IMHO it is irrelevant in most cases, and applying some kind of filtering would unnecessarily impact performance.
 




