### PR TITLE
Issue #1868 RACDescription on non-NSObject objects

### DIFF
--- a/ReactiveCocoa/MKAnnotationView+RACSignalSupport.m
+++ b/ReactiveCocoa/MKAnnotationView+RACSignalSupport.m
@@ -22,7 +22,7 @@
 	signal = [[[self
 		rac_signalForSelector:@selector(prepareForReuse)]
 		mapReplace:RACUnit.defaultUnit]
-		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", RACDescription(self)];
 
 	objc_setAssociatedObject(self, _cmd, signal, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 	return signal;

--- a/ReactiveCocoa/NSControl+RACTextSignalSupport.m
+++ b/ReactiveCocoa/NSControl+RACTextSignalSupport.m
@@ -32,7 +32,7 @@
 			return [control.stringValue copy];
 		}]
 		startWith:[self.stringValue copy]]
-		setNameWithFormat:@"%@ -rac_textSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_textSignal", RACDescription(self)];
 }
 
 @end

--- a/ReactiveCocoa/NSFileHandle+RACSupport.m
+++ b/ReactiveCocoa/NSFileHandle+RACSupport.m
@@ -16,7 +16,7 @@
 
 - (RACSignal *)rac_readInBackground {
 	RACReplaySubject *subject = [RACReplaySubject subject];
-	[subject setNameWithFormat:@"%@ -rac_readInBackground", self.rac_description];
+	[subject setNameWithFormat:@"%@ -rac_readInBackground", RACDescription(self)];
 
 	RACSignal *dataNotification = [[[NSNotificationCenter defaultCenter] rac_addObserverForName:NSFileHandleReadCompletionNotification object:self] map:^(NSNotification *note) {
 		return note.userInfo[NSFileHandleNotificationDataItem];

--- a/ReactiveCocoa/NSObject+RACDescription.h
+++ b/ReactiveCocoa/NSObject+RACDescription.h
@@ -19,3 +19,6 @@
 - (NSString *)rac_description;
 
 @end
+
+// Global function to be called on any object not known to inherit from NSObject
+NSString *rac_description(id object);

--- a/ReactiveCocoa/NSObject+RACDescription.h
+++ b/ReactiveCocoa/NSObject+RACDescription.h
@@ -21,4 +21,4 @@
 @end
 
 // Global function to be called on any object not known to inherit from NSObject
-NSString *rac_description(id object);
+NSString *rac_description(id object);NSString *RACDescription(id object);

--- a/ReactiveCocoa/NSObject+RACDescription.h
+++ b/ReactiveCocoa/NSObject+RACDescription.h
@@ -8,17 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
-// A private category providing a terser but faster alternative to -description.
-@interface NSObject (RACDescription)
-
-// A simplified description of the receiver, which does not invoke -description
+// A simplified description of the object, which does not invoke -description
 // (and thus should be much faster in many cases).
 //
 // This is for debugging purposes only, and will return a constant string
 // unless the RAC_DEBUG_SIGNAL_NAMES environment variable is set.
-- (NSString *)rac_description;
-
-@end
-
-// Global function to be called on any object not known to inherit from NSObject
-NSString *rac_description(id object);NSString *RACDescription(id object);
+NSString *RACDescription(id object);

--- a/ReactiveCocoa/NSObject+RACDescription.m
+++ b/ReactiveCocoa/NSObject+RACDescription.m
@@ -49,7 +49,7 @@
 
 @end
 
-NSString *rac_description(id object) {
+NSString *RACDescription(id object) {
 	if ([object respondsToSelector:@selector(rac_description)]) {
 		return [object rac_description];
 	} else {

--- a/ReactiveCocoa/NSObject+RACDescription.m
+++ b/ReactiveCocoa/NSObject+RACDescription.m
@@ -48,3 +48,15 @@
 }
 
 @end
+
+NSString *rac_description(id object) {
+	if ([object respondsToSelector:@selector(rac_description)]) {
+		return [object rac_description];
+	} else {
+		if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL && [object respondsToSelector:@selector(description)]) {
+			return [object description];
+		} else {
+			return @"(description skipped)";
+		}
+	}
+}

--- a/ReactiveCocoa/NSObject+RACDescription.m
+++ b/ReactiveCocoa/NSObject+RACDescription.m
@@ -42,7 +42,7 @@ NSString *RACDescription(id object) {
 		if ([object respondsToSelector:@selector(rac_description)]) {
 			return [object rac_description];
 		} else {
-			return [[NSString alloc] initWithFormat:@"<%@: %p>", object.class, object];
+			return [[NSString alloc] initWithFormat:@"<%@: %p>", [object class], object];
 		}
 	} else {
 		return @"(description skipped)";

--- a/ReactiveCocoa/NSObject+RACDescription.m
+++ b/ReactiveCocoa/NSObject+RACDescription.m
@@ -9,18 +9,6 @@
 #import "NSObject+RACDescription.h"
 #import "RACTuple.h"
 
-@implementation NSObject (RACDescription)
-
-- (NSString *)rac_description {
-	if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
-		return [[NSString alloc] initWithFormat:@"<%@: %p>", self.class, self];
-	} else {
-		return @"(description skipped)";
-	}
-}
-
-@end
-
 @implementation NSValue (RACDescription)
 
 - (NSString *)rac_description {
@@ -50,13 +38,13 @@
 @end
 
 NSString *RACDescription(id object) {
-	if ([object respondsToSelector:@selector(rac_description)]) {
-		return [object rac_description];
-	} else {
-		if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL && [object respondsToSelector:@selector(description)]) {
-			return [object description];
+	if (getenv("RAC_DEBUG_SIGNAL_NAMES") != NULL) {
+		if ([object respondsToSelector:@selector(rac_description)]) {
+			return [object rac_description];
 		} else {
-			return @"(description skipped)";
+			return [[NSString alloc] initWithFormat:@"<%@: %p>", object.class, object];
 		}
+	} else {
+		return @"(description skipped)";
 	}
 }

--- a/ReactiveCocoa/NSObject+RACLifting.m
+++ b/ReactiveCocoa/NSObject+RACLifting.m
@@ -38,7 +38,7 @@
 			return invocation.rac_returnValue;
 		}]
 		replayLast]
-		setNameWithFormat:@"%@ -rac_liftSelector: %s withSignalsOfArguments: %@", self.rac_description, sel_getName(selector), arguments];
+		setNameWithFormat:@"%@ -rac_liftSelector: %s withSignalsOfArguments: %@", RACDescription(self), sel_getName(selector), arguments];
 }
 
 - (RACSignal *)rac_liftSelector:(SEL)selector withSignalsFromArray:(NSArray *)signals {
@@ -53,7 +53,7 @@
 
 	return [[self
 		rac_liftSelector:selector withSignalOfArguments:[RACSignal combineLatest:signals]]
-		setNameWithFormat:@"%@ -rac_liftSelector: %s withSignalsFromArray: %@", self.rac_description, sel_getName(selector), signals];
+		setNameWithFormat:@"%@ -rac_liftSelector: %s withSignalsFromArray: %@", RACDescription(self), sel_getName(selector), signals];
 }
 
 - (RACSignal *)rac_liftSelector:(SEL)selector withSignals:(RACSignal *)firstSignal, ... {
@@ -72,7 +72,7 @@
 
 	return [[self
 		rac_liftSelector:selector withSignalsFromArray:signals]
-		setNameWithFormat:@"%@ -rac_liftSelector: %s withSignals: %@", self.rac_description, sel_getName(selector), signals];
+		setNameWithFormat:@"%@ -rac_liftSelector: %s withSignals: %@", RACDescription(self), sel_getName(selector), signals];
 }
 
 @end

