### PR TITLE
Add zip and combineLatest array operators

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -292,7 +292,7 @@ public func combineLatestWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal
 	}
 }
 
-private func combineLatestWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
+internal func combineLatestWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
 	return signal |> combineLatestWith(otherSignal) |> map { $0.0 + [$0.1] }
 }
 
@@ -720,7 +720,7 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 	}
 }
 
-private func zipWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
+internal func zipWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
 	return signal |> zipWith(otherSignal) |> map { $0.0 + [$0.1] }
 }
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -292,7 +292,7 @@ public func combineLatestWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal
 	}
 }
 
-public func combineLatestWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
+private func combineLatestWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
 	return signal |> combineLatestWith(otherSignal) |> map { $0.0 + [$0.1] }
 }
 
@@ -720,7 +720,7 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 	}
 }
 
-public func zipWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
+private func zipWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
 	return signal |> zipWith(otherSignal) |> map { $0.0 + [$0.1] }
 }
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -898,6 +898,17 @@ public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Erro
 		|> map(repack)
 }
 
+/// Combines the values of all the given signals, in the manner described by
+/// `combineLatestWith`.
+public func combineLatest<T, Error>(signals: [Signal<T, Error>]) -> Signal<[T], Error> {
+	if let first = signals.first {
+		let initial = first |> map { [$0] }
+		return signals[1 ..< signals.count].reduce(initial) { $0 |> combineLatestWith($1) }
+	}
+	
+	return Signal.never
+}
+
 /// Zips the values of all the given signals, in the manner described by
 /// `zipWith`.
 public func zip<A, B, Error>(a: Signal<A, Error>, b: Signal<B, Error>) -> Signal<(A, B), Error> {
@@ -966,6 +977,17 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Error>, b: Sig
 	return zip(a, b, c, d, e, f, g, h, i)
 		|> zipWith(j)
 		|> map(repack)
+}
+
+/// Zips the values of all the given signals, in the manner described by
+/// `zipWith`.
+public func zip<T, Error>(signals: [Signal<T, Error>]) -> Signal<[T], Error> {
+	if let first = signals.first {
+		let initial = first |> map { [$0] }
+		return signals[1 ..< signals.count].reduce(initial) { $0 |> zipWith($1) }
+	}
+	
+	return Signal.never
 }
 
 /// Forwards events from `signal` until `interval`. Then if signal isn't completed yet,

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -974,7 +974,7 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Error>, b: Sig
 
 /// Zips the values of all the given signals, in the manner described by
 /// `zipWith`.
