### PR TITLE
Remaining producer tests

### DIFF
--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -284,10 +284,33 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("start") {
-			pending("should immediately begin sending events") {
+			it("should immediately begin sending events") {
+				let producer = SignalProducer<Int, NoError>(values: [1, 2])
+
+				var values: [Int] = []
+				var completed = false
+				producer.start(next: {
+					values.append($0)
+				}, completed: {
+					completed = true
+				})
+
+				expect(values).to(equal([1, 2]))
+				expect(completed).to(beTruthy())
 			}
 
-			pending("should send interrupted if disposed") {
+			it("should send interrupted if disposed") {
+				let producer = SignalProducer<(), NoError>.never
+
+				var interrupted = false
+				let disposable = producer.start(interrupted: {
+					interrupted = true
+				})
+
+				expect(interrupted).to(beFalsy())
+
+				disposable.dispose()
+				expect(interrupted).to(beTruthy())
 			}
 
 			pending("should release sink when disposed") {

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -34,7 +34,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should dispose of added disposables upon completion") {
-				let addedDisposable = SerialDisposable()
+				let addedDisposable = SimpleDisposable()
 				var test: () -> () = { }
 
 				let producer = SignalProducer<(), NoError>() { observer, disposable in
@@ -50,7 +50,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should dispose of added disposables upon error") {
-				let addedDisposable = SerialDisposable()
+				let addedDisposable = SimpleDisposable()
 				var test: () -> () = { }
 
 				let producer = SignalProducer<(), TestError>() { observer, disposable in
@@ -66,7 +66,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should dispose of added disposables upon interruption") {
-				let addedDisposable = SerialDisposable()
+				let addedDisposable = SimpleDisposable()
 				var test: () -> () = { }
 
 				let producer = SignalProducer<(), NoError>() { observer, disposable in
@@ -82,7 +82,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should dispose of added disposables upon start() disposal") {
-				let addedDisposable = SerialDisposable()
+				let addedDisposable = SimpleDisposable()
 
 				let producer = SignalProducer<(), TestError>() { _, disposable in
 					disposable.addDisposable(addedDisposable)
@@ -278,7 +278,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should dispose of added disposables if disposed") {
-				let addedDisposable = SerialDisposable()
+				let addedDisposable = SimpleDisposable()
 				var test: () -> () = { }
 
 				let producer = SignalProducer<Int, NoError>() { _, disposable in
@@ -360,7 +360,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should dispose of added disposables upon completion") {
-				let addedDisposable = SerialDisposable()
+				let addedDisposable = SimpleDisposable()
 				var test: () -> () = { }
 
 				let producer = SignalProducer<Int, TestError>() { observer, disposable in
@@ -376,7 +376,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			it("should dispose of added disposables upon error") {
-				let addedDisposable = SerialDisposable()
+				let addedDisposable = SimpleDisposable()
 				var test: () -> () = { }
 
 				let producer = SignalProducer<Int, TestError>() { observer, disposable in

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -321,7 +321,42 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("on") {
-			pending("should attach event handlers to each started signal") {
+			it("should attach event handlers to each started signal") {
+				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
+
+				var started = 0
+				var event = 0
+				var next = 0
+				var completed = 0
+				var terminated = 0
+
+				let producer = baseProducer
+					|> on(started: { () -> () in
+							started += 1
+						}, event: { (e: Event<Int, TestError>) -> () in
+							event += 1
+						}, next: { (n: Int) -> () in
+							next += 1
+						}, completed: { () -> () in
+							completed += 1
+						}, terminated: { () -> () in
+							terminated += 1
+						})
+
+				producer.start()
+				expect(started).to(equal(1))
+
+				producer.start()
+				expect(started).to(equal(2))
+
+				sendNext(sink, 1)
+				expect(event).to(equal(2))
+				expect(next).to(equal(2))
+
+				sendCompleted(sink)
+				expect(event).to(equal(4))
+				expect(completed).to(equal(2))
+				expect(terminated).to(equal(2))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -538,7 +538,7 @@ class SignalProducerSpec: QuickSpec {
 
 					let transform = { (signal: Signal<Int, NoError>) -> Signal<Int, NoError> -> Signal<Int, NoError> in
 						return { otherSignal in
-							return zip(signal, otherSignal) |> map { return $0.0 + $0.1 }
+							return zip(signal, otherSignal) |> map { first, second in first + second }
 						}
 					}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -314,23 +314,21 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should send interrupted if disposed") {
 				var interrupted = false
-				var scheduler = TestScheduler()
+				var disposable: Disposable!
 
 				SignalProducer<Int, NoError>(value: 42)
-					|> startOn(scheduler)
-					|> startWithSignal { signal, disposable in
+					|> startOn(TestScheduler())
+					|> startWithSignal { signal, innerDisposable in
 						signal.observe(interrupted: {
 							interrupted = true
 						})
 
-						scheduler.schedule {
-							disposable.dispose()
-						}
+						disposable = innerDisposable
 					}
 
 				expect(interrupted).to(beFalsy())
 
-				scheduler.run()
+				disposable.dispose()
 				expect(interrupted).to(beTruthy())
 			}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -160,7 +160,7 @@ class SignalProducerSpec: QuickSpec {
 
 		describe("SignalProducer.buffer") {
 			it("should replay buffered events when started, then forward events as added") {
-				let (producer, sink) = SignalProducer<Int, NSError>.buffer();
+				let (producer, sink) = SignalProducer<Int, NSError>.buffer()
 
 				sendNext(sink, 1)
 				sendNext(sink, 2)
@@ -268,7 +268,7 @@ class SignalProducerSpec: QuickSpec {
 					}, next: {
 						value = $0
 					})
-					|> startWithSignal { signal, disposable in
+					|> startWithSignal { _ in
 						expect(started).to(beFalsy())
 						expect(value).to(beNil())
 					}
@@ -331,7 +331,7 @@ class SignalProducerSpec: QuickSpec {
 					}, next: {
 						value = $0
 					})
-					|> startWithSignal { signal, disposable in
+					|> startWithSignal { _, disposable in
 						expect(started).to(beFalsy())
 						expect(value).to(beNil())
 
@@ -555,16 +555,16 @@ class SignalProducerSpec: QuickSpec {
 
 				let producer = baseProducer
 					|> on(started: { () -> () in
-							started += 1
-						}, event: { (e: Event<Int, TestError>) -> () in
-							event += 1
-						}, next: { (n: Int) -> () in
-							next += 1
-						}, completed: { () -> () in
-							completed += 1
-						}, terminated: { () -> () in
-							terminated += 1
-						})
+						started += 1
+					}, event: { (e: Event<Int, TestError>) -> () in
+						event += 1
+					}, next: { (n: Int) -> () in
+						next += 1
+					}, completed: { () -> () in
+						completed += 1
+					}, terminated: { () -> () in
+						terminated += 1
+					})
 
 				producer.start()
 				expect(started).to(equal(1))

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -33,16 +33,67 @@ class SignalProducerSpec: QuickSpec {
 			pending("should release signal observers when given disposable is disposed") {
 			}
 
-			pending("should dispose of added disposables upon completion") {
+			it("should dispose of added disposables upon completion") {
+				let addedDisposable = SerialDisposable()
+				var test: () -> () = { }
+
+				let producer = SignalProducer<(), NoError>() { observer, disposable in
+					disposable.addDisposable(addedDisposable)
+					test = { _ in sendCompleted(observer) }
+				}
+
+				producer.start()
+				expect(addedDisposable.disposed).to(beFalsy())
+
+				test()
+				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
-			pending("should dispose of added disposables upon error") {
+			it("should dispose of added disposables upon error") {
+				let addedDisposable = SerialDisposable()
+				var test: () -> () = { }
+
+				let producer = SignalProducer<(), TestError>() { observer, disposable in
+					disposable.addDisposable(addedDisposable)
+					test = { _ in sendError(observer, .Default) }
+				}
+
+				producer.start()
+				expect(addedDisposable.disposed).to(beFalsy())
+
+				test()
+				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
-			pending("should dispose of added disposables upon interruption") {
+			it("should dispose of added disposables upon interruption") {
+				let addedDisposable = SerialDisposable()
+				var test: () -> () = { }
+
+				let producer = SignalProducer<(), NoError>() { observer, disposable in
+					disposable.addDisposable(addedDisposable)
+					test = { _ in sendInterrupted(observer) }
+				}
+
+				producer.start()
+				expect(addedDisposable.disposed).to(beFalsy())
+
+				test()
+				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
-			pending("should dispose of added disposables upon start() disposal") {
+			it("should dispose of added disposables upon start() disposal") {
+				let addedDisposable = SerialDisposable()
+
+				let producer = SignalProducer<(), TestError>() { _, disposable in
+					disposable.addDisposable(addedDisposable)
+					return
+				}
+
+				let startDisposable = producer.start()
+				expect(addedDisposable.disposed).to(beFalsy())
+
+				startDisposable.dispose()
+				expect(addedDisposable.disposed).to(beTruthy())
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -584,10 +584,38 @@ class SignalProducerSpec: QuickSpec {
 		}
 
 		describe("startOn") {
-			pending("should invoke effects on the given scheduler") {
+			it("should invoke effects on the given scheduler") {
+				let scheduler = TestScheduler()
+				var invoked = false
+
+				let producer = SignalProducer<Int, NoError>() { _ in
+					invoked = true
+				}
+
+				producer |> startOn(scheduler) |> start()
+				expect(invoked).to(beFalsy())
+
+				scheduler.advance()
+				expect(invoked).to(beTruthy())
 			}
 
-			pending("should forward events on their original scheduler") {
+			it("should forward events on their original scheduler") {
+				let startScheduler = TestScheduler()
+				let testScheduler = TestScheduler()
+
+				let producer = timer(2, onScheduler: testScheduler, withLeeway: 0)
+
+				var next: NSDate?
+				producer |> startOn(startScheduler) |> start(next: { next = $0 })
+
+				startScheduler.advanceByInterval(2)
+				expect(next).to(beNil())
+
+				testScheduler.advanceByInterval(1)
+				expect(next).to(beNil())
+
+				testScheduler.advanceByInterval(1)
+				expect(next).to(equal(testScheduler.currentDate))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -469,6 +469,10 @@ class SignalProducerSpec: QuickSpec {
 				test()
 				expect(testSink).toNot(beNil())
 
+				// FIXME: Disposing _should_ result in the test sink being released here. Implementing
+				// an identical `start` method as a producer extension in the test module and using that
+				// works as expected. Calling the normal `start` method on `SignalProducer` leaks the
+				// sink a yet to be determined reason.
 				disposable.dispose()
 				expect(testSink).to(beNil())
 			}


### PR DESCRIPTION
Will resolve #1794

* [x] `init`
  * [x] ~~`observer` lifetime~~
  * [x] `disposable` lifetime
* [x] `buffer`
* [x] `startWithSignal`
* [x] `start`
* [x] `lift`
  * [x] unary operators
  * [x] binary operators
* [x] `timer`
* [x] `on`
* [x] `startOn`
* [x] `catch`
* [x] `observer` lifetimes (is this even possible?)