### PR TITLE
`PropertyTerminal` implementation

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -159,6 +159,35 @@ extension MutableProperty: SinkType {
 	}
 }
 
+public class PropertyTerminal<P : MutablePropertyType> : MutablePropertyType {
+	typealias Value = P.Value
+	
+	public let property : P
+	private var _producerLocked : Bool
+	
+	public var value : Value {
+		get {
+			return self.property.value
+		}
+		set (x) {
+			self._producerLocked = true
+			self.property.value = x
+			self._producerLocked = false
+		}
+	}
+	
+	public var producer: SignalProducer<Value, NoError> {
+		get {
+			return self.property.producer |> filter { _ in !self._producerLocked }
+		}
+	}
+	
+	public init (property : P) {
+		self.property = property
+		self._producerLocked = false
+	}
+}
+
 infix operator <~ {
 	associativity right
 	precedence 90

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -162,28 +162,28 @@ extension MutableProperty: SinkType {
 public class PropertyTerminal<P : MutablePropertyType> : MutablePropertyType {
 	typealias Value = P.Value
 	
-	public let property : P
+	private let _property : P
 	private var _producerLocked : Bool
 	
 	public var value : Value {
 		get {
-			return self.property.value
+			return self._property.value
 		}
 		set (x) {
 			self._producerLocked = true
-			self.property.value = x
+			self._property.value = x
 			self._producerLocked = false
 		}
 	}
 	
 	public var producer: SignalProducer<Value, NoError> {
 		get {
-			return self.property.producer |> filter { _ in !self._producerLocked }
+			return self._property.producer |> filter { _ in !self._producerLocked }
 		}
 	}
 	
 	public init (property : P) {
-		self.property = property
+		self._property = property
 		self._producerLocked = false
 	}
 }


### PR DESCRIPTION
This follows `RACChannelTerminal` concept and provides a way to support mutual property bindings through wrapping them in PropertyTerminal