### PR TITLE
add DependentType

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -47,10 +47,16 @@ public struct ConstantProperty<T>: PropertyType {
 	}
 }
 
+/// Represents a property that's value is depended on Signal/Producer.
+/// i.e., Operator (<~) binds a signal to a property.
+public protocol DependentType: class, PropertyType {
+	var value: Value { get set }
+}
+
 /// A mutable property of type T that allows observation of its changes.
 ///
 /// Instances of this class are thread-safe.
-public final class MutableProperty<T>: PropertyType {
+public final class MutableProperty<T>: DependentType {
 	public typealias Value = T
 
 	private let observer: Signal<T, NoError>.Observer
@@ -101,7 +107,7 @@ extension MutableProperty: SinkType {
 /// Use this class only as a last resort! `MutableProperty` is generally better
 /// unless KVC/KVO is required by the API you're using (for example,
 /// `NSOperation`).
-@objc public final class DynamicProperty: RACDynamicPropertySuperclass, PropertyType {
+@objc public final class DynamicProperty: RACDynamicPropertySuperclass, DependentType {
 	public typealias Value = AnyObject?
 
 	private weak var object: NSObject?
@@ -156,7 +162,7 @@ infix operator <~ {
 ///
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the signal sends a `Completed` event.
-public func <~ <T>(property: MutableProperty<T>, signal: Signal<T, NoError>) -> Disposable {
+public func <~ <T, U: DependentType where U.Value == T>(property: U, signal: Signal<T, NoError>) -> Disposable {
 	let disposable = CompositeDisposable()
 	let propertyDisposable = property.producer.start(completed: {
 		disposable.dispose()
@@ -182,7 +188,7 @@ public func <~ <T>(property: MutableProperty<T>, signal: Signal<T, NoError>) -> 
 ///
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the created signal sends a `Completed` event.
-public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T, NoError>) -> Disposable {
+public func <~ <T, U: DependentType where U.Value == T>(property: U, producer: SignalProducer<T, NoError>) -> Disposable {
 	var disposable: Disposable!
 
 	producer.startWithSignal { signal, signalDisposable in


### PR DESCRIPTION
Resolves #1828 

But I'm worried about 2 points.

1) This code allows only ```Signal<AnyObject?, _>```
2) Sense for name ```DependentType```

What do you think?