### PR TITLE
Add `+[RACSignal try:]` which wraps computations that may fail

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -1044,6 +1044,7 @@
 				D04725EB19E49ED7006002AA /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		D04725EB19E49ED7006002AA /* Products */ = {
 			isa = PBXGroup;

--- a/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoa/RACSignal+Operations.h
@@ -380,6 +380,22 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Subscribes to the given signal when an error occurs.
 - (RACSignal *)catchTo:(RACSignal *)signal;
 
+/// Returns a signal that will either immediately send the return value of
+/// `tryBlock` and complete, or send the `NSError` passed from the block without
+/// sending any value.
+///
+/// tryBlock - An action that performs some computation that could fail. If
+///            an error is passed via `errorPtr`, failure is assumed. If no
+///            error is passed, any value returned by the block is considered
+///            successful (including `nil`). This block must not be nil.
+///
+/// Example:
+///
+///   [RACSignal try:^(NSError **error) {
+///       return [NSJSONSerialization JSONObjectWithData:someJSONData options:0 error:error];
+///   }];
++ (RACSignal *)try:(id (^)(NSError **errorPtr))tryBlock;
+
 /// Runs `tryBlock` against each of the receiver's values, passing values
 /// until `tryBlock` returns NO, or the receiver completes.
 ///

--- a/ReactiveCocoa/RACSignal+Operations.h
+++ b/ReactiveCocoa/RACSignal+Operations.h
@@ -381,13 +381,12 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 - (RACSignal *)catchTo:(RACSignal *)signal;
 
 /// Returns a signal that will either immediately send the return value of
-/// `tryBlock` and complete, or send the `NSError` passed from the block without
-/// sending any value.
+/// `tryBlock` and complete, or error using the `NSError` passed out from the
+/// block.
 ///
-/// tryBlock - An action that performs some computation that could fail. If
-///            an error is passed via `errorPtr`, failure is assumed. If no
-///            error is passed, any value returned by the block is considered
-///            successful (including `nil`). This block must not be nil.
+/// tryBlock - An action that performs some computation that could fail. If the
+///            block returns nil, the block must return an error via the
+///            `errorPtr` parameter.
 ///
 /// Example:
 ///

--- a/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoa/RACSignal+Operations.m
@@ -276,7 +276,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
 		NSError *error;
 		id value = tryBlock(&error);
-		RACSignal *signal = (error == nil ? [RACSignal return:value] : [RACSignal error:error]);
+		RACSignal *signal = (value == nil ? [RACSignal error:error] : [RACSignal return:value]);
 		return [signal subscribe:subscriber];
 	}] setNameWithFormat:@"+try:"];
 }

--- a/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoa/RACSignal+Operations.m
@@ -270,6 +270,17 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 	}] setNameWithFormat:@"[%@] -catchTo: %@", self.name, signal];
 }
 
