### PR TITLE
Handle Interrupted events in promoteErrors

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -995,6 +995,8 @@ public func promoteErrors<T, E: ErrorType>(_: E.Type)(signal: Signal<T, NoError>
 			sendNext(observer, value)
 		}, completed: {
 			sendCompleted(observer)
+		}, interrupted: {
+			sendInterrupted(observer)
 		})
 	}
 }


### PR DESCRIPTION
I couldn't trace any real issues to this in practice, but This Seems Bad™.