### PR TITLE
Increase <~ operator precedence

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -162,8 +162,8 @@ extension MutableProperty: SinkType {
 infix operator <~ {
 	associativity right
 
-	// Binds tighter than assignment but looser than everything else.
-	precedence 91
+	// Binds tighter than assignment but looser than everything else, including `|>`
+	precedence 93
 }
 
 /// Binds a signal to a property, updating the property's value to the latest

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -161,7 +161,9 @@ extension MutableProperty: SinkType {
 
 infix operator <~ {
 	associativity right
-	precedence 90
+
+	// Binds tighter than assignment but looser than everything else.
+	precedence 91
 }
 
 /// Binds a signal to a property, updating the property's value to the latest


### PR DESCRIPTION
Enables assignment of the returned disposable to an optional var without parenthesizing the entire binding expression.