### PR TITLE
Optimize collect() performance and memory usage

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -215,9 +215,18 @@ public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 	}
 }
 
+private final class CollectState<T> {
+	var values: [T] = []
+
+	func append(value: T) -> Self {
+		values.append(value)
+		return self
+	}
+}
+
 /// Returns a signal that will yield an array of values when `signal` completes.
 public func collect<T, E>(signal: Signal<T, E>) -> Signal<[T], E> {
-	return signal |> reduce([]) { $0 + [ $1 ] }
+	return signal |> reduce(CollectState()) { $0.append($1) } |> map { $0.values }
 }
 
 /// Forwards all events onto the given scheduler, instead of whichever

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -215,6 +215,8 @@ public func take<T, E>(count: Int)(signal: Signal<T, E>) -> Signal<T, E> {
 	}
 }
 
+/// A reference type which wraps an array to avoid copying it for performance and
+/// memory usage optimization.
 private final class CollectState<T> {
 	var values: [T] = []
 


### PR DESCRIPTION
Use a class type for the accumulator, avoid copying array.

It might not be acceptable because of premature optimization, but the improvements are not so bad.

Using the following test case and Debug Session's Memory Report in Xcode for Mac tests with 5 times:

```swift
fit("test collect performance") {
	let producer = SignalProducer<Int, NoError> { observer, _ in
		for i in 1...100_000 {
			sendNext(observer, i)
		}
		sendCompleted(observer)
	}

	let startTime = CACurrentMediaTime()

	producer |> collect |> start(completed: { println("Completed") })

	let endTime = CACurrentMediaTime()
	println("elapsed time: \(endTime - startTime)")
}
```

- old impl: 20.02MB memory, 4.511005624 seconds elapsed in average
- new impl: 7.58MB memory, 1.84319988 seconds elapsed in average

How do you think guys?