--- a/ReactiveCocoa/NSObject+RACPropertySubscribing.m
+++ b/ReactiveCocoa/NSObject+RACPropertySubscribing.m
@@ -28,7 +28,7 @@
 			// -map: because it doesn't require the block trampoline that -reduceEach: uses
 			return value[0];
 		}]
-		setNameWithFormat:@"RACObserve(%@, %@)", self.rac_description, keyPath];
+		setNameWithFormat:@"RACObserve(%@, %@)", RACDescription(self), keyPath];
 }
 
 - (RACSignal *)rac_valuesAndChangesForKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(__weak NSObject *)weakObserver {
@@ -78,7 +78,7 @@
 			}];
 		}]
 		takeUntil:deallocSignal]
-		setNameWithFormat:@"%@ -rac_valueAndChangesForKeyPath: %@ options: %lu observer: %@", self.rac_description, keyPath, (unsigned long)options, strongObserver.rac_description];
+		setNameWithFormat:@"%@ -rac_valueAndChangesForKeyPath: %@ options: %lu observer: %@", RACDescription(self), keyPath, (unsigned long)options, RACDescription(strongObserver)];
 }
 
 @end
@@ -139,7 +139,7 @@ static RACSignal *signalWithoutChangesFor(Class class, NSObject *object, NSStrin
 			[objectDisposable removeDisposable:deallocDisposable];
 			[KVOTrampoline dispose];
 		}];
