### PR TITLE
Setting APPLICATION_EXTENSION_API_ONLY to YES in iOS and Mac frameworks

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "jspahrsummers/xcconfigs" >= 0.7.1
+github "jspahrsummers/xcconfigs" >= 0.8
 github "Quick/Quick" "master"
 github "Quick/Nimble" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "LlamaKit/LlamaKit" "v0.6.0"
 github "Quick/Nimble" "6a679cbf20da3fe570c26296b3029dd168b72c00"
 github "Quick/Quick" "155f858bce082373fc60d0c0a63415bf336c676b"
-github "jspahrsummers/xcconfigs" "0.7.2"
+github "jspahrsummers/xcconfigs" "0.8"


### PR DESCRIPTION
Per the documentation:

```
When enabled, this causes the compiler and linker to
disallow use of APIs that are not available
to app extensions and to disallow linking to frameworks
that have not been built with this setting enabled. 
```

Since we're not using any of these APIs, we can safely turn this setting on.

This allows `ReactiveCocoa` to be used in application extensions without receiving this warning:
![screen shot 2015-04-12 at 11 00 23](https://cloud.githubusercontent.com/assets/685609/7106799/4723c7b2-e103-11e4-83a1-f1c93d6e769e.png)

The only problem is that compiling now prompts this same error with `LlamaKit`, but I imagine we can enable this in https://github.com/antitypical/Result after #1887.