### PR TITLE
Refactor switchToLatest to fix deadlock

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1363,10 +1363,9 @@ private func switchToLatest<T, E>(signal: Signal<SignalProducer<T, E>, E>) -> Si
 						}
 
 					default:
-						state.withValue { value -> () in
-							if value.isLatestIncompleteSignal(innerSignal) {
-								sink.put(event)
-							}
+						let shouldSend = state.withValue { $0.isLatestIncompleteSignal(innerSignal) }
+						if shouldSend {
+							sink.put(event)
 						}
 					}
 				})

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1325,58 +1325,71 @@ private func merge<T, E>(signal: Signal<SignalProducer<T, E>, E>) -> Signal<T, E
 private func switchToLatest<T, E>(signal: Signal<SignalProducer<T, E>, E>) -> Signal<T, E> {
 	return Signal<T, E> { sink in
 		let disposable = CompositeDisposable()
+
 		let latestInnerDisposable = SerialDisposable()
 		disposable.addDisposable(latestInnerDisposable)
 
-		let state = Atomic(LatestState<T, E>(outerSignalComplete: false, latestIncompleteSignal: nil))
-		let updateState = { (action: LatestState<T, E> -> LatestState<T, E>) -> () in
-			state.modify(action)
-			if state.value.isComplete {
-				sendCompleted(sink)
-			}
-		}
+		let state = Atomic(LatestState<T, E>())
 
 		signal.observe(next: { innerProducer in
 			innerProducer.startWithSignal { innerSignal, innerDisposable in
-				state.modify { state in
-					return state.isComplete
-						? state
-						: LatestState(
-							outerSignalComplete: state.outerSignalComplete,
-							latestIncompleteSignal: innerSignal)
+				state.modify { (var state) in
+					// When we replace the disposable below, this prevents the
+					// generated Interrupted event from doing any work.
+					state.replacingInnerSignal = true
+					return state
 				}
 
-				// Don't dispose of the previous signal until we've
-				// registered this new signal as the latest, or else we
-				// may inadvertently send Interrupted to our observer.
 				latestInnerDisposable.innerDisposable = innerDisposable
+
+				state.modify { (var state) in
+					state.replacingInnerSignal = false
+					state.innerSignalComplete = false
+					return state
+				}
 
 				innerSignal.observe(Signal.Observer { event in
 					switch event {
-					case .Completed, .Interrupted:
-						updateState { state in
-							return state.isLatestIncompleteSignal(innerSignal)
-								? LatestState(
-									outerSignalComplete: state.outerSignalComplete,
-									latestIncompleteSignal: nil)
-								: state
+					case .Interrupted:
+						// If interruption occurred as a result of a new signal
+						// arriving, we don't want to notify our observer.
+						let original = state.modify { (var state) in
+							if !state.replacingInnerSignal {
+								state.innerSignalComplete = true
+							}
+
+							return state
+						}
+
+						if !original.replacingInnerSignal && original.outerSignalComplete {
+							sendCompleted(sink)
+						}
+
+					case .Completed:
+						let original = state.modify { (var state) in
+							state.innerSignalComplete = true
+							return state
+						}
+
+						if original.outerSignalComplete {
+							sendCompleted(sink)
 						}
 
 					default:
-						let shouldSend = state.withValue { $0.isLatestIncompleteSignal(innerSignal) }
-						if shouldSend {
-							sink.put(event)
-						}
+						sink.put(event)
 					}
 				})
 			}
 		}, error: { error in
 			sendError(sink, error)
 		}, completed: {
-			updateState { state in
-				LatestState(
-					outerSignalComplete: true,
-					latestIncompleteSignal: state.latestIncompleteSignal)
+			let original = state.modify { (var state) in
+				state.outerSignalComplete = true
+				return state
+			}
+
+			if original.innerSignalComplete {
+				sendCompleted(sink)
 			}
 		}, interrupted: {
 			sendInterrupted(sink)
@@ -1387,18 +1400,8 @@ private func switchToLatest<T, E>(signal: Signal<SignalProducer<T, E>, E>) -> Si
 }
 
 private struct LatestState<T, E: ErrorType> {
-	let outerSignalComplete: Bool
-	let latestIncompleteSignal: Signal<T, E>?
+	var outerSignalComplete: Bool = false
+	var innerSignalComplete: Bool = true
 
-	func isLatestIncompleteSignal(signal: Signal<T, E>) -> Bool {
-		if let latestIncompleteSignal = latestIncompleteSignal {
-			return latestIncompleteSignal === signal
-		} else {
-			return false
-		}
-	}
-
-	var isComplete: Bool {
-		return outerSignalComplete && latestIncompleteSignal == nil
-	}
+	var replacingInnerSignal: Bool = false
 }

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1044,6 +1044,15 @@ class SignalProducerSpec: QuickSpec {
 
 					expect(completed).to(beTruthy())
 				}
+
+				it("should not deadlock") {
+					let result = SignalProducer<Int, NoError>(value: 1)
+						|> flatMap(.Latest) { _ in SignalProducer(value: 10) }
+						|> take(1)
+						|> last
+
+					expect(result?.value).to(equal(10))
+				}
 			}
 
 			describe("interruption") {


### PR DESCRIPTION
Fixes #2035.

I didn’t originally intend to rewrite the operator, but I was worried that the naive fix for the deadlock (13fe954) could introduce a small race condition window where producer `N - 1` could forward an event after producer `N` has started.

/cc @brow @neilpa @stevebrambilla