-	}] setNameWithFormat:@"RACAble(%@, %@)", object.rac_description, keyPath];
+	}] setNameWithFormat:@"RACAble(%@, %@)", RACDescription(object), keyPath];
 }
 
 - (RACSignal *)rac_signalForKeyPath:(NSString *)keyPath observer:(NSObject *)observer {

--- a/ReactiveCocoa/NSObject+RACSelectorSignal.m
+++ b/ReactiveCocoa/NSObject+RACSelectorSignal.m
@@ -182,7 +182,7 @@ static RACSignal *NSObjectRACSignalForSelector(NSObject *self, SEL selector, Pro
 		Class class = RACSwizzleClass(self);
 		NSCAssert(class != nil, @"Could not swizzle class of %@", self);
 
-		subject = [[RACSubject subject] setNameWithFormat:@"%@ -rac_signalForSelector: %s", self.rac_description, sel_getName(selector)];
+		subject = [[RACSubject subject] setNameWithFormat:@"%@ -rac_signalForSelector: %s", RACDescription(self), sel_getName(selector)];
 		objc_setAssociatedObject(self, aliasSelector, subject, OBJC_ASSOCIATION_RETAIN);
 
 		[self.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{

--- a/ReactiveCocoa/NSText+RACSignalSupport.m
+++ b/ReactiveCocoa/NSText+RACSignalSupport.m
@@ -32,7 +32,7 @@
 			return [text.string copy];
 		}]
 		startWith:[self.string copy]]
-		setNameWithFormat:@"%@ -rac_textSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_textSignal", RACDescription(self)];
 }
 
 @end

--- a/ReactiveCocoa/RACCommand.m
+++ b/ReactiveCocoa/RACCommand.m
@@ -253,7 +253,7 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	}];
 
 	[connection connect];
-	return [connection.signal setNameWithFormat:@"%@ -execute: %@", self, rac_description(input)];
+	return [connection.signal setNameWithFormat:@"%@ -execute: %@", self, RACDescription(input)];
 }
 
 #pragma mark NSKeyValueObserving

--- a/ReactiveCocoa/RACCommand.m
+++ b/ReactiveCocoa/RACCommand.m
@@ -253,7 +253,7 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	}];
 
 	[connection connect];
-	return [connection.signal setNameWithFormat:@"%@ -execute: %@", self, [input rac_description]];
+	return [connection.signal setNameWithFormat:@"%@ -execute: %@", self, rac_description(input)];
 }
 
 #pragma mark NSKeyValueObserving

--- a/ReactiveCocoa/RACEagerSequence.m
+++ b/ReactiveCocoa/RACEagerSequence.m
@@ -15,7 +15,7 @@
 #pragma mark RACStream
 
 + (instancetype)return:(id)value {
-	return [[self sequenceWithArray:@[ value ] offset:0] setNameWithFormat:@"+return: %@", rac_description(value)];
+	return [[self sequenceWithArray:@[ value ] offset:0] setNameWithFormat:@"+return: %@", RACDescription(value)];
 }
 
 - (instancetype)bind:(RACStreamBindBlock (^)(void))block {

--- a/ReactiveCocoa/RACEagerSequence.m
+++ b/ReactiveCocoa/RACEagerSequence.m
@@ -15,7 +15,7 @@
 #pragma mark RACStream
 
 + (instancetype)return:(id)value {
-	return [[self sequenceWithArray:@[ value ] offset:0] setNameWithFormat:@"+return: %@", [value rac_description]];
+	return [[self sequenceWithArray:@[ value ] offset:0] setNameWithFormat:@"+return: %@", rac_description(value)];
 }
 
 - (instancetype)bind:(RACStreamBindBlock (^)(void))block {

--- a/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoa/RACSignal+Operations.m
@@ -611,7 +611,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		reduceWithIndex:^(id running, id next, NSUInteger index) {
 			return reduceBlock(running, next);
 		}]
-		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduce:", self.name, rac_description(start)];
+		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduce:", self.name, RACDescription(start)];
 }
 
 - (RACSignal *)aggregateWithStart:(id)start reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
@@ -619,7 +619,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		scanWithStart:start reduceWithIndex:reduceBlock]
 		startWith:start]
 		takeLast:1]
