### PR TITLE
Workarounds for Swift runtime memory corruption

### DIFF
--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -52,21 +52,12 @@ internal final class Atomic<T> {
 	///
 	/// Returns the old value.
 	func modify(action: T -> T) -> T {
-		let (oldValue, _) = modify { oldValue in (action(oldValue), 0) }
-		return oldValue
-	}
-	
-	/// Atomically modifies the variable.
-	///
-	/// Returns the old value, plus arbitrary user-defined data.
-	func modify<U>(action: T -> (T, U)) -> (T, U) {
 		lock()
-		let oldValue: T = _value
-		let (newValue, data) = action(_value)
-		_value = newValue
+		let oldValue = _value
+		_value = action(_value)
 		unlock()
 		
-		return (oldValue, data)
+		return oldValue
 	}
 	
 	/// Atomically performs an arbitrary action using the current value of the

--- a/ReactiveCocoa/Swift/Bag.swift
+++ b/ReactiveCocoa/Swift/Bag.swift
@@ -48,6 +48,16 @@ internal struct Bag<T>: SequenceType {
 	}
 	
 	internal func generate() -> GeneratorOf<T> {
-		return GeneratorOf(elements.values.generate())
+		var values: [T] = []
+
+		var index = next + 1
+		while index > 0 {
+			--index
+			if let value = elements[index] {
+				values.append(value)
+			}
+		}
+
+		return GeneratorOf(values.generate())
 	}
 }

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -124,20 +124,23 @@ public final class CompositeDisposable: Disposable {
 			return DisposableHandle()
 		}
 
-		let (_, handle) = disposables.modify { ds -> (Bag<Disposable>?, DisposableHandle?) in
+		var handle: DisposableHandle? = nil
+		disposables.modify { ds in
 			if var ds = ds {
 				let token = ds.insert(d!)
-				return (ds, DisposableHandle(bagToken: token, disposable: self))
+				handle = DisposableHandle(bagToken: token, disposable: self)
+				return ds
 			} else {
-				return (nil, nil)
+				return nil
 			}
 		}
 
-		if handle == nil {
+		if let handle = handle {
+			return handle
+		} else {
 			d!.dispose()
+			return DisposableHandle()
 		}
-
-		return handle ?? DisposableHandle()
 	}
 
 	/// Adds an ActionDisposable to the list.


### PR DESCRIPTION
“Fixes” crashes [like these](https://gist.github.com/jspahrsummers/b77aeb5ff0eabe67feb7), as reported in https://github.com/Carthage/Carthage/pull/368#issuecomment-87943571.

I basically just addressed these with the brute force approach: run until we crash, and then find another way to express the code there. :confused: 

/cc @robrix @jckarter