### PR TITLE
Add override of map for transforming signals with optional values

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -142,6 +142,25 @@ public func map<T, U, E>(transform: T -> U)(signal: Signal<T, E>) -> Signal<U, E
 	}
 }
 
+// Maps each non-nil value in a signal to a new value.  Nils are passed through
+// to the new signal.
+public func map<T, U, E>(transform: T -> U)(signal: Signal<T?, E>) -> Signal<U?, E> {
+	return Signal<U?, E> { observer in
+		return signal.observe(Signal.Observer { event in
+			switch event {
+			case let .Next(value):
+				sendNext(observer, value.unbox.map(transform))
+			case let .Error(error):
+				sendError(observer, error.unbox)
+			case let .Completed:
+				sendCompleted(observer)
+			case let .Interrupted:
+				sendInterrupted(observer)
+			}
+		})
+	}
+}
+
 /// Maps errors in the signal to a new error.
 public func mapError<T, E, F>(transform: E -> F)(signal: Signal<T, E>) -> Signal<T, F> {
 	return Signal { observer in

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -430,6 +430,29 @@ class SignalSpec: QuickSpec {
 				sendNext(sink, 1)
 				expect(lastValue).to(equal("2"))
 			}
+			
+			it("should transform the non-nil values of the signal") {
+				let (signal, sink) = Signal<Int?, NoError>.pipe()
+				let mappedSignal = signal |> map { String($0 + 1) }
+				
+				var lastValue: String?
+				
+				mappedSignal.observe(next: {
+					lastValue = $0
+					return
+				})
+				
+				expect(lastValue).to(beNil())
+				
+				sendNext(sink, 0)
+				expect(lastValue).to(equal("1"))
+				
+				sendNext(sink, 1)
+				expect(lastValue).to(equal("2"))
+				
+				sendNext(sink, nil)
+				expect(lastValue).to(beNil())
+			}
 		}
 		
 		


### PR DESCRIPTION
Adding an override for map that allows for a transformation of `Signal<T?,E>` to `Signal<U?,E>` but using a transform function that maps from `T` to `U`.  Nil values are passed through.  I have found this to be helpful simplifying my transform functions where I want to allow `nil` values to continue to be sent.

I'm fairly new to both FP and FRP and had originally used a different name for the transformation.  However, in searching on this transformation, it seemed that `map` was the correct name, at least when viewing the use of it in the Swift standard library ([map](http://swiftdoc.org/func/map/)).  Sorry if there is A) a better name, or B) an existing operator that does this. :smile: 