### PR TITLE
Fix order of Completed event in .Concat

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1141,9 +1141,10 @@ private func concat<T, E>(signal: Signal<SignalProducer<T, E>, E>) -> Signal<T, 
 		}, completed: {
 			// Add one last producer to the queue, whose sole job is to
 			// "turn out the lights" by completing `observer`.
-			let completion: SignalProducer<T, E> = .empty |> on(completed: {
+			let completion = SignalProducer<T, E> { innerObserver, _ in
+				sendCompleted(innerObserver)
 				sendCompleted(observer)
-			})
+			}
 
 			state.enqueueSignalProducer(completion)
 		}, interrupted: {


### PR DESCRIPTION
Outer signal observer should be notified of Completed event after all inner producers have completed.

It should fix https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2009#discussion_r30481218.