### PR TITLE
add new operator(Signal.mapError) and tests

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -147,14 +147,14 @@ public func mapError<T, E, F>(transform: E -> F)(signal: Signal<T, E>) -> Signal
 	return Signal { observer in
 		return signal.observe(Signal.Observer { event in
 			switch event {
-				case let .Next(value):
-					sendNext(observer, value.unbox)
-				case let .Error(error):
-					sendError(observer, transform(error.unbox))
-				case .Completed:
-					sendCompleted(observer)
-				case .Interrupted:
-					sendInterrupted(observer)
+			case let .Next(value):
+				sendNext(observer, value.unbox)
+			case let .Error(error):
+				sendError(observer, transform(error.unbox))
+			case .Completed:
+				sendCompleted(observer)
+			case .Interrupted:
+				sendInterrupted(observer)
 			}
 		})
 	}

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -142,6 +142,24 @@ public func map<T, U, E>(transform: T -> U)(signal: Signal<T, E>) -> Signal<U, E
 	}
 }
 
+/// Maps errors in the signal to a new error.
+public func mapError<T, E, F>(transform: E -> F)(signal: Signal<T, E>) -> Signal<T, F> {
+	return Signal { observer in
+		return signal.observe(Signal.Observer { event in
+			switch event {
+				case let .Next(value):
+					sendNext(observer, value.unbox)
+				case let .Error(error):
+					sendError(observer, transform(error.unbox))
+				case .Completed:
+					sendCompleted(observer)
+				case .Interrupted:
+					sendInterrupted(observer)
+			}
+		})
+	}
+}
+
 /// Preserves only the values of the signal that pass the given predicate.
 public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T, E> {
 	return Signal { observer in

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -412,6 +412,30 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(equal("2"))
 			}
 		}
+		
+		
+		describe("mapError") {
+			it("should transform the errors of the signal") {
+				let (signal, sink) = Signal<Int, TestError>.pipe()
+				let producerError = NSError(domain: "com.reactivecocoa.errordomain", code: 100, userInfo: nil)
+				let mappedSignal = signal |> mapError { _ in
+					producerError
+				}
+
+				var error: NSError?
+
+				mappedSignal.observe(error: {
+					error = $0
+					return
+				})
+
+				expect(error).to(beNil())
+
+				sendError(sink, TestError.Default)
+				expect(error).to(equal(producerError))
+			}
+		}
+		
 
 		describe("filter") {
 			it("should omit values from the signal") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -418,16 +418,9 @@ class SignalSpec: QuickSpec {
 			it("should transform the errors of the signal") {
 				let (signal, sink) = Signal<Int, TestError>.pipe()
 				let producerError = NSError(domain: "com.reactivecocoa.errordomain", code: 100, userInfo: nil)
-				let mappedSignal = signal |> mapError { _ in
-					producerError
-				}
-
 				var error: NSError?
 
-				mappedSignal.observe(error: {
-					error = $0
-					return
-				})
+				signal |> mapError { _ in producerError } |> observe(next: { _ in return }, error: { error = $0 })
 
 				expect(error).to(beNil())
 


### PR DESCRIPTION
add new operator(Signal.mapError) which would map from errors to other errors and corresponding tests #1814 