### PR TITLE
Ignore unhelpful warnings from -Wreceiver-is-weak in RACObserve

### DIFF
--- a/ReactiveCocoa/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoa/NSObject+RACPropertySubscribing.h
@@ -48,8 +48,11 @@
 /// completed if self or observer is deallocated.
 #define RACObserve(TARGET, KEYPATH) \
 	({ \
+        _Pragma("clang diagnostic push") \
+        _Pragma("clang diagnostic ignored \"-Wreceiver-is-weak\"") \
 		__weak id target_ = (TARGET); \
 		[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
+        _Pragma("clang diagnostic pop") \
 	})
 
 @class RACDisposable;

--- a/ReactiveCocoa/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoa/NSObject+RACPropertySubscribing.h
@@ -48,11 +48,11 @@
 /// completed if self or observer is deallocated.
 #define RACObserve(TARGET, KEYPATH) \
 	({ \
-        _Pragma("clang diagnostic push") \
-        _Pragma("clang diagnostic ignored \"-Wreceiver-is-weak\"") \
+		_Pragma("clang diagnostic push") \
+		_Pragma("clang diagnostic ignored \"-Wreceiver-is-weak\"") \
 		__weak id target_ = (TARGET); \
 		[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
-        _Pragma("clang diagnostic pop") \
+		_Pragma("clang diagnostic pop") \
 	})
 
 @class RACDisposable;


### PR DESCRIPTION
https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1595 changed `RACObserve` to message a weakified target, but this emits a compiler warning when `-Wreceiver-is-weak` is enabled.

This is fine for `RACObserve` since the lifetime of the signal is tied to the lifetime of the target, so it's safe to fix with a `clang diagnostic ignored`.