### PR TITLE
fix -take: vs recursive -sendNext:

### DIFF
--- a/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoa/RACStream.m
@@ -176,9 +176,13 @@
 		__block NSUInteger taken = 0;
 
 		return ^ id (id value, BOOL *stop) {
-			if (++taken >= count) *stop = YES;
-
-			return [class return:value];
+			if (taken < count) {
+				++taken;
+				if (taken == count) *stop = YES;
+				return [class return:value];
+			} else {
+				return nil;
+			}
 		};
 	}] setNameWithFormat:@"[%@] -take: %lu", self.name, (unsigned long)count];
 }

--- a/ReactiveCocoaTests/RACSignalSpec.m
+++ b/ReactiveCocoaTests/RACSignalSpec.m
@@ -2913,6 +2913,34 @@ qck_it(@"should complete take: even if the original signal doesn't", ^{
 	expect(@(completed)).to(beTruthy());
 });
 
+qck_it(@"should complete take: even if the signal is recursive", ^{
+    RACSubject *subject = [RACSubject subject];
+    const NSUInteger number = 3;
+    const NSUInteger guard = number + 1;
+
+    NSMutableArray *values = NSMutableArray.array;
+    __block BOOL completed = NO;
+
+    [[subject take:number] subscribeNext:^(NSNumber* received) {
+        [values addObject:received];
+        if (values.count >= guard) {
+            [subject sendError:RACSignalTestError];
+        }
+        [subject sendNext:@(received.integerValue + 1)];
+    } completed:^{
+        completed = YES;
+    }];
+    [subject sendNext:@0];
+
+    NSMutableArray* expectedValues = [NSMutableArray arrayWithCapacity:number];
+    for (NSUInteger i = 0 ; i < number ; ++i) {
+        [expectedValues addObject:@(i)];
+    }
+
+    expect(values).to(equal(expectedValues));
+    expect(@(completed)).to(beTruthy());
+});
+
 qck_describe(@"+zip:", ^{
 	__block RACSubject *subject1 = nil;
 	__block RACSubject *subject2 = nil;


### PR DESCRIPTION
The following code causes infinite loop
```objective-c
RACSubject* subject = [RACSubject subject];
[[subject take:3] subscribeNext:^(NSNumber* value) {
    NSLog(@"value=%@", value);
    [subject sendNext:@(value.integerValue + 1)];
} completed:^{
    NSLog(@"completed");
}];
[subject sendNext:@100];
```

IIUC, this should output
```
value=100
value=101
value=102
completed
```
on debug console, then should stop.