-		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduceWithIndex:", self.name, rac_description(start)];
+		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduceWithIndex:", self.name, RACDescription(start)];
 }
 
 - (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object {

--- a/ReactiveCocoa/RACSignal+Operations.m
+++ b/ReactiveCocoa/RACSignal+Operations.m
@@ -611,7 +611,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		reduceWithIndex:^(id running, id next, NSUInteger index) {
 			return reduceBlock(running, next);
 		}]
-		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduce:", self.name, [start rac_description]];
+		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduce:", self.name, rac_description(start)];
 }
 
 - (RACSignal *)aggregateWithStart:(id)start reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
@@ -619,7 +619,7 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		scanWithStart:start reduceWithIndex:reduceBlock]
 		startWith:start]
 		takeLast:1]
-		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduceWithIndex:", self.name, [start rac_description]];
+		setNameWithFormat:@"[%@] -aggregateWithStart: %@ reduceWithIndex:", self.name, rac_description(start)];
 }
 
 - (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object {

--- a/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoa/RACStream.m
@@ -99,7 +99,7 @@
 - (instancetype)mapReplace:(id)object {
 	return [[self map:^(id _) {
 		return object;
-	}] setNameWithFormat:@"[%@] -mapReplace: %@", self.name, [object rac_description]];
+	}] setNameWithFormat:@"[%@] -mapReplace: %@", self.name, rac_description(object)];
 }
 
 - (instancetype)combinePreviousWithStart:(id)start reduce:(id (^)(id previous, id next))reduceBlock {
@@ -113,7 +113,7 @@
 		map:^(RACTuple *tuple) {
 			return tuple[1];
 		}]
-		setNameWithFormat:@"[%@] -combinePreviousWithStart: %@ reduce:", self.name, [start rac_description]];
+		setNameWithFormat:@"[%@] -combinePreviousWithStart: %@ reduce:", self.name, rac_description(start)];
 }
 
 - (instancetype)filter:(BOOL (^)(id value))block {
@@ -133,7 +133,7 @@
 - (instancetype)ignore:(id)value {
 	return [[self filter:^ BOOL (id innerValue) {
 		return innerValue != value && ![innerValue isEqual:value];
-	}] setNameWithFormat:@"[%@] -ignore: %@", self.name, [value rac_description]];
+	}] setNameWithFormat:@"[%@] -ignore: %@", self.name, rac_description(value)];
 }
 
 - (instancetype)reduceEach:(id (^)())reduceBlock {
@@ -149,7 +149,7 @@
 - (instancetype)startWith:(id)value {
 	return [[[self.class return:value]
 		concat:self]
-		setNameWithFormat:@"[%@] -startWith: %@", self.name, [value rac_description]];
+		setNameWithFormat:@"[%@] -startWith: %@", self.name, rac_description(value)];
 }
 
 - (instancetype)skip:(NSUInteger)skipCount {
@@ -261,7 +261,7 @@
 		reduceWithIndex:^(id running, id next, NSUInteger index) {
 			return reduceBlock(running, next);
 		}]
-		setNameWithFormat:@"[%@] -scanWithStart: %@ reduce:", self.name, [startingValue rac_description]];
+		setNameWithFormat:@"[%@] -scanWithStart: %@ reduce:", self.name, rac_description(startingValue)];
 }
 
 - (instancetype)scanWithStart:(id)startingValue reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
@@ -277,7 +277,7 @@
 			running = reduceBlock(running, value, index++);
 			return [class return:running];
 		};
-	}] setNameWithFormat:@"[%@] -scanWithStart: %@ reduceWithIndex:", self.name, [startingValue rac_description]];
+	}] setNameWithFormat:@"[%@] -scanWithStart: %@ reduceWithIndex:", self.name, rac_description(startingValue)];
 }
 
 - (instancetype)takeUntilBlock:(BOOL (^)(id x))predicate {

--- a/ReactiveCocoa/RACStream.m
+++ b/ReactiveCocoa/RACStream.m
@@ -99,7 +99,7 @@
 - (instancetype)mapReplace:(id)object {
 	return [[self map:^(id _) {
 		return object;
-	}] setNameWithFormat:@"[%@] -mapReplace: %@", self.name, rac_description(object)];
+	}] setNameWithFormat:@"[%@] -mapReplace: %@", self.name, RACDescription(object)];
 }
 
 - (instancetype)combinePreviousWithStart:(id)start reduce:(id (^)(id previous, id next))reduceBlock {
@@ -113,7 +113,7 @@
 		map:^(RACTuple *tuple) {
 			return tuple[1];
 		}]
