### PR TITLE
Proper check if ARC is enabled for the GCD

### DIFF
--- a/ReactiveCocoa/RACQueueScheduler+Subclass.h
+++ b/ReactiveCocoa/RACQueueScheduler+Subclass.h
@@ -15,7 +15,7 @@
 @interface RACQueueScheduler ()
 
 /// The queue on which blocks are enqueued.
-#if OS_OBJECT_HAVE_OBJC_SUPPORT
+#if OS_OBJECT_USE_OBJC
 @property (nonatomic, strong, readonly) dispatch_queue_t queue;
 #else
 // Swift builds with OS_OBJECT_HAVE_OBJC_SUPPORT=0 for Playgrounds and LLDB :(

--- a/ReactiveCocoa/RACQueueScheduler.m
+++ b/ReactiveCocoa/RACQueueScheduler.m
@@ -22,14 +22,14 @@
 	if (self == nil) return nil;
 
 	_queue = queue;
-#if !OS_OBJECT_HAVE_OBJC_SUPPORT
+#if !OS_OBJECT_USE_OBJC
 	dispatch_retain(_queue);
 #endif
 
 	return self;
 }
 
-#if !OS_OBJECT_HAVE_OBJC_SUPPORT
+#if !OS_OBJECT_USE_OBJC
 
 - (void)dealloc {
 	if (_queue != NULL) {


### PR DESCRIPTION
You should check if feature is enabled instead of just availability.
Actually fixes #1679. 

Please check for Swift playground/LLDB. 