### PR TITLE
Signal<T, E:ErrorType> binds to DynamicProperty

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -164,7 +164,7 @@ infix operator <~ {
 ///
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the signal sends a `Completed` event.
-public func <~ <T, P: MutablePropertyType where P.Value == T>(property: P, signal: Signal<T, NoError>) -> Disposable {
+public func <~ <T, P: MutablePropertyType, E: ErrorType where P.Value == T>(property: P, signal: Signal<T, E>) -> Disposable {
 	let disposable = CompositeDisposable()
 	let propertyDisposable = property.producer.start(completed: {
 		disposable.dispose()
@@ -190,7 +190,7 @@ public func <~ <T, P: MutablePropertyType where P.Value == T>(property: P, signa
 ///
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the created signal sends a `Completed` event.
-public func <~ <T, P: MutablePropertyType where P.Value == T>(property: P, producer: SignalProducer<T, NoError>) -> Disposable {
+public func <~ <T, P: MutablePropertyType, E: ErrorType where P.Value == T>(property: P, producer: SignalProducer<T, E>) -> Disposable {
 	var disposable: Disposable!
 
 	producer.startWithSignal { signal, signalDisposable in


### PR DESCRIPTION
I want to bind `Signal<T, E>` to `DynamicProperty`.

Specifically, I want `DynamicProperty <~ Signal(UIKit)` through `RACSignal.toSignalProducer()`.
But it's not easy, because `RACSignal.toSignalProducer()` returns `SignalProducer<AnyObject?, NSError>`.

I think that operator (<~) doesn't need `Sigal<T, NoError>`. 
Operator (<~) doesn't do anything for error.

How about?