-		setNameWithFormat:@"[%@] -combinePreviousWithStart: %@ reduce:", self.name, rac_description(start)];
+		setNameWithFormat:@"[%@] -combinePreviousWithStart: %@ reduce:", self.name, RACDescription(start)];
 }
 
 - (instancetype)filter:(BOOL (^)(id value))block {
@@ -133,7 +133,7 @@
 - (instancetype)ignore:(id)value {
 	return [[self filter:^ BOOL (id innerValue) {
 		return innerValue != value && ![innerValue isEqual:value];
-	}] setNameWithFormat:@"[%@] -ignore: %@", self.name, rac_description(value)];
+	}] setNameWithFormat:@"[%@] -ignore: %@", self.name, RACDescription(value)];
 }
 
 - (instancetype)reduceEach:(id (^)())reduceBlock {
@@ -149,7 +149,7 @@
 - (instancetype)startWith:(id)value {
 	return [[[self.class return:value]
 		concat:self]
-		setNameWithFormat:@"[%@] -startWith: %@", self.name, rac_description(value)];
+		setNameWithFormat:@"[%@] -startWith: %@", self.name, RACDescription(value)];
 }
 
 - (instancetype)skip:(NSUInteger)skipCount {
@@ -261,7 +261,7 @@
 		reduceWithIndex:^(id running, id next, NSUInteger index) {
 			return reduceBlock(running, next);
 		}]
-		setNameWithFormat:@"[%@] -scanWithStart: %@ reduce:", self.name, rac_description(startingValue)];
+		setNameWithFormat:@"[%@] -scanWithStart: %@ reduce:", self.name, RACDescription(startingValue)];
 }
 
 - (instancetype)scanWithStart:(id)startingValue reduceWithIndex:(id (^)(id, id, NSUInteger))reduceBlock {
@@ -277,7 +277,7 @@
 			running = reduceBlock(running, value, index++);
 			return [class return:running];
 		};
-	}] setNameWithFormat:@"[%@] -scanWithStart: %@ reduceWithIndex:", self.name, rac_description(startingValue)];
+	}] setNameWithFormat:@"[%@] -scanWithStart: %@ reduceWithIndex:", self.name, RACDescription(startingValue)];
 }
 
 - (instancetype)takeUntilBlock:(BOOL (^)(id x))predicate {

--- a/ReactiveCocoa/RACUnarySequence.m
+++ b/ReactiveCocoa/RACUnarySequence.m
@@ -28,7 +28,7 @@
 + (instancetype)return:(id)value {
 	RACUnarySequence *sequence = [[self alloc] init];
 	sequence.head = value;
-	return [sequence setNameWithFormat:@"+return: %@", rac_description(value)];
+	return [sequence setNameWithFormat:@"+return: %@", RACDescription(value)];
 }
 
 #pragma mark RACSequence

--- a/ReactiveCocoa/RACUnarySequence.m
+++ b/ReactiveCocoa/RACUnarySequence.m
@@ -28,7 +28,7 @@
 + (instancetype)return:(id)value {
 	RACUnarySequence *sequence = [[self alloc] init];
 	sequence.head = value;
-	return [sequence setNameWithFormat:@"+return: %@", [value rac_description]];
+	return [sequence setNameWithFormat:@"+return: %@", rac_description(value)];
 }
 
 #pragma mark RACSequence

--- a/ReactiveCocoa/UIActionSheet+RACSignalSupport.m
+++ b/ReactiveCocoa/UIActionSheet+RACSignalSupport.m
@@ -39,7 +39,7 @@ static void RACUseDelegateProxy(UIActionSheet *self) {
 			return buttonIndex;
 		}]
 		takeUntil:self.rac_willDeallocSignal]
-		setNameWithFormat:@"%@ -rac_buttonClickedSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_buttonClickedSignal", RACDescription(self)];
 
 	RACUseDelegateProxy(self);
 

--- a/ReactiveCocoa/UIAlertView+RACSignalSupport.m
+++ b/ReactiveCocoa/UIAlertView+RACSignalSupport.m
@@ -39,7 +39,7 @@ static void RACUseDelegateProxy(UIAlertView *self) {
 			return buttonIndex;
 		}]
 		takeUntil:self.rac_willDeallocSignal]
