### PR TITLE
Enable test fixed by Swift 1.2b3

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -946,17 +946,19 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Error>, b: Sig
 ///
 /// If the interval is 0, the timeout will be scheduled immediately. The signal
 /// must complete synchronously (or on a faster scheduler) to avoid the timeout.
-public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType)(signal: Signal<T, E>) -> Signal<T, E> {
+public func timeoutWithError<T, E>(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> Signal<T, E> -> Signal<T, E> {
 	precondition(interval >= 0)
 
-	return Signal { observer in
-		let date = scheduler.currentDate.dateByAddingTimeInterval(interval)
-		let schedulerDisposable = scheduler.scheduleAfter(date) {
-			sendError(observer, error)
-		}
+	return { signal in
+		return Signal { observer in
+			let date = scheduler.currentDate.dateByAddingTimeInterval(interval)
+			let schedulerDisposable = scheduler.scheduleAfter(date) {
+				sendError(observer, error)
+			}
 
-		let signalDisposable = signal.observe(observer)
-		return CompositeDisposable(ignoreNil([ signalDisposable, schedulerDisposable ]))
+			let signalDisposable = signal.observe(observer)
+			return CompositeDisposable(ignoreNil([ signalDisposable, schedulerDisposable ]))
+		}
 	}
 }
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -452,7 +452,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(interrupted).to(beTruthy())
 			}
 
-			pending("should release sink when disposed") {
+			it("should release sink when disposed") {
 				weak var testSink: TestSink?
 
 				var disposable: Disposable!
@@ -467,10 +467,6 @@ class SignalProducerSpec: QuickSpec {
 				test()
 				expect(testSink).toNot(beNil())
 
-				// FIXME: Disposing _should_ result in the test sink being released here. Implementing
-				// an identical `start` method as a producer extension in the test module and using that
-				// works as expected. Calling the normal `start` method on `SignalProducer` leaks the
-				// sink a yet to be determined reason.
 				disposable.dispose()
 				expect(testSink).to(beNil())
 			}


### PR DESCRIPTION
Also fixes `timeoutWithError` since that was still crashing in the tests like a few other curried functions.

/cc @jspahrsummers