### PR TITLE
> Unannotated single-expression closures with non-Void return types can ...

### DIFF
--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -129,7 +129,6 @@ public func toRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
 
 		return RACDisposable {
 			selfDisposable?.dispose()
-			return
 		}
 	}
 }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -179,7 +179,6 @@ public func <~ <T, P: MutablePropertyType where P.Value == T>(property: P, signa
 
 	let signalDisposable = signal.observe(next: { [weak property] value in
 		property?.value = value
-		return
 	}, completed: {
 		disposable.dispose()
 	})

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1030,9 +1030,9 @@ public func single<T, E>(producer: SignalProducer<T, E>) -> Result<T, E>? {
 			result = failure(error)
 			dispatch_semaphore_signal(semaphore)
 		}, completed: {
-			_ = dispatch_semaphore_signal(semaphore)
+			dispatch_semaphore_signal(semaphore)
 		}, interrupted: {
-			_ = dispatch_semaphore_signal(semaphore)
+			dispatch_semaphore_signal(semaphore)
 		})
 
 	dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)


### PR DESCRIPTION
...now be used in Void contexts

The cases of `observeOn` and `sampleOn` in Signal.swift cannot be omitted due to compilation error.