-		setNameWithFormat:@"%@ -rac_buttonClickedSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_buttonClickedSignal", RACDescription(self)];
 
 	RACUseDelegateProxy(self);
 
@@ -53,7 +53,7 @@ static void RACUseDelegateProxy(UIAlertView *self) {
 			return buttonIndex;
 		}]
 		takeUntil:self.rac_willDeallocSignal]
-		setNameWithFormat:@"%@ -rac_willDismissSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_willDismissSignal", RACDescription(self)];
 
 	RACUseDelegateProxy(self);
 

--- a/ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m
+++ b/ReactiveCocoa/UICollectionReusableView+RACSignalSupport.m
@@ -22,7 +22,7 @@
 	signal = [[[self
 		rac_signalForSelector:@selector(prepareForReuse)]
 		mapReplace:RACUnit.defaultUnit]
-		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", RACDescription(self)];
 	
 	objc_setAssociatedObject(self, _cmd, signal, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 	return signal;

--- a/ReactiveCocoa/UIControl+RACSignalSupport.m
+++ b/ReactiveCocoa/UIControl+RACSignalSupport.m
@@ -34,7 +34,7 @@
 				[self removeTarget:subscriber action:@selector(sendNext:) forControlEvents:controlEvents];
 			}];
 		}]
-		setNameWithFormat:@"%@ -rac_signalForControlEvents: %lx", self.rac_description, (unsigned long)controlEvents];
+		setNameWithFormat:@"%@ -rac_signalForControlEvents: %lx", RACDescription(self), (unsigned long)controlEvents];
 }
 
 @end

--- a/ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m
+++ b/ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.m
@@ -34,7 +34,7 @@
 				[self removeTarget:subscriber action:@selector(sendNext:)];
 			}];
 		}]
-		setNameWithFormat:@"%@ -rac_gestureSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_gestureSignal", RACDescription(self)];
 }
 
 @end

--- a/ReactiveCocoa/UIImagePickerController+RACSignalSupport.m
+++ b/ReactiveCocoa/UIImagePickerController+RACSignalSupport.m
@@ -43,7 +43,7 @@ static void RACUseDelegateProxy(UIImagePickerController *self) {
 			return userInfo;
 		}]
 		takeUntil:pickerCancelledSignal]
-		setNameWithFormat:@"%@ -rac_imageSelectedSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_imageSelectedSignal", RACDescription(self)];
     
 	RACUseDelegateProxy(self);
     

--- a/ReactiveCocoa/UITableViewCell+RACSignalSupport.m
+++ b/ReactiveCocoa/UITableViewCell+RACSignalSupport.m
@@ -22,7 +22,7 @@
 	signal = [[[self
 		rac_signalForSelector:@selector(prepareForReuse)]
 		mapReplace:RACUnit.defaultUnit]
-		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", RACDescription(self)];
 	
 	objc_setAssociatedObject(self, _cmd, signal, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 	return signal;

--- a/ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.m
+++ b/ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.m
@@ -22,7 +22,7 @@
 	signal = [[[self
 		rac_signalForSelector:@selector(prepareForReuse)]
 		mapReplace:RACUnit.defaultUnit]
-		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_prepareForReuseSignal", RACDescription(self)];
 
 	objc_setAssociatedObject(self, _cmd, signal, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 	return signal;

--- a/ReactiveCocoa/UITextField+RACSignalSupport.m
+++ b/ReactiveCocoa/UITextField+RACSignalSupport.m
@@ -29,7 +29,7 @@
 			return x.text;
 		}]
 		takeUntil:self.rac_willDeallocSignal]
-		setNameWithFormat:@"%@ -rac_textSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_textSignal", RACDescription(self)];
 }
 
 - (RACChannelTerminal *)rac_newTextChannel {

--- a/ReactiveCocoa/UITextView+RACSignalSupport.m
+++ b/ReactiveCocoa/UITextView+RACSignalSupport.m
@@ -46,7 +46,7 @@ static void RACUseDelegateProxy(UITextView *self) {
 			return x.text;
 		}]
 		takeUntil:self.rac_willDeallocSignal]
-		setNameWithFormat:@"%@ -rac_textSignal", self.rac_description];
+		setNameWithFormat:@"%@ -rac_textSignal", RACDescription(self)];
 
 	RACUseDelegateProxy(self);
 


### PR DESCRIPTION
This addresses issue #1868 by adding a global command to be used anywhere where we try to use ``rac_description`` on objects which are not known to inherit from ``NSObject``.
This is my first PR for this project, so be gentle!