### PR TITLE
@noescape for Signal/SignalProducer, fix memory corruption in times()

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -129,7 +129,7 @@ infix operator |> {
 /// 	|> filter { num in num % 2 == 0 }
 /// 	|> map(toString)
 /// 	|> observe(next: { string in println(string) })
-public func |> <T, E, X>(signal: Signal<T, E>, transform: Signal<T, E> -> X) -> X {
+public func |> <T, E, X>(signal: Signal<T, E>, @noescape transform: Signal<T, E> -> X) -> X {
 	return transform(signal)
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -179,7 +179,7 @@ public struct SignalProducer<T, E: ErrorType> {
 	/// The closure will also receive a disposable which can be used to
 	/// interrupt the work associated with the signal and immediately send an
 	/// `Interrupted` event.
-	public func startWithSignal(setUp: (Signal<T, E>, Disposable) -> ()) {
+	public func startWithSignal(@noescape setUp: (Signal<T, E>, Disposable) -> ()) {
 		let (signal, observer) = Signal<T, E>.pipe()
 
 		// Create a composite disposable that will automatically be torn
@@ -294,7 +294,7 @@ public func |> <T, E, U, F>(producer: SignalProducer<T, E>, transform: Signal<T,
 /// 	|> start { signal in
 /// 		signal.observe(next: { num in println(num) })
 /// 	}
-public func |> <T, E, X>(producer: SignalProducer<T, E>, transform: SignalProducer<T, E> -> X) -> X {
+public func |> <T, E, X>(producer: SignalProducer<T, E>, @noescape transform: SignalProducer<T, E> -> X) -> X {
 	return transform(producer)
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -937,18 +937,17 @@ public func times<T, E>(count: Int)(producer: SignalProducer<T, E>) -> SignalPro
 		let serialDisposable = SerialDisposable()
 		disposable.addDisposable(serialDisposable)
 
-		var remainingTimes = count
-
-		let iterate = fix { recur in
-			{
+		let iterate: Int -> () = fix { recur in
+			{ current in
 				producer.startWithSignal { signal, signalDisposable in
 					serialDisposable.innerDisposable = signalDisposable
 
 					signal.observe(Signal.Observer { event in
 						switch event {
 						case .Completed:
-							if --remainingTimes > 0 {
-								recur()
+							let remainingTimes = current - 1
+							if remainingTimes > 0 {
+								recur(remainingTimes)
 							} else {
 								sendCompleted(observer)
 							}
@@ -961,7 +960,7 @@ public func times<T, E>(count: Int)(producer: SignalProducer<T, E>) -> SignalPro
 			}
 		}
 
-		iterate()
+		iterate(count)
 	}
 }
 


### PR DESCRIPTION
Running tests at 99b9995 leads to the result like following captures:

![2015-05-01 23 36 52](https://cloud.githubusercontent.com/assets/909674/7432606/91930e32-f064-11e4-942b-f5b1b0102f04.png)

![2015-05-01 23 37 31](https://cloud.githubusercontent.com/assets/909674/7432621/abb945d8-f064-11e4-8ba7-bbeebc4c781b.png)

![2015-05-02 0 44 53](https://cloud.githubusercontent.com/assets/909674/7432625/b739b6e0-f064-11e4-91c0-1a1a8bafc36e.png)
