### PR TITLE
Make "next" the trailing closure for Signal.observe() and SignalProducer.start()

### DIFF
--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -64,7 +64,7 @@ public enum Event<T, E: ErrorType> {
 
 	/// Creates a sink that can receive events of this type, then invoke the
 	/// given handlers based on the kind of event received.
-	public static func sink(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil) -> SinkOf<Event> {
+	public static func sink(error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> SinkOf<Event> {
 		return SinkOf { event in
 			switch event {
 			case let .Next(value):

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -109,7 +109,7 @@ public final class Signal<T, E: ErrorType> {
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observe(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil) -> Disposable? {
+	public func observe(error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> Disposable? {
 		return observe(Event.sink(next: next, error: error, completed: completed, interrupted: interrupted))
 	}
 }
@@ -990,6 +990,6 @@ public func observe<T, E, S: SinkType where S.Element == Event<T, E>>(sink: S)(s
 }
 
 /// Signal.observe() as a free function, for easier use with |>.
-public func observe<T, E>(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil)(signal: Signal<T, E>) -> Disposable? {
+public func observe<T, E>(error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil)(signal: Signal<T, E>) -> Disposable? {
 	return signal.observe(next: next, error: error, completed: completed, interrupted: interrupted)
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -233,7 +233,7 @@ public struct SignalProducer<T, E: ErrorType> {
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func start(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil) -> Disposable {
+	public func start(error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> Disposable {
 		return start(Event.sink(next: next, error: error, completed: completed, interrupted: interrupted))
 	}
 
@@ -332,7 +332,7 @@ public func timer(interval: NSTimeInterval, onScheduler scheduler: DateScheduler
 }
 
 /// Injects side effects to be performed upon the specified signal events.
-public func on<T, E>(started: (() -> ())? = nil, event: (Event<T, E> -> ())? = nil, next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil)(producer: SignalProducer<T, E>) -> SignalProducer<T, E> {
+public func on<T, E>(started: (() -> ())? = nil, event: (Event<T, E> -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil, next: (T -> ())? = nil)(producer: SignalProducer<T, E>) -> SignalProducer<T, E> {
 	return SignalProducer { observer, compositeDisposable in
 		started?()
 		disposed.map(compositeDisposable.addDisposable)
@@ -1062,6 +1062,6 @@ public func start<T, E, S: SinkType where S.Element == Event<T, E>>(sink: S)(pro
 }
 
 /// SignalProducer.start() as a free function, for easier use with |>.
-public func start<T, E>(next: (T -> ())? = nil, error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil)(producer: SignalProducer<T, E>) -> Disposable {
+public func start<T, E>(error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil)(producer: SignalProducer<T, E>) -> Disposable {
 	return producer.start(next: next, error: error, completed: completed, interrupted: interrupted)
 }

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -470,6 +470,25 @@ class SignalProducerSpec: QuickSpec {
 				disposable.dispose()
 				expect(testSink).to(beNil())
 			}
+
+			describe("trailing closure") {
+				it("receives next values") {
+					var values = [Int]()
+					let (producer, sink) = SignalProducer<Int, NoError>.buffer()
+
+					producer.start { next in
+						values.append(next)
+					}
+
+					sendNext(sink, 1)
+					sendNext(sink, 2)
+					sendNext(sink, 3)
+
+					sendCompleted(sink)
+
+					expect(values).to(equal([1, 2, 3]))
+				}
+			}
 		}
 
 		describe("lift") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -389,6 +389,25 @@ class SignalSpec: QuickSpec {
 				sendInterrupted(sink)
 				expect(testStr).to(beNil())
 			}
+
+			describe("trailing closure") {
+				it("receives next values") {
+					var values = [Int]()
+					let (signal, sink) = Signal<Int, NoError>.pipe()
+
+					signal.observe { next in
+						values.append(next)
+					}
+
+					sendNext(sink, 1)
+					sendNext(sink, 2)
+					sendNext(sink, 3)
+
+					sendCompleted(sink)
+
+					expect(values).to(equal([1, 2, 3]))
+				}
+			}
 		}
 
 		describe("map") {


### PR DESCRIPTION
First, a little story:

When I first decided to test out the great new Swift API (and it really is lovely!), I had to work out how to get values out of a signal. The very first time I observed a signal, this is more or less what I wrote:

```swift
producer.start { next in
  // do something with next value
}
```

However, this didn't compile!

```
/path/to/Sadface.swift: error: cannot invoke 'start' with an argument list of type '((_) -> _)'
                                        producer.start { next in
                                                 ^
```

After I little bit of digging I realised that because the `interrupted:` parameter is the last in the parameter list, my trailing closure was not the closure I expected it to be.

*****

So I'm floating this breaking API change so it can be considered before the 3.0 release. My argument is this:

- Trailing closure syntax is a thing, so we may as well make the trailing closure useful
- The values sent on a signal are the valuable bit, so making `next:` the trailing closure makes sense to me

*****

So basically this just reorders some parameter lists to make `next:` the trailing closure, and adds some tests to make the semantics explicit. If this is a desirable change, there's probably a bunch of other things to do like updating documentation! Also I may well have missed other parts of the API where this would also make sense.

Thanks for your time!