### PR TITLE
Fixing throttle bug

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -763,7 +763,8 @@ public func throttle<T, E>(interval: NSTimeInterval, onScheduler scheduler: Date
 					let (_, scheduleDate) = state.modify { (var state) -> (ThrottleState<T>, NSDate) in
 						state.pendingValue = value.unbox
 
-						let scheduleDate = state.previousDate?.dateByAddingTimeInterval(interval) ?? scheduler.currentDate
+						let proposedScheduleDate = state.previousDate?.dateByAddingTimeInterval(interval) ?? scheduler.currentDate
+						let scheduleDate = proposedScheduleDate.laterDate(scheduler.currentDate)
 						return (state, scheduleDate)
 					}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1035,7 +1035,7 @@ class SignalSpec: QuickSpec {
 				scheduler.advanceByInterval(1.5)
 				expect(values).to(equal([ 0, 2 ]))
 
-				scheduler.advanceByInterval(1)
+				scheduler.advanceByInterval(3)
 				expect(values).to(equal([ 0, 2 ]))
 
 				sendNext(observer, 3)


### PR DESCRIPTION
This fixes a bug in the throttle operator.  There was an error in the logic for scheduling the next signal that would cause a drift backwards.  This meant that given enough time passing, throttle would have no effect.  The fix is to make sure that the scheduled date is never in the past.  The change in the test demonstrates the issue.