### PR TITLE
Some Signal tests

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -170,22 +170,28 @@ public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 	precondition(count >= 0)
 
 	return Signal { observer in
-		var taken = 0
-
-		return signal.observe(next: { value in
-			if taken < count {
-				taken++
-				sendNext(observer, value)
-			}
-
-			if taken == count {
-				sendCompleted(observer)
-			}
-		}, error: { error in
-			sendError(observer, error)
-		}, completed: {
+		if count == 0 {
 			sendCompleted(observer)
-		})
+
+			return nil
+		} else {
+			var taken = 0
+
+			return signal.observe(next: { value in
+				if taken < count {
+					taken++
+					sendNext(observer, value)
+				}
+
+				if taken == count {
+					sendCompleted(observer)
+				}
+				}, error: { error in
+					sendError(observer, error)
+				}, completed: {
+					sendCompleted(observer)
+			})
+		}
 	}
 }
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -65,7 +65,24 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("map") {
-			pending("should transform the values of the signal") {
+			it("should transform the values of the signal") {
+				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let mappedSignal = signal |> map { String($0 + 1) }
+
+				var lastValue: String?
+
+				mappedSignal.observe(next: {
+					lastValue = $0
+					return
+				})
+
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 0)
+				expect(lastValue).to(equal("1"))
+
+				sendNext(sink, 1)
+				expect(lastValue).to(equal("2"))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -112,7 +112,24 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("scan") {
-			pending("should incrementally accumulate a value") {
+			it("should incrementally accumulate a value") {
+				let (signal, sink) = Signal<String, NoError>.pipe()
+				let mappedSignal = signal |> scan("", +)
+
+				var lastValue: String?
+
+				mappedSignal.observe(next: {
+					lastValue = $0
+					return
+				})
+
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, "a")
+				expect(lastValue).to(equal("a"))
+
+				sendNext(sink, "bb")
+				expect(lastValue).to(equal("abb"))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -300,10 +300,47 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("take") {
-			pending("should take initial values") {
+			it("should take initial values") {
+				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				let signal = baseSignal |> take(2)
+
+				var lastValue: Int?
+				var completed = false
+				signal.observe(
+					next: { lastValue = $0 },
+					completed: { completed = true }
+				)
+
+				expect(lastValue).to(beNil())
+				expect(completed).to(beFalse())
+
+				sendNext(sink, 1)
+				expect(lastValue).to(equal(1))
+				expect(completed).to(beFalse())
+
+				sendNext(sink, 2)
+				expect(lastValue).to(equal(2))
+				expect(completed).to(beTrue())
 			}
 
-			pending("should complete when 0") {
+			it("should complete when 0") {
+				let producer = SignalProducer<Int, NoError> { observer, disposable in
+					sendNext(observer, 0)
+				} |> take(0)
+
+				var completed = false
+				var valueSent = false
+
+				expect(completed).to(beFalse())
+				expect(valueSent).to(beFalse())
+
+				producer.start(
+					next: { _ in valueSent = true },
+					completed: { completed = true }
+				)
+
+				expect(completed).to(beTrue())
+				expect(valueSent).to(beFalse())
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -284,10 +284,10 @@ class SignalSpec: QuickSpec {
 				expect(completed).to(beFalsy())
 				
 				sendNext(observer, 1)
-				expect(fromSignal).to(equal([1]))
+				expect(fromSignal).to(equal([ 1 ]))
 				
 				sendNext(observer, 2)
-				expect(fromSignal).to(equal([1, 2]))
+				expect(fromSignal).to(equal([ 1, 2 ]))
 				
 				expect(completed).to(beFalsy())
 				sendCompleted(observer)
@@ -307,7 +307,7 @@ class SignalSpec: QuickSpec {
 				
 				let signal: Signal<Int, NoError> = Signal { observer in
 					testScheduler.schedule {
-						for number in [1, 2] {
+						for number in [ 1, 2 ] {
 							sendNext(observer, number)
 						}
 						sendCompleted(observer)
@@ -327,7 +327,7 @@ class SignalSpec: QuickSpec {
 				testScheduler.run()
 				
 				expect(disposable.disposed).to(beTruthy())
-				expect(fromSignal).to(equal([1, 2]))
+				expect(fromSignal).to(equal([ 1, 2 ]))
 			}
 
 			it("should not trigger side effects") {
@@ -551,16 +551,16 @@ class SignalSpec: QuickSpec {
 				expect(values).to(equal([]))
 
 				sendNext(sink, true)
-				expect(values).to(equal([true]))
+				expect(values).to(equal([ true ]))
 
 				sendNext(sink, true)
-				expect(values).to(equal([true]))
+				expect(values).to(equal([ true ]))
 
 				sendNext(sink, false)
-				expect(values).to(equal([true, false]))
+				expect(values).to(equal([ true, false ]))
 
 				sendNext(sink, true)
-				expect(values).to(equal([true, false, true]))
+				expect(values).to(equal([ true, false, true ]))
 			}
 
 			it("should skip values according to a predicate") {
@@ -573,16 +573,16 @@ class SignalSpec: QuickSpec {
 				expect(values).to(equal([]))
 
 				sendNext(sink, "a")
-				expect(values).to(equal(["a"]))
+				expect(values).to(equal([ "a" ]))
 
 				sendNext(sink, "b")
-				expect(values).to(equal(["a"]))
+				expect(values).to(equal([ "a" ]))
 
 				sendNext(sink, "cc")
-				expect(values).to(equal(["a", "cc"]))
+				expect(values).to(equal([ "a", "cc" ]))
 
 				sendNext(sink, "d")
-				expect(values).to(equal(["a", "cc", "d"]))
+				expect(values).to(equal([ "a", "cc", "d" ]))
 			}
 		}
 
@@ -633,10 +633,11 @@ class SignalSpec: QuickSpec {
 
 				var lastValue: Int?
 				var completed = false
-				signal.observe(
-					next: { lastValue = $0 },
-					completed: { completed = true }
-				)
+				signal.observe(next: {
+					lastValue = $0
+				}, completed: {
+					completed = true
+				})
 
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
@@ -684,10 +685,11 @@ class SignalSpec: QuickSpec {
 				expect(completed).to(beFalse())
 				expect(valueSent).to(beFalse())
 
-				producer.start(
-					next: { _ in valueSent = true },
-					completed: { completed = true }
-				)
+				producer.start(next: { _ in
+					valueSent = true
+				}, completed: {
+					completed = true
+				})
 
 				expect(completed).to(beTrue())
 				expect(valueSent).to(beFalse())
@@ -698,7 +700,7 @@ class SignalSpec: QuickSpec {
 			it("should collect all values") {
 				let (original, sink) = Signal<Int, NoError>.pipe()
 				let signal = original |> collect
-				let expectedResult = [1, 2, 3]
+				let expectedResult = [ 1, 2, 3 ]
 
 				var result: [Int]?
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -180,10 +180,36 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("skip") {
-			pending("should skip initial values") {
+			it("should skip initial values") {
+				let (originalSignal, sink) = Signal<Int, NoError>.pipe()
+				let signal = originalSignal |> skip(1)
+
+				var lastValue: Int?
+				signal.observe(next: { lastValue = $0 })
+
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 1)
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 2)
+				expect(lastValue).to(equal(2))
 			}
 
-			pending("should not skip any values when 0") {
+			it("should not skip any values when 0") {
+				let (originalSignal, sink) = Signal<Int, NoError>.pipe()
+				let signal = originalSignal |> skip(0)
+
+				var lastValue: Int?
+				signal.observe(next: { lastValue = $0 })
+
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 1)
+				expect(lastValue).to(equal(1))
+
+				sendNext(sink, 2)
+				expect(lastValue).to(equal(2))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -214,10 +214,48 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("skipRepeats") {
-			pending("should skip duplicate Equatable values") {
+			it("should skip duplicate Equatable values") {
+				let (originalSignal, sink) = Signal<Bool, NoError>.pipe()
+				let signal = originalSignal |> skipRepeats
+
+				var values: [Bool] = []
+				signal.observe(next: { values.append($0) })
+
+				expect(values).to(equal([]))
+
+				sendNext(sink, true)
+				expect(values).to(equal([true]))
+
+				sendNext(sink, true)
+				expect(values).to(equal([true]))
+
+				sendNext(sink, false)
+				expect(values).to(equal([true, false]))
+
+				sendNext(sink, true)
+				expect(values).to(equal([true, false, true]))
 			}
 
-			pending("should skip values according to a predicate") {
+			it("should skip values according to a predicate") {
+				let (originalSignal, sink) = Signal<String, NoError>.pipe()
+				let signal = originalSignal |> skipRepeats { countElements($0) == countElements($1) }
+
+				var values: [String] = []
+				signal.observe(next: { values.append($0) })
+
+				expect(values).to(equal([]))
+
+				sendNext(sink, "a")
+				expect(values).to(equal(["a"]))
+
+				sendNext(sink, "b")
+				expect(values).to(equal(["a"]))
+
+				sendNext(sink, "cc")
+				expect(values).to(equal(["a", "cc"]))
+
+				sendNext(sink, "d")
+				expect(values).to(equal(["a", "cc", "d"]))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -87,7 +87,27 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("filter") {
-			pending("should omit values from the signal") {
+			it("should omit values from the signal") {
+				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let mappedSignal = signal |> filter { $0 % 2 == 0 }
+
+				var lastValue: Int?
+
+				mappedSignal.observe(next: {
+					lastValue = $0
+					return
+				})
+
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 0)
+				expect(lastValue).to(equal(0))
+
+				sendNext(sink, 1)
+				expect(lastValue).to(equal(0))
+
+				sendNext(sink, 2)
+				expect(lastValue).to(equal(2))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -93,10 +93,7 @@ class SignalSpec: QuickSpec {
 
 				var lastValue: Int?
 
-				mappedSignal.observe(next: {
-					lastValue = $0
-					return
-				})
+				mappedSignal.observe(next: { lastValue = $0 })
 
 				expect(lastValue).to(beNil())
 
@@ -113,15 +110,12 @@ class SignalSpec: QuickSpec {
 
 		describe("scan") {
 			it("should incrementally accumulate a value") {
-				let (signal, sink) = Signal<String, NoError>.pipe()
-				let mappedSignal = signal |> scan("", +)
+				let (originalSignal, sink) = Signal<String, NoError>.pipe()
+				let signal = originalSignal |> scan("", +)
 
 				var lastValue: String?
 
-				mappedSignal.observe(next: {
-					lastValue = $0
-					return
-				})
+				signal.observe(next: { lastValue = $0 })
 
 				expect(lastValue).to(beNil())
 
@@ -245,10 +239,7 @@ class SignalSpec: QuickSpec {
 
 				var result: [Int]?
 
-				signal.observe(next: { value in
-					result = value
-					return
-				})
+				signal.observe(next: { result = $0 })
 
 				expect(result).to(beNil())
 				sendCompleted(sink)
@@ -261,10 +252,7 @@ class SignalSpec: QuickSpec {
 
 				var error: TestError?
 
-				signal.observe(error: { value in
-					error = value
-					return
-				})
+				signal.observe(error: { error = $0 })
 
 				expect(error).to(beNil())
 				sendError(sink, .Default)

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -134,10 +134,54 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("reduce") {
-			pending("should accumulate one value") {
+			it("should accumulate one value") {
+				let (originalSignal, sink) = Signal<Int, NoError>.pipe()
+				let signal = originalSignal |> reduce(1, +)
+
+				var lastValue: Int?
+				var completed = false
+
+				signal.observe(next: {
+					lastValue = $0
+				}, completed: {
+					completed = true
+				})
+
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 1)
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 2)
+				expect(lastValue).to(beNil())
+
+				expect(completed).to(beFalse())
+				sendCompleted(sink)
+				expect(completed).to(beTrue())
+
+				expect(lastValue).to(equal(4))
 			}
 
-			pending("should send the initial value if none are received") {
+			it("should send the initial value if none are received") {
+				let (originalSignal, sink) = Signal<Int, NoError>.pipe()
+				let signal = originalSignal |> reduce(1, +)
+
+				var lastValue: Int?
+				var completed = false
+
+				signal.observe(next: {
+					lastValue = $0
+				}, completed: {
+					completed = true
+				})
+
+				expect(lastValue).to(beNil())
+				expect(completed).to(beFalse())
+
+				sendCompleted(sink)
+
+				expect(lastValue).to(equal(1))
+				expect(completed).to(beTrue())
 			}
 		}
 


### PR DESCRIPTION
Written tests for the following `Signal` operators:
- [x] `map`
- [x] `filter`
- [x] `scan`
- [x] `reduce`
- [x] `skip`
- [x] `skipRepeats`
- [x] `skipWhile`
- [x] `take`
- [x] `takeUntil`
- [x] `takeUntilReplacement`