### PR TITLE
Added versions of <~ to bind values of a Signal or SignalProducer into any T -> () function

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -205,3 +205,29 @@ public func <~ <T>(property: MutableProperty<T>, producer: SignalProducer<T, NoE
 public func <~ <T, P: PropertyType where P.Value == T>(destinationProperty: MutableProperty<T>, sourceProperty: P) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }
+
+
+/// Invokes the provided function with the values sent by `producer`
+///
+/// The binding will automatically terminate when the producer sends a `Completed` event,
+/// or when the returned disposable is disposed of.
+public func <~ <T>(f: T -> (), producer: SignalProducer<T, NoError>) -> Disposable {
+	return producer.start(next: f)
+}
+
+/// Invokes the provided function with the values sent by `signal`
+///
+/// The binding will automatically terminate when the signal sends a `Completed` event,
+/// or when the returned disposable is disposed of.
+public func <~<T>(f: T -> (), signal: Signal<T, NoError>) -> Disposable {
+	var disposable = CompositeDisposable()
+
+	let signalDisposable = signal.observe(next: { value in
+		f(value)
+	}, completed: {
+		disposable.dispose()
+	})
+
+	disposable.addDisposable(signalDisposable)
+	return disposable
+}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -206,6 +206,37 @@ class PropertySpec: QuickSpec {
 					mutableProperty = nil
 					expect(bindingDisposable.disposed).to(beTruthy())
 				}
+
+				it("Should call the function when binding a signal producer to it") {
+					let (signal, observer) = Signal<String, NoError>.pipe()
+
+					var functionCalledWithString: String?
+					let function: String -> () = { string in
+						functionCalledWithString = string
+					}
+
+					function <~ signal
+
+					sendNext(observer, initialPropertyValue)
+
+					expect(functionCalledWithString).to(equal(initialPropertyValue))
+				}
+
+				it("Should not call the function anymore when the binding is disposed") {
+					let (signal, observer) = Signal<String, NoError>.pipe()
+
+					var functionCalledWithString: String?
+					let function: String -> () = { string in
+						functionCalledWithString = string
+					}
+
+					let disposable = function <~ signal
+					disposable.dispose()
+
+					sendNext(observer, initialPropertyValue)
+
+					expect(functionCalledWithString).to(beNil())
+				}
 			}
 
 			describe("from a SignalProducer") {
@@ -242,6 +273,36 @@ class PropertySpec: QuickSpec {
 
 					mutableProperty = nil
 					expect(disposable.disposed).to(beTruthy())
+				}
+
+				it("Should call the function when binding a signal producer to it") {
+					let producerValue = initialPropertyValue
+
+					var functionCalledWithString: String?
+					let function: String -> () = { string in
+						functionCalledWithString = string
+					}
+
+					function <~ SignalProducer(value: producerValue)
+
+					expect(functionCalledWithString).to(equal(producerValue))
+				}
+
+				it("Should not call the function anymore when the binding is disposed") {
+					let producerValue = initialPropertyValue
+
+					var functionCalledWithString: String?
+					let function: String -> () = { string in
+						functionCalledWithString = string
+					}
+
+					let (producer, observer) = SignalProducer<String, NoError>.buffer()
+					let disposable = function <~ producer
+					disposable.dispose()
+
+					sendNext(observer, producerValue)
+
+					expect(functionCalledWithString).to(beNil())
 				}
 			}
 


### PR DESCRIPTION
Not sure how useful this is, and whether we would prefer to keep it outside of the 1.0 API to limit the API surface, but I found myself doing:

```swift
someProducer.start(next: { value in
    self.doSomethingWithValue(value: value)
})
```

(Which I later realized I could just write like:)

```swift
someProducer.start(next: self.doSomethingWithValue)
```

And it reminded me of the `-[RACSignal setKeyPath:onObject:]` from RAC2. I think it would make sense to be able to use the `<~` operator also with `T -> ()` functions, like so:

```swift
self.doSomethingWithValue <~ someProducer
```

Does this make sense?