### PR TITLE
Specify Release configuration for test build, fix some optimization issues

### DIFF
--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa Mac.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa Mac.xcscheme
@@ -40,7 +40,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa iOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa iOS.xcscheme
@@ -40,7 +40,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -480,20 +480,22 @@ public func combinePrevious<T, E>(initial: T) -> Signal<T, E> -> Signal<(T, T), 
 }
 
 /// Like `scan`, but sends only the final value and then immediately completes.
-public func reduce<T, U, E>(initial: U, combine: (U, T) -> U)(signal: Signal<T, E>) -> Signal<U, E> {
-	// We need to handle the special case in which `signal` sends no values.
-	// We'll do that by sending `initial` on the output signal (before taking
-	// the last value).
-	let (scannedSignalWithInitialValue: Signal<U, E>, outputSignalObserver) = Signal.pipe()
-	let outputSignal = scannedSignalWithInitialValue |> takeLast(1)
+public func reduce<T, U, E>(initial: U, combine: (U, T) -> U) -> Signal<T, E> -> Signal<U, E> {
+	return { signal in
+		// We need to handle the special case in which `signal` sends no values.
+		// We'll do that by sending `initial` on the output signal (before taking
+		// the last value).
+		let (scannedSignalWithInitialValue: Signal<U, E>, outputSignalObserver) = Signal.pipe()
+		let outputSignal = scannedSignalWithInitialValue |> takeLast(1)
 
-	// Now that we've got takeLast() listening to the piped signal, send that initial value.
-	sendNext(outputSignalObserver, initial)
+		// Now that we've got takeLast() listening to the piped signal, send that initial value.
+		sendNext(outputSignalObserver, initial)
 
-	// Pipe the scanned input signal into the output signal.
-	signal |> scan(initial, combine) |> observe(outputSignalObserver)
+		// Pipe the scanned input signal into the output signal.
+		signal |> scan(initial, combine) |> observe(outputSignalObserver)
 
-	return outputSignal
+		return outputSignal
+	}
 }
 
 /// Aggregates `signal`'s values into a single combined value. When `signal` emits

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -501,16 +501,18 @@ public func reduce<T, U, E>(initial: U, combine: (U, T) -> U)(signal: Signal<T, 
 /// that emitted value as the second argument. The result is emitted from the
 /// signal returned from `reduce`. That result is then passed to `combine` as the
 /// first argument when the next value is emitted, and so on.
-public func scan<T, U, E>(initial: U, combine: (U, T) -> U)(signal: Signal<T, E>) -> Signal<U, E> {
-	return Signal { observer in
-		var accumulator = initial
+public func scan<T, U, E>(initial: U, combine: (U, T) -> U) -> Signal<T, E> -> Signal<U, E> {
+	return { signal in
+		return Signal { observer in
+			var accumulator = initial
 
-		return signal.observe(Signal.Observer { event in
-			observer.put(event.map { value in
-				accumulator = combine(accumulator, value)
-				return accumulator
+			return signal.observe(Signal.Observer { event in
+				observer.put(event.map { value in
+					accumulator = combine(accumulator, value)
+					return accumulator
+				})
 			})
-		})
+		}
 	}
 }
 

--- a/ReactiveCocoaTests/Objective-C/RACKVOWrapperSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACKVOWrapperSpec.m
@@ -607,7 +607,7 @@ qck_describe(@"rac_addObserver:forKeyPath:options:block:", ^{
 
 	qck_it(@"should automatically stop KVO when the observer deallocates", ^{
 		__weak id weakObserver = nil;
-		__weak id identifier = nil;
+		__weak id weakIdentifier = nil;
 
 		NSOperation *operation = [[NSOperation alloc] init];
 
@@ -619,13 +619,17 @@ qck_describe(@"rac_addObserver:forKeyPath:options:block:", ^{
 			weakObserver = (__bridge id)observer;
 			expect(weakObserver).notTo(beNil());
 
-			identifier = [operation rac_observeKeyPath:@"isFinished" options:0 observer:(__bridge id)observer block:^(id value, NSDictionary *change, BOOL causedByDealloc, BOOL affectedOnlyLastComponent) {}];
+			id identifier = [operation rac_observeKeyPath:@"isFinished" options:0 observer:(__bridge id)observer block:^(id value, NSDictionary *change, BOOL causedByDealloc, BOOL affectedOnlyLastComponent) {}];
 			expect(identifier).notTo(beNil());
+
+			weakIdentifier = identifier;
+			expect(weakIdentifier).notTo(beNil());
 
 			CFRelease(observer);
 		}
 
 		expect(weakObserver).to(beNil());
+		expect(weakIdentifier).to(beNil());
 	});
 
 	qck_it(@"should stop KVO when the observer is disposed", ^{


### PR DESCRIPTION
Depends on #1902. To detect issues caused by the compiler optimization.

Now unfortunately, [this test](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/091d09960df11c3538b9e59f732d1e3ad8bb2e97/ReactiveCocoaTests/Objective-C/RACKVOWrapperSpec.m#L623) is failing :cry: 