### PR TITLE
Rename `as` bridging functions to `to`

### DIFF
--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -28,20 +28,20 @@ extension RACScheduler: DateSchedulerType {
 }
 
 extension ImmediateScheduler {
-	public func asRACScheduler() -> RACScheduler {
+	public func toRACScheduler() -> RACScheduler {
 		return RACScheduler.immediateScheduler()
 	}
 }
 
 extension UIScheduler {
-	public func asRACScheduler() -> RACScheduler {
+	public func toRACScheduler() -> RACScheduler {
 		return RACScheduler.mainThreadScheduler()
 	}
 }
 
 extension QueueScheduler {
-	public func asRACScheduler() -> RACScheduler {
-		return RACTargetQueueScheduler(name: "org.reactivecocoa.ReactiveCocoa.QueueScheduler.asRACScheduler()", targetQueue: queue)
+	public func toRACScheduler() -> RACScheduler {
+		return RACTargetQueueScheduler(name: "org.reactivecocoa.ReactiveCocoa.QueueScheduler.toRACScheduler()", targetQueue: queue)
 	}
 }
 
@@ -54,7 +54,7 @@ private func defaultNSError(message: String, #file: String, #line: Int) -> NSErr
 extension RACSignal {
 	/// Creates a SignalProducer which will subscribe to the receiver once for
 	/// each invocation of start().
-	public func asSignalProducer(file: String = __FILE__, line: Int = __LINE__) -> SignalProducer<AnyObject?, NSError> {
+	public func toSignalProducer(file: String = __FILE__, line: Int = __LINE__) -> SignalProducer<AnyObject?, NSError> {
 		return SignalProducer { observer, disposable in
 			let next = { (obj: AnyObject?) -> () in
 				sendNext(observer, obj)
@@ -83,15 +83,15 @@ private func optionalize<T, E>(signal: Signal<T, E>) -> Signal<T?, E> {
 /// subscription.
 ///
 /// Any `Interrupted` events will be silently discarded.
-public func asRACSignal<T: AnyObject, E>(producer: SignalProducer<T, E>) -> RACSignal {
-	return asRACSignal(producer |> optionalize)
+public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T, E>) -> RACSignal {
+	return toRACSignal(producer |> optionalize)
 }
 
 /// Creates a RACSignal that will start() the producer once for each
 /// subscription.
 ///
 /// Any `Interrupted` events will be silently discarded.
-public func asRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RACSignal {
+public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RACSignal {
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start(next: { value in
 			subscriber.sendNext(value)
@@ -110,14 +110,14 @@ public func asRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RAC
 /// Creates a RACSignal that will observe the given signal.
 ///
 /// Any `Interrupted` event will be silently discarded.
-public func asRACSignal<T: AnyObject, E>(signal: Signal<T, E>) -> RACSignal {
-	return asRACSignal(signal |> optionalize)
+public func toRACSignal<T: AnyObject, E>(signal: Signal<T, E>) -> RACSignal {
+	return toRACSignal(signal |> optionalize)
 }
 
 /// Creates a RACSignal that will observe the given signal.
 ///
 /// Any `Interrupted` event will be silently discarded.
-public func asRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
+public func toRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = signal.observe(next: { value in
 			subscriber.sendNext(value)
@@ -140,10 +140,10 @@ extension RACCommand {
 	/// Note that the returned Action will not necessarily be marked as
 	/// executing when the command is. However, the reverse is always true:
 	/// the RACCommand will always be marked as executing when the action is.
-	public func asAction(file: String = __FILE__, line: Int = __LINE__) -> Action<AnyObject?, AnyObject?, NSError> {
+	public func toAction(file: String = __FILE__, line: Int = __LINE__) -> Action<AnyObject?, AnyObject?, NSError> {
 		let enabledProperty = MutableProperty(true)
 
-		enabledProperty <~ self.enabled.asSignalProducer()
+		enabledProperty <~ self.enabled.toSignalProducer()
 			|> map { $0 as Bool }
 			|> catch { _ in SignalProducer<Bool, NoError>(value: false) }
 
@@ -152,7 +152,7 @@ extension RACCommand {
 				return self.execute(input)
 			}
 
-			return executionSignal.asSignalProducer(file: file, line: line)
+			return executionSignal.toSignalProducer(file: file, line: line)
 		}
 	}
 }
@@ -160,7 +160,7 @@ extension RACCommand {
 extension Action {
 	private var commandEnabled: RACSignal {
 		let enabled = self.enabled.producer |> map { $0 as NSNumber }
-		return asRACSignal(enabled)
+		return toRACSignal(enabled)
 	}
 }
 
@@ -169,9 +169,9 @@ extension Action {
 /// Note that the returned command will not necessarily be marked as
 /// executing when the action is. However, the reverse is always true:
 /// the Action will always be marked as executing when the RACCommand is.
-public func asRACCommand<Output: AnyObject, E>(action: Action<AnyObject?, Output, E>) -> RACCommand {
+public func toRACCommand<Output: AnyObject, E>(action: Action<AnyObject?, Output, E>) -> RACCommand {
 	return RACCommand(enabled: action.commandEnabled) { (input: AnyObject?) -> RACSignal in
-		return asRACSignal(action.apply(input))
+		return toRACSignal(action.apply(input))
 	}
 }
 
@@ -180,8 +180,8 @@ public func asRACCommand<Output: AnyObject, E>(action: Action<AnyObject?, Output
 /// Note that the returned command will not necessarily be marked as
 /// executing when the action is. However, the reverse is always true:
 /// the Action will always be marked as executing when the RACCommand is.
-public func asRACCommand<Output: AnyObject, E>(action: Action<AnyObject?, Output?, E>) -> RACCommand {
+public func toRACCommand<Output: AnyObject, E>(action: Action<AnyObject?, Output?, E>) -> RACCommand {
 	return RACCommand(enabled: action.commandEnabled) { (input: AnyObject?) -> RACSignal in
-		return asRACSignal(action.apply(input))
+		return toRACSignal(action.apply(input))
 	}
 }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -127,7 +127,7 @@ extension MutableProperty: SinkType {
 	/// KVO-compliant. Most UI controls are not!
 	public var producer: SignalProducer<AnyObject?, NoError> {
 		if let object = object {
-			return object.rac_valuesForKeyPath(keyPath, observer: nil).asSignalProducer()
+			return object.rac_valuesForKeyPath(keyPath, observer: nil).toSignalProducer()
 				// Errors aren't possible, but the compiler doesn't know that.
 				|> catch { error in
 					fatalError("Received unexpected error from KVO signal: \(error)")

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -169,7 +169,7 @@ class ActionSpec: QuickSpec {
 
 				cocoaAction
 					.rac_valuesForKeyPath("enabled", observer: nil)
-					.asSignalProducer()
+					.toSignalProducer()
 					|> map { $0! as Bool }
 					|> start(Event.sink(next: { values.append($0) }))
 
@@ -185,7 +185,7 @@ class ActionSpec: QuickSpec {
 
 				cocoaAction
 					.rac_valuesForKeyPath("executing", observer: nil)
-					.asSignalProducer()
+					.toSignalProducer()
 					|> map { $0! as Bool }
 					|> start(Event.sink(next: { values.append($0) }))
 

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -13,7 +13,7 @@ import ReactiveCocoa
 
 class ObjectiveCBridgingSpec: QuickSpec {
 	override func spec() {
-		describe("RACSignal.asSignalProducer") {
+		describe("RACSignal.toSignalProducer") {
 			it("should subscribe once per start()") {
 				var subscriptions = 0
 
@@ -24,7 +24,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					return nil
 				}
 
-				let producer = racSignal.asSignalProducer() |> map { $0 as Int }
+				let producer = racSignal.toSignalProducer() |> map { $0 as Int }
 
 				expect((producer |> single)?.value).to(equal(0))
 				expect((producer |> single)?.value).to(equal(1))
@@ -35,18 +35,18 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				let error = TestError.Default.nsError
 
 				let racSignal = RACSignal.error(error)
-				let producer = racSignal.asSignalProducer()
+				let producer = racSignal.toSignalProducer()
 				let result = producer |> last
 
 				expect(result?.error).to(equal(error))
 			}
 		}
 
-		describe("asRACSignal") {
+		describe("toRACSignal") {
 			describe("on a Signal") {
 				it("should forward events") {
 					let (signal, sink) = Signal<NSNumber, NoError>.pipe()
-					let racSignal = asRACSignal(signal)
+					let racSignal = toRACSignal(signal)
 
 					var lastValue: NSNumber?
 					var didComplete = false
@@ -71,7 +71,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 				it("should convert errors to NSError") {
 					let (signal, sink) = Signal<AnyObject, TestError>.pipe()
-					let racSignal = asRACSignal(signal)
+					let racSignal = toRACSignal(signal)
 
 					let expectedError = TestError.Error2
 					var error: NSError?
@@ -95,7 +95,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					let producer = SignalProducer<NSNumber, NoError>.try {
 						return success(subscriptions++)
 					}
-					let racSignal = asRACSignal(producer)
+					let racSignal = toRACSignal(producer)
 
 					expect(racSignal.first() as? NSNumber).to(equal(0))
 					expect(racSignal.first() as? NSNumber).to(equal(1))
@@ -104,7 +104,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 				it("should convert errors to NSError") {
 					let producer = SignalProducer<AnyObject, TestError>(error: .Error1)
-					let racSignal = asRACSignal(producer).materialize()
+					let racSignal = toRACSignal(producer).materialize()
 
 					let event = racSignal.first() as? RACEvent
 
@@ -114,7 +114,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			}
 		}
 
-		describe("RACCommand.asAction") {
+		describe("RACCommand.toAction") {
 			pending("should reflect the enabledness of the command") {
 			}
 
@@ -125,7 +125,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			}
 		}
 
-		describe("asRACCommand") {
+		describe("toRACCommand") {
 			pending("should reflect the enabledness of the action") {
 			}
 


### PR DESCRIPTION
Resolves #1795.