### PR TITLE
Overloaded skipRepeats for Array<T: Equatable>

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -518,6 +518,12 @@ public func skipRepeats<T: Equatable, E>(signal: Signal<T, E>) -> Signal<T, E> {
 	return signal |> skipRepeats { $0 == $1 }
 }
 
+/// Forwards only those values from `signal` which are not duplicates of the
+/// immedately preceding value. The first value is always forwarded.
+public func skipRepeats<T: Equatable, E>(signal: Signal<[T], E>) -> Signal<[T], E> {
+	return signal |> skipRepeats { $0 == $1 }
+}
+
 /// Forwards only those values from `signal` which do not pass `isRepeat` with
 /// respect to the previous value. The first value is always forwarded.
 public func skipRepeats<T, E>(isRepeat: (T, T) -> Bool)(signal: Signal<T, E>) -> Signal<T, E> {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -604,6 +604,28 @@ class SignalSpec: QuickSpec {
 				expect(values).to(equal([ true, false, true ]))
 			}
 
+			it("should skip duplicate Arrays of Equatable values") {
+				let (baseSignal, sink) = Signal<[Bool], NoError>.pipe()
+				let signal = baseSignal |> skipRepeats
+
+				var values: [[Bool]] = []
+				signal.observe(next: { values.append($0) })
+
+				expect(values).to(equal([]))
+
+				sendNext(sink, [ true ])
+				expect(values).to(equal([ [ true ] ]))
+
+				sendNext(sink, [ true ])
+				expect(values).to(equal([ [ true ] ]))
+
+				sendNext(sink, [ false ])
+				expect(values).to(equal([ [ true ], [ false ] ]))
+
+				sendNext(sink, [ true ])
+				expect(values).to(equal([ [ true ], [ false ], [ true ] ]))
+			}
+
 			it("should skip values according to a predicate") {
 				let (baseSignal, sink) = Signal<String, NoError>.pipe()
 				let signal = baseSignal |> skipRepeats { count($0) == count($1) }


### PR DESCRIPTION
I'm not sure if this is something we want to include, but I've needed this myself.

This is necessary because `Array` is not `Equatable` *yet*. Hopefully one day Swift will allow partial specialization of types (is that the right term?) so this won't be necessary.