### PR TITLE
Throttle (redux (redux))

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -729,10 +729,9 @@ public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: Date
 
 	return Signal { observer in
 		let state: Atomic<ThrottleState<T>> = Atomic(ThrottleState())
-		let schedulerDisposable = SerialDisposable()
 
-		let disposable = CompositeDisposable()
-		disposable.addDisposable(schedulerDisposable)
+		let schedulerDisposable = SerialDisposable()
+		let disposable = CompositeDisposable([ schedulerDisposable ])
 
 		let signalDisposable = signal.observe(SinkOf { event in
 			switch event {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -722,8 +722,8 @@ public func tryMap<T, U, E>(operation: T -> Result<U, E>)(signal: Signal<T, E>) 
 /// If multiple values are received before the interval has elapsed, the
 /// latest value is the one that will be passed on.
 ///
-/// If the input signal completes while a value is being throttled, that value
-/// will be discarded and the returned signal will complete immediately.
+/// If the input signal terminates while a value is being throttled, that value
+/// will be discarded and the returned signal will terminate immediately.
 public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E> {
 	precondition(interval >= 0)
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -729,9 +729,10 @@ public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: Date
 
 	return Signal { observer in
 		let state: Atomic<ThrottleState<T>> = Atomic(ThrottleState())
-
 		let schedulerDisposable = SerialDisposable()
-		let disposable = CompositeDisposable([ schedulerDisposable ])
+
+		let disposable = CompositeDisposable()
+		disposable.addDisposable(schedulerDisposable)
 
 		let signalDisposable = signal.observe(SinkOf { event in
 			switch event {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -570,7 +570,7 @@ public func takeWhile<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signa
 }
 
 /// Throttle values sent by the receiver for which `predicate` returns true,
-/// so that at least `interval`seconds pass between each, then forwards
+/// so that at least `interval` seconds pass between each, then forwards
 /// them on the given scheduler.
 /// 
 /// Values that do not pass `predicate`, Errors, and Completed events

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -585,9 +585,15 @@ public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: Date
 		let flush = {
 			state.modify { state in
 				if let value = state.pendingValue {
-					let date = scheduler.currentDate
-					sendNext(observer, value)
-					return ThrottleState(previousDate: date, pendingValue: nil, schedulerDisposable: nil)
+					let now = scheduler.currentDate
+					
+					// we need to check date again, to handle schedulers that don't give us Disposables
+					if state.previousDate == nil || now.timeIntervalSinceDate(state.previousDate!) >= interval {
+						sendNext(observer, value)
+						return ThrottleState(previousDate: now, pendingValue: nil, schedulerDisposable: nil)
+					} else {
+						return state
+					}
 				} else {
 					return state
 				}

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -593,7 +593,7 @@ public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: Date
 			doSend?()
 		}
 		return signal.observe(next: { value in
-			let (_, (scheduleDate: NSDate, compositeDisposable: CompositeDisposable)) = state.modify { ( var state) in
+			let (_, (scheduleDate: NSDate, compositeDisposable: CompositeDisposable)) = state.modify { state in
 				
 				let now = scheduler.currentDate
 				let prev = state.previousDate
@@ -605,9 +605,8 @@ public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: Date
 				}
 				
 				let compositeDisposable = CompositeDisposable()
-				state.scheduleDisposable = ScopedDisposable(compositeDisposable)
-				state.pendingValue = value
-				return (state, (scheduleDate, compositeDisposable))
+				let newState = ThrottleState(previousDate: prev, pendingValue: value, scheduleDisposable: ScopedDisposable(compositeDisposable))
+				return (newState, (scheduleDate, compositeDisposable))
 			}
 
 			let disposableFromScheduler = scheduler.scheduleAfter(scheduleDate) {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -747,8 +747,10 @@ public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: Date
 				schedulerDisposable.innerDisposable = scheduler.scheduleAfter(scheduleDate) {
 					let (_, pendingValue) = state.modify { (var state) -> (ThrottleState<T>, T?) in
 						let value = state.pendingValue
-						state.pendingValue = nil
-						state.previousDate = scheduler.currentDate
+						if value != nil {
+							state.pendingValue = nil
+							state.previousDate = scheduleDate
+						}
 
 						return (state, value)
 					}


### PR DESCRIPTION
Builds upon @adly-holler's implementation in #1730, with these additional changes:

- Completion no longer flushes the latest throttled value, since the contract of the operator is that _at least_ `interval` seconds pass between each value.
- Error and completed events are now scheduled, ensuring that all events get delivered on the given scheduler.
- Simplifies the logic for determining when to send values.

/cc @neilpa @kastiglione 

**To do:**

- [x] Add tests
- [x] Fix [race condition](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1790#discussion_r25550454)
- [x] Merge `swift-development`