### PR TITLE
Add ignoreNil for Signal

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -177,12 +177,12 @@ public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T
 	}
 }
 
-/// Applies `transform` to values from `signal` with non-`nil` results unwrapped and
-/// forwared on the returned signal.
-public func filterMap<T, U, E>(transform: T -> U?)(signal: Signal<T, E>) -> Signal<U, E> {
+/// Unwraps non-`nil` values from `signal` and forwards them on the returned
+/// signal, `nil` values are dropped.
+public func ignoreNil<T, E>(signal: Signal<T?, E>) -> Signal<T, E> {
 	return Signal { observer in
 		signal.observe(next: { value in
-			if let val = transform(value) {
+			if let val = value {
 				sendNext(observer, val)
 			}
 		}, error: { error in

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -180,20 +180,7 @@ public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T
 /// Unwraps non-`nil` values from `signal` and forwards them on the returned
 /// signal, `nil` values are dropped.
 public func ignoreNil<T, E>(signal: Signal<T?, E>) -> Signal<T, E> {
-	// This is equivalent to `signal |> filter { $0 != nil } |> map { $0! }`
-	return Signal { observer in
-		signal.observe(next: { value in
-			if let val = value {
-				sendNext(observer, val)
-			}
-		}, error: { error in
-			sendError(observer, error)
-		}, completed: {
-			sendCompleted(observer)
-		}, interrupted: {
-			sendInterrupted(observer)
-		})
-	}
+	return signal |> filter { $0 != nil } |> map { $0! }
 }
 
 /// Returns a signal that will yield the first `count` values from the

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -177,6 +177,24 @@ public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T
 	}
 }
 
+/// Applies `transform` to values from `signal` with non-`nil` results unwrapped and
+/// forwared on the returned signal.
+public func flatMap<T, U, E>(transform: T -> U?)(signal: Signal<T, E>) -> Signal<U, E> {
+	return Signal { observer in
+		signal.observe(next: { value in
+			if let val = transform(value) {
+				sendNext(observer, val)
+			}
+		}, error: { error in
+			sendError(observer, error)
+		}, completed: {
+			sendCompleted(observer)
+		}, interrupted: {
+			sendInterrupted(observer)
+		})
+	}
+}
+
 /// Returns a signal that will yield the first `count` values from the
 /// input signal.
 public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -179,7 +179,7 @@ public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T
 
 /// Applies `transform` to values from `signal` with non-`nil` results unwrapped and
 /// forwared on the returned signal.
-public func flatMap<T, U, E>(transform: T -> U?)(signal: Signal<T, E>) -> Signal<U, E> {
+public func filterMap<T, U, E>(transform: T -> U?)(signal: Signal<T, E>) -> Signal<U, E> {
 	return Signal { observer in
 		signal.observe(next: { value in
 			if let val = transform(value) {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -180,6 +180,7 @@ public func filter<T, E>(predicate: T -> Bool)(signal: Signal<T, E>) -> Signal<T
 /// Unwraps non-`nil` values from `signal` and forwards them on the returned
 /// signal, `nil` values are dropped.
 public func ignoreNil<T, E>(signal: Signal<T?, E>) -> Signal<T, E> {
+	// This is equivalent to `signal |> filter { $0 != nil } |> map { $0! }`
 	return Signal { observer in
 		signal.observe(next: { value in
 			if let val = value {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -452,6 +452,30 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("flatMap") {
+			it("should map values and omit nils from the signal") {
+				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let mappedSignal = signal |> flatMap { $0 % 2 == 0 ? nil : toString($0) }
+
+				var lastValue: String?
+
+				mappedSignal.observe(next: { lastValue = $0 })
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 0)
+				expect(lastValue).to(beNil())
+
+				sendNext(sink, 1)
+				expect(lastValue).to(equal("1"))
+
+				sendNext(sink, 2)
+				expect(lastValue).to(equal("1"))
+
+				sendNext(sink, 3)
+				expect(lastValue).to(equal("3"))
+			}
+		}
+
 		describe("scan") {
 			it("should incrementally accumulate a value") {
 				let (baseSignal, sink) = Signal<String, NoError>.pipe()

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -452,27 +452,27 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("filterMap") {
-			it("should map values and omit nils from the signal") {
-				let (signal, sink) = Signal<Int, NoError>.pipe()
-				let mappedSignal = signal |> filterMap { $0 % 2 == 0 ? nil : toString($0) }
+		describe("ignoreNil") {
+			it("should forward only non-nil values") {
+				let (signal, sink) = Signal<Int?, NoError>.pipe()
+				let mappedSignal = signal |> ignoreNil
 
-				var lastValue: String?
+				var lastValue: Int?
 
 				mappedSignal.observe(next: { lastValue = $0 })
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 0)
+				sendNext(sink, nil)
 				expect(lastValue).to(beNil())
 
 				sendNext(sink, 1)
-				expect(lastValue).to(equal("1"))
+				expect(lastValue).to(equal(1))
+
+				sendNext(sink, nil)
+				expect(lastValue).to(equal(1))
 
 				sendNext(sink, 2)
-				expect(lastValue).to(equal("1"))
-
-				sendNext(sink, 3)
-				expect(lastValue).to(equal("3"))
+				expect(lastValue).to(equal(2))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -452,10 +452,10 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
-		describe("flatMap") {
+		describe("filterMap") {
 			it("should map values and omit nils from the signal") {
 				let (signal, sink) = Signal<Int, NoError>.pipe()
-				let mappedSignal = signal |> flatMap { $0 % 2 == 0 ? nil : toString($0) }
+				let mappedSignal = signal |> filterMap { $0 % 2 == 0 ? nil : toString($0) }
 
 				var lastValue: String?
 


### PR DESCRIPTION
Essentially filter+map without the need to force unwrap values in the latter if you implement it in terms of the two.

~~I went with the name `flatMap` to be consistent with the stdlib. I also considered `filterMap` and am open to other suggestions~~. ~~Lets go with `filterMap`~~. Take 3, `ignoreNil`.

@ReactiveCocoa/reactivecocoa thoughts?