-public func zip<T, Error>(signals: [Signal<T, Error>]) -> Signal<[T], Error> {
+public func zip<S: SequenceType, T, Error where S.Generator.Element == Signal<T, Error>>(signals: S) -> Signal<[T], Error> {
 	var generator = signals.generate()
 	if let first = generator.next() {
 		let initial = first |> map { [$0] }

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -891,7 +891,7 @@ public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Erro
 }
 
 /// Combines the values of all the given signals, in the manner described by
-/// `combineLatestWith`.
+/// `combineLatestWith`. No events will be sent if the sequence is empty.
 public func combineLatest<S: SequenceType, T, Error where S.Generator.Element == Signal<T, Error>>(signals: S) -> Signal<[T], Error> {
 	var generator = signals.generate()
 	if let first = generator.next() {
@@ -973,7 +973,7 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Error>, b: Sig
 }
 
 /// Zips the values of all the given signals, in the manner described by
-/// `zipWith`.
+/// `zipWith`. No events will be sent if the sequence is empty.
 public func zip<S: SequenceType, T, Error where S.Generator.Element == Signal<T, Error>>(signals: S) -> Signal<[T], Error> {
 	var generator = signals.generate()
 	if let first = generator.next() {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -721,8 +721,8 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 	return signal |> zipMapWith(otherSignal) { ($0, $1) }
 }
 
-public func zipWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<T, E>) -> Signal<[T], E> {
-	return signal |> zipMapWith(otherSignal) { [$1, $0] }
+public func zipWith<T, E>(otherSignal: Signal<T, E>)(signal: Signal<[T], E>) -> Signal<[T], E> {
+	return signal |> zipMapWith(otherSignal) { $0 + [$1] }
 }
 
 /// Applies `operation` to values from `signal` with `Success`ful results

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -900,10 +900,11 @@ public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Erro
 
 /// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-public func combineLatest<T, Error>(signals: [Signal<T, Error>]) -> Signal<[T], Error> {
-	if let first = signals.first {
+public func combineLatest<S: SequenceType, T, Error where S.Generator.Element == Signal<T, Error>>(signals: S) -> Signal<[T], Error> {
+	var generator = signals.generate()
+	if let first = generator.next() {
 		let initial = first |> map { [$0] }
-		return signals[1 ..< signals.count].reduce(initial) { $0 |> combineLatestWith($1) }
+		return reduce(GeneratorSequence(generator), initial) { $0 |> combineLatestWith($1) }
 	}
 	
 	return Signal.never
@@ -982,9 +983,10 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Error>, b: Sig
 /// Zips the values of all the given signals, in the manner described by
 /// `zipWith`.
 public func zip<T, Error>(signals: [Signal<T, Error>]) -> Signal<[T], Error> {
-	if let first = signals.first {
+	var generator = signals.generate()
+	if let first = generator.next() {
 		let initial = first |> map { [$0] }
-		return signals[1 ..< signals.count].reduce(initial) { $0 |> zipWith($1) }
+		return reduce(GeneratorSequence(generator), initial) { $0 |> zipWith($1) }
 	}
 	
 	return Signal.never

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -273,7 +273,7 @@ public func combineLatestWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal
 	return Signal { observer in
 		let lock = NSRecursiveLock()
 		lock.name = "org.reactivecocoa.ReactiveCocoa.combineLatestWith"
-		
+
 		let signalState = CombineLatestState<T>()
 		let otherState = CombineLatestState<U>()
 		
@@ -692,12 +692,12 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 			
 			flush()
 		}, error: onError, completed: {
-				states.modify { (var states) in
-					states.0.completed = true
-					return states
-				}
+			states.modify { (var states) in
+				states.0.completed = true
+				return states
+			}
 				
-				flush()
+			flush()
 		}, interrupted: onInterrupted)
 		
 		let otherDisposable = otherSignal.observe(next: { value in
@@ -708,12 +708,12 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 			
 			flush()
 		}, error: onError, completed: {
-				states.modify { (var states) in
-					states.1.completed = true
-					return states
-				}
+			states.modify { (var states) in
+				states.1.completed = true
+				return states
+			}
 				
-				flush()
+			flush()
 		}, interrupted: onInterrupted)
 		
 		return CompositeDisposable(ignoreNil([ signalDisposable, otherDisposable ]))

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -691,14 +691,14 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 			}
 			
 			flush()
-			}, error: onError, completed: {
+		}, error: onError, completed: {
 				states.modify { (var states) in
 					states.0.completed = true
 					return states
 				}
 				
 				flush()
-			}, interrupted: onInterrupted)
+		}, interrupted: onInterrupted)
 		
 		let otherDisposable = otherSignal.observe(next: { value in
 			states.modify { (var states) in
@@ -707,14 +707,14 @@ public func zipWith<T, U, E>(otherSignal: Signal<U, E>)(signal: Signal<T, E>) ->
 			}
 			
 			flush()
-			}, error: onError, completed: {
+		}, error: onError, completed: {
 				states.modify { (var states) in
 					states.1.completed = true
 					return states
 				}
 				
 				flush()
-			}, interrupted: onInterrupted)
+		}, interrupted: onInterrupted)
 		
 		return CompositeDisposable(ignoreNil([ signalDisposable, otherDisposable ]))
 	}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -398,6 +398,10 @@ public func combineLatestWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>
 	return producer.lift(combineLatestWith)(otherSignalProducer)
 }
 
