### PR TITLE
Try to crash less

### DIFF
--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -67,20 +67,20 @@ public enum Event<T, E: ErrorType> {
 
 	/// Creates a sink that can receive events of this type, then invoke the
 	/// given handlers based on the kind of event received.
-	public static func sink(next: T -> () = doNothing, error: E -> () = doNothing, completed: () -> () = doNothing, interrupted: () -> () = doNothing) -> SinkOf<Event> {
+	public static func sink(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil) -> SinkOf<Event> {
 		return SinkOf { event in
 			switch event {
 			case let .Next(value):
-				next(value.unbox)
+				next?(value.unbox)
 
 			case let .Error(err):
-				error(err.unbox)
+				error?(err.unbox)
 
 			case .Completed:
-				completed()
+				completed?()
 
 			case .Interrupted:
-				interrupted()
+				interrupted?()
 			}
 		}
 	}

--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -8,9 +8,6 @@
 
 import LlamaKit
 
-internal func doNothing<T>(value: T) {}
-internal func doNothing() {}
-
 /// Represents a signal event.
 ///
 /// Signals must conform to the grammar:

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -109,7 +109,7 @@ public final class Signal<T, E: ErrorType> {
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observe(next: T -> () = doNothing, error: E -> () = doNothing, completed: () -> () = doNothing, interrupted: () -> () = doNothing) -> Disposable? {
+	public func observe(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil) -> Disposable? {
 		return observe(Event.sink(next: next, error: error, completed: completed, interrupted: interrupted))
 	}
 }
@@ -983,6 +983,6 @@ public func observe<T, E, S: SinkType where S.Element == Event<T, E>>(sink: S)(s
 }
 
 /// Signal.observe() as a free function, for easier use with |>.
-public func observe<T, E>(next: T -> () = doNothing, error: E -> () = doNothing, completed: () -> () = doNothing, interrupted: () -> () = doNothing)(signal: Signal<T, E>) -> Disposable? {
+public func observe<T, E>(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil)(signal: Signal<T, E>) -> Disposable? {
 	return signal.observe(next: next, error: error, completed: completed, interrupted: interrupted)
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -233,7 +233,7 @@ public struct SignalProducer<T, E: ErrorType> {
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func start(next: T -> () = doNothing, error: E -> () = doNothing, completed: () -> () = doNothing, interrupted: () -> () = doNothing) -> Disposable {
+	public func start(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil) -> Disposable {
 		return start(Event.sink(next: next, error: error, completed: completed, interrupted: interrupted))
 	}
 
@@ -1061,6 +1061,6 @@ public func start<T, E, S: SinkType where S.Element == Event<T, E>>(sink: S)(pro
 }
 
 /// SignalProducer.start() as a free function, for easier use with |>.
-public func start<T, E>(next: T -> () = doNothing, error: E -> () = doNothing, completed: () -> () = doNothing, interrupted: () -> () = doNothing)(producer: SignalProducer<T, E>) -> Disposable {
+public func start<T, E>(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil)(producer: SignalProducer<T, E>) -> Disposable {
 	return producer.start(next: next, error: error, completed: completed, interrupted: interrupted)
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -332,33 +332,33 @@ public func timer(interval: NSTimeInterval, onScheduler scheduler: DateScheduler
 }
 
 /// Injects side effects to be performed upon the specified signal events.
-public func on<T, E>(started: () -> () = doNothing, event: Event<T, E> -> () = doNothing, next: T -> () = doNothing, error: E -> () = doNothing, completed: () -> () = doNothing, interrupted: () -> () = doNothing, terminated: () -> () = doNothing, disposed: () -> () = doNothing)(producer: SignalProducer<T, E>) -> SignalProducer<T, E> {
+public func on<T, E>(started: (() -> ())? = nil, event: (Event<T, E> -> ())? = nil, next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil)(producer: SignalProducer<T, E>) -> SignalProducer<T, E> {
 	return SignalProducer { observer, compositeDisposable in
-		started()
-		compositeDisposable.addDisposable(disposed)
+		started?()
+		disposed.map(compositeDisposable.addDisposable)
 
 		producer.startWithSignal { signal, disposable in
 			compositeDisposable.addDisposable(disposable)
 
 			let innerObserver = Signal<T, E>.Observer { receivedEvent in
-				event(receivedEvent)
+				event?(receivedEvent)
 
 				switch receivedEvent {
 				case let .Next(value):
-					next(value.unbox)
+					next?(value.unbox)
 
 				case let .Error(err):
-					error(err.unbox)
+					error?(err.unbox)
 
 				case .Completed:
-					completed()
+					completed?()
 
 				case .Interrupted:
-					interrupted()
+					interrupted?()
 				}
 
 				if receivedEvent.isTerminating {
-					terminated()
+					terminated?()
 				}
 
 				observer.put(receivedEvent)


### PR DESCRIPTION
`nil` turns out to be 99% less crashy than `doNothing`, so :fire:.

Fixes a nasty crasher: https://github.com/Carthage/Carthage/pull/368