++ (RACSignal *)try:(id (^)(NSError **errorPtr))tryBlock {
+	NSCParameterAssert(tryBlock != NULL);
+
+	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+		NSError *error;
+		id value = tryBlock(&error);
+		RACSignal *signal = (error == nil ? [RACSignal return:value] : [RACSignal error:error]);
+		return [signal subscribe:subscriber];
+	}] setNameWithFormat:@"+try:"];
+}
+
 - (RACSignal *)try:(BOOL (^)(id value, NSError **errorPtr))tryBlock {
 	NSCParameterAssert(tryBlock != NULL);
 

--- a/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaTests/RACSignalSpec.m
@@ -2528,7 +2528,7 @@ qck_describe(@"+try:", ^{
 		receivedError = nil;
 	});
 
-	qck_it(@"should pass the value if no error is set", ^{
+	qck_it(@"should pass the value if it is non-nil", ^{
 		RACSignal *signal = [RACSignal try:^(NSError **error) {
 			return @"foo";
 		}];
@@ -2543,7 +2543,7 @@ qck_describe(@"+try:", ^{
 		expect(receivedError).to(beNil());
 	});
 
-	qck_it(@"should discard the value if an error is set", ^{
+	qck_it(@"should ignore the error if the value is non-nil", ^{
 		RACSignal *signal = [RACSignal try:^(NSError **error) {
 			if (error != nil) *error = RACSignalTestError;
 
@@ -2556,26 +2556,25 @@ qck_describe(@"+try:", ^{
 			receivedError = error;
 		}];
 
-		expect(receivedError).to(equal(RACSignalTestError));
-		expect(value).to(beNil());
+		expect(receivedError).to(beNil());
+		expect(value).to(equal(@"foo"));
 	});
 
-	qck_it(@"should allow nil values when no error is set", ^{
+	qck_it(@"should send the error if the return value is nil", ^{
 		RACSignal *signal = [RACSignal try:^id(NSError **error) {
+			if (error) *error = RACSignalTestError;
+
 			return nil;
 		}];
 
-		__block BOOL valueReceived = NO;
 		[signal subscribeNext:^(id x) {
-			valueReceived = YES;
 			value = x;
 		} error:^(NSError *error) {
 			receivedError = error;
 		}];
 
 		expect(value).to(beNil());
-		expect(@(valueReceived)).to(beTruthy());
-		expect(receivedError).to(beNil());
+		expect(receivedError).to(equal(RACSignalTestError));
 	});
 });
 

--- a/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaTests/RACSignalSpec.m
@@ -2519,6 +2519,66 @@ qck_describe(@"-catch:", ^{
 	});
 });
 
+qck_describe(@"+try:", ^{
+	__block id value;
+	__block NSError *receivedError;
+
+	qck_beforeEach(^{
+		value = nil;
+		receivedError = nil;
+	});
+
+	qck_it(@"should pass the value if no error is set", ^{
+		RACSignal *signal = [RACSignal try:^(NSError **error) {
+			return @"foo";
+		}];
+
+		[signal subscribeNext:^(id x) {
+			value = x;
+		} error:^(NSError *error) {
+			receivedError = error;
+		}];
+
+		expect(value).to(equal(@"foo"));
+		expect(receivedError).to(beNil());
+	});
+
+	qck_it(@"should discard the value if an error is set", ^{
+		RACSignal *signal = [RACSignal try:^(NSError **error) {
+			if (error != nil) *error = RACSignalTestError;
+
+			return @"foo";
+		}];
+
+		[signal subscribeNext:^(id x) {
+			value = x;
+		} error:^(NSError *error) {
+			receivedError = error;
+		}];
+
+		expect(receivedError).to(equal(RACSignalTestError));
+		expect(value).to(beNil());
+	});
+
+	qck_it(@"should allow nil values when no error is set", ^{
+		RACSignal *signal = [RACSignal try:^id(NSError **error) {
+			return nil;
+		}];
+
+		__block BOOL valueReceived = NO;
+		[signal subscribeNext:^(id x) {
+			valueReceived = YES;
+			value = x;
+		} error:^(NSError *error) {
+			receivedError = error;
+		}];
+
+		expect(value).to(beNil());
+		expect(@(valueReceived)).to(beTruthy());
+		expect(receivedError).to(beNil());
+	});
+});
+
 qck_describe(@"-try:", ^{
 	__block RACSubject *subject;
 	__block NSError *receivedError;


### PR DESCRIPTION
In my own projects I've found this to be a useful addition, which complements `-try:` and `-tryMap:`.

I've taken a stab at documentation and tests, and tried to find a logical place for the method to live—but open to suggestions/corrections/improvements on anything at all!

Also, while you can achieve equivalent functionality with a combination of `+return:` and `-tryMap:`, e.g.:

```objc
RACSignal *JSONSignal = [[RACSignal return:data] tryMap:^(NSData *data, NSError **error) {
  return [NSJSONSerialization JSONObjectWithData:data options:0 error:error];
];
```

I think this is conceptually simpler:

```objc
RACSignal *JSONSignal = [RACSignal try:^(NSError **error) {
  return [NSJSONSerialization JSONObjectWithData:data options:0 error:error];
];
```