+public func combineLatestWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
+	return producer.lift(combineLatestWith)(otherSignalProducer)
+}
+
 /// Zips elements of two signal producers into pairs. The elements of any Nth
 /// pair are the Nth elements of the two input producers.
 public func zipWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>)(producer: SignalProducer<T, E>) -> SignalProducer<(T, U), E> {
@@ -476,6 +480,19 @@ public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer
 	return combineLatest(a, b, c, d, e, f, g, h, i)
 		|> combineLatestWith(j)
 		|> map(repack)
+}
+
+/// Combines the values of all the given producers, in the manner described by
+/// `combineLatestWith`.
+public func combineLatest<T, Error>(signalProducers: [SignalProducer<T, Error>]) -> SignalProducer<[T], Error> {
+	if let first = signalProducers.first {
+		let initial = first.lift { signal in
+			return signal |> map { [$0] }
+		}
+		return signalProducers[1 ..< signalProducers.count].reduce(initial) { $0 |> combineLatestWith($1) }
+	}
+	
+	return SignalProducer.empty
 }
 
 /// Zips the values of all the given producers, in the manner described by

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -398,7 +398,7 @@ public func combineLatestWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>
 	return producer.lift(combineLatestWith)(otherSignalProducer)
 }
 
-public func combineLatestWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
+private func combineLatestWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
 	return producer.lift(combineLatestWith)(otherSignalProducer)
 }
 
@@ -408,7 +408,7 @@ public func zipWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>)(producer
 	return producer.lift(zipWith)(otherSignalProducer)
 }
 
-public func zipWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
+private func zipWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
 	return producer.lift(zipWith)(otherSignalProducer)
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -404,7 +404,7 @@ public func zipWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>)(producer
 	return producer.lift(zipWith)(otherSignalProducer)
 }
 
-public func zipWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<T, E>) -> SignalProducer<[T], E> {
+public func zipWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
 	return producer.lift(zipWith)(otherSignalProducer)
 }
 
@@ -546,6 +546,14 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer<A, Error>
 	return zip(a, b, c, d, e, f, g, h, i)
 		|> zipWith(j)
 		|> map(repack)
+}
+
+/// Zips the values of all the given producers, in the manner described by
+/// `zipWith`.
+public func zip<T, Error>(signalProducers: [SignalProducer<T, Error>]) -> SignalProducer<[T], Error> {
+	return signalProducers.reduce(SignalProducer<[T], Error>.never) { memo, signalProducer in
+		return memo |> zipWith(signalProducer)
+	}
 }
 
 /// Forwards the latest value from `producer` whenever `sampler` sends a Next

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -404,6 +404,10 @@ public func zipWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>)(producer
 	return producer.lift(zipWith)(otherSignalProducer)
 }
 
+public func zipWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<T, E>) -> SignalProducer<[T], E> {
+	return producer.lift(zipWith)(otherSignalProducer)
+}
+
 /// Combines the values of all the given producers, in the manner described by
 /// `combineLatestWith`.
 public func combineLatest<A, B, Error>(a: SignalProducer<A, Error>, b: SignalProducer<B, Error>) -> SignalProducer<(A, B), Error> {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -398,7 +398,7 @@ public func combineLatestWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>
 	return producer.lift(combineLatestWith)(otherSignalProducer)
 }
 
-private func combineLatestWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
+internal func combineLatestWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
 	return producer.lift(combineLatestWith)(otherSignalProducer)
 }
 
@@ -408,7 +408,7 @@ public func zipWith<T, U, E>(otherSignalProducer: SignalProducer<U, E>)(producer
 	return producer.lift(zipWith)(otherSignalProducer)
 }
 
-private func zipWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
+internal func zipWith<T, E>(otherSignalProducer: SignalProducer<T, E>)(producer: SignalProducer<[T], E>) -> SignalProducer<[T], E> {
 	return producer.lift(zipWith)(otherSignalProducer)
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -483,13 +483,12 @@ public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer
 }
 
 /// Combines the values of all the given producers, in the manner described by
-/// `combineLatestWith`.
-public func combineLatest<T, Error>(signalProducers: [SignalProducer<T, Error>]) -> SignalProducer<[T], Error> {
-	if let first = signalProducers.first {
-		let initial = first.lift { signal in
-			return signal |> map { [$0] }
-		}
-		return signalProducers[1 ..< signalProducers.count].reduce(initial) { $0 |> combineLatestWith($1) }
+/// `combineLatestWith`. Will return an empty `SignalProducer` if the sequence is empty.
+public func combineLatest<S: SequenceType, T, Error where S.Generator.Element == SignalProducer<T, Error>>(signalProducers: S) -> SignalProducer<[T], Error> {
+	var generator = signalProducers.generate()
+	if let first = generator.next() {
+		let initial = first |> map { [$0] }
+		return reduce(GeneratorSequence(generator), initial) { $0 |> combineLatestWith($1) }
 	}
 	
 	return SignalProducer.empty
@@ -566,13 +565,12 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer<A, Error>
 }
 
 /// Zips the values of all the given producers, in the manner described by
-/// `zipWith`.
-public func zip<T, Error>(signalProducers: [SignalProducer<T, Error>]) -> SignalProducer<[T], Error> {
-	if let first = signalProducers.first {
-		let initial = first.lift { signal in
-			return signal |> map { [$0] }
-		}
-		return signalProducers[1 ..< signalProducers.count].reduce(initial) { $0 |> zipWith($1) }
+/// `zipWith`. Will return an empty `SignalProducer` if the sequence is empty.
+public func zip<S: SequenceType, T, Error where S.Generator.Element == SignalProducer<T, Error>>(signalProducers: S) -> SignalProducer<[T], Error> {
+	var generator = signalProducers.generate()
+	if let first = generator.next() {
+		let initial = first |> map { [$0] }
+		return reduce(GeneratorSequence(generator), initial) { $0 |> zipWith($1) }
 	}
 	
 	return SignalProducer.empty

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -551,7 +551,14 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer<A, Error>
 /// Zips the values of all the given producers, in the manner described by
 /// `zipWith`.
 public func zip<T, Error>(signalProducers: [SignalProducer<T, Error>]) -> SignalProducer<[T], Error> {
-	return signalProducers.reduce(SignalProducer<[T], Error>.empty) { $0 |> zipWith($1) }
+	if let first = signalProducers.first {
+		let initial = first.lift { signal in
+			return signal |> map { [$0] }
+		}
+		return signalProducers[1 ..< signalProducers.count].reduce(initial) { $0 |> zipWith($1) }
+	}
+	
+	return SignalProducer.empty
 }
 
 /// Forwards the latest value from `producer` whenever `sampler` sends a Next

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -551,9 +551,7 @@ public func zip<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer<A, Error>
 /// Zips the values of all the given producers, in the manner described by
 /// `zipWith`.
 public func zip<T, Error>(signalProducers: [SignalProducer<T, Error>]) -> SignalProducer<[T], Error> {
-	return signalProducers.reduce(SignalProducer<[T], Error>.never) { memo, signalProducer in
-		return memo |> zipWith(signalProducer)
-	}
+	return signalProducers.reduce(SignalProducer<[T], Error>.empty) { $0 |> zipWith($1) }
 }
 
 /// Forwards the latest value from `producer` whenever `sampler` sends a Next

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -562,6 +562,30 @@ class SignalProducerSpec: QuickSpec {
 				}
 			}
 		}
+		
+		describe("sequence operators") {
+			var producerA: SignalProducer<Int, NoError>!
+			var producerB: SignalProducer<Int, NoError>!
+			
+			beforeEach {
+				producerA = SignalProducer<Int, NoError>(values: [ 1, 2 ])
+				producerB = SignalProducer<Int, NoError>(values: [ 3, 4 ])
+			}
+			
+			it("should combine the events to one array") {
+				let producer = combineLatest([producerA, producerB])
+				let result = producer |> collect |> single
+				
+				expect(result?.value).to(equal([[1, 4], [2, 4]]))
+			}
+			
+			it("should zip the events to one array") {
+				let producer = zip([producerA, producerB])
+				let result = producer |> collect |> single
+				
+				expect(result?.value).to(equal([[1, 3], [2, 4]]))
+			}
+		}
 
 		describe("timer") {
 			it("should send the current date at the given interval") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1582,7 +1582,7 @@ class SignalSpec: QuickSpec {
 				sinkC = baseSinkC
 			}
 			
-			sharedExamples("combineLatest example") {
+			sharedExamples("combineLatest examples") {
 				it("should forward the latest values from all inputs"){
 					expect(combinedValues).to(beNil())
 					
@@ -1630,7 +1630,7 @@ class SignalSpec: QuickSpec {
 						})
 				}
 				
-				itBehavesLike("combineLatest example")
+				itBehavesLike("combineLatest examples")
 			}
 			
 			describe("sequence") {
@@ -1643,7 +1643,7 @@ class SignalSpec: QuickSpec {
 						})
 				}
 				
-				itBehavesLike("combineLatest example")
+				itBehavesLike("combineLatest examples")
 			}
 		}
 		

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1624,11 +1624,11 @@ class SignalSpec: QuickSpec {
 			describe("tuple") {
 				beforeEach {
 					combineLatest(signalA, signalB, signalC)
-						|> observe(next: {
-							combinedValues = [$0, $1, $2]
-							}, completed: {
-								completed = true
-						})
+					|> observe(next: {
+						combinedValues = [$0, $1, $2]
+					}, completed: {
+						completed = true
+					})
 				}
 				
 				itBehavesLike(combineLatestExampleName)
@@ -1637,11 +1637,11 @@ class SignalSpec: QuickSpec {
 			describe("sequence") {
 				beforeEach {
 					combineLatest([signalA, signalB, signalC])
-						|> observe(next: {
-							combinedValues = $0
-							}, completed: {
-								completed = true
-						})
+					|> observe(next: {
+						combinedValues = $0
+					}, completed: {
+						completed = true
+					})
 				}
 				
 				itBehavesLike(combineLatestExampleName)

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1582,7 +1582,8 @@ class SignalSpec: QuickSpec {
 				sinkC = baseSinkC
 			}
 			
-			sharedExamples("combineLatest examples") {
+			let combineLatestExampleName = "combineLatest examples"
+			sharedExamples(combineLatestExampleName) {
 				it("should forward the latest values from all inputs"){
 					expect(combinedValues).to(beNil())
 					
@@ -1630,7 +1631,7 @@ class SignalSpec: QuickSpec {
 						})
 				}
 				
-				itBehavesLike("combineLatest examples")
+				itBehavesLike(combineLatestExampleName)
 			}
 			
 			describe("sequence") {
@@ -1643,7 +1644,7 @@ class SignalSpec: QuickSpec {
 						})
 				}
 				
-				itBehavesLike("combineLatest examples")
+				itBehavesLike(combineLatestExampleName)
 			}
 		}
 		
@@ -1675,7 +1676,8 @@ class SignalSpec: QuickSpec {
 				sinkC = baseSinkC
 			}
 			
-			sharedExamples("zip examples") {
+			let zipExampleName = "zip examples"
+			sharedExamples(zipExampleName) {
 				it("should combine all set"){
 					expect(zippedValues).to(beNil())
 					
@@ -1725,7 +1727,7 @@ class SignalSpec: QuickSpec {
 					})
 				}
 				
-				itBehavesLike("zip examples")
+				itBehavesLike(zipExampleName)
 			}
 			
 			describe("sequence") {
@@ -1738,7 +1740,7 @@ class SignalSpec: QuickSpec {
 					})
 				}
 				
-				itBehavesLike("zip examples")
+				itBehavesLike(zipExampleName)
 			}
 		}
 	}


### PR DESCRIPTION
So I've tried to use RAC as a Futures & Promises library in an app I'm working on and realized that the `zip` and `combineLatest` operators would only return tuples which is rather inconvenient when the number of signals or signal producers is variable.

So I've added the array operators to make code as follows possible:
```swift
zip(repositories.map { github.getRepository($0.fullName) }).start(error: nil, completed: nil, interrupted: nil, next:  {}
```

This is my first pull request for RAC so excuse me if I forgot about something very obvious.