### PR TITLE
Documentation: Basic Operators

### DIFF
--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -51,9 +51,24 @@ code-style will be used.
 
 ## Operator composition
 
-### Lifting
 ### Pipe
 
+The `|>` operator can be used to apply a signal operator to a signal. Multiple operators can be chained after eachother using the `|>` operator
+
+```Swift
+intSignal
+    |> filter { num in num % 2 == 0 }
+    |> map(toString)
+    |> observe(next: { string in println(string) })
+```
+
+### Lifting
+
+Signal operators can be _lifted_ to operate upon `SignalProducer`s instead using the `lift` operator.
+In other words, this will create a new `SignalProducer` which will apply the given signal operator to _every_ signal created from the incoming `SignalProducer`s
+just if the operator had been applied to each signal yielded from `start()`.
+
+The `|>` operator implicitely lifts signal operators, when used with `SignalProducer`s.
 
 ## Transforming signals
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -187,7 +187,7 @@ These operators combine multiple signals into a single new signal.
 
 ### Combining latest values
 
-The `combineLatest` function combines the latest values of two (or more) signals. The resulting signal will not send a value until both inputs have sent at least one value each.
+The `combineLatest` function combines the latest values of two (or more) signals. The resulting signal will only send a the first value after both inputs have sent at least one value each. After that, each value on either of the inputs will cause a new value on the output.
 
 ```Swift
 let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
@@ -208,7 +208,7 @@ The `combineLatestWith` operator works in the same way, but as an operator.
 
 ### Zipping
 
-The `zip` function combines values of two signals into pairs. The elements of any Nth pair are the Nth elements of the two input signals.
+The `zip` function combines values of two signals into pairs. The elements of any Nth pair are the Nth elements of the two input signals. That means the output signal will always wait for both input signals to send and ouptut.
 
 ```Swift
 let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -162,7 +162,7 @@ The `zipWith` operator works in the same way, but as an operator.
 
 ## Flattening producers
 
-The `flatten` operators transforms a producer-of-producers into a single producer. 
+The `flatten` operators transforms a `SignalProducer`-of-`SignalProducer`s into a single `SignalProducer`.
 There are multiple different semantics of the operation which can be chosen as a `FlattenStrategy`.
 
 ### Merging

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -67,15 +67,16 @@ signal.observe(Signal.Observer { event in
 Alternatively, callbacks for the `Next`, `Error`, `Completed` and `Interrupted` events can be provided which will be called when a corresponding event occurs.
 
 ```Swift
-signal.observe(error: { error in
-            println("Error: \(error)")
-        }, completed: {
-            println("Completed")
-        }, interrupted: {
-            println("Interrupted")
-        }, next: { next in
-            println("Next: \(next)")
-    })
+signal.observe(next: { next in
+        println("Next: \(next)")
+    }, error: { error in
+        println("Error: \(error)")
+    }, completed: {
+        println("Completed")
+    }, interrupted: {
+        println("Interrupted")
+    }
+)
 ```
 
 `observe` is also available as operator that can be used with [|>][#pipe]

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -143,7 +143,7 @@ The `map` operator is used to transform the values in a signal, creating a new s
 let (signal, sink) = Signal<String, NoError>.pipe()
 signal
     |> map { string in string.uppercaseString }
-    |> observe(next: { println($0) })
+    |> observe(next: println)
 
 sendNext(sink, "a")     // Prints A
 sendNext(sink, "b")     // Prints B
@@ -159,7 +159,7 @@ The `filter` operator is used to include only values in a signal that satisfy a 
 let (signal, sink) = Signal<Int, NoError>.pipe()
 signal
     |> filter { number in number % 2 == 0 }
-    |> observe(next: { println($0) })
+    |> observe(next: println)
 
 sendNext(sink, 1)     // Not printed
 sendNext(sink, 2)     // Prints 2
@@ -176,7 +176,7 @@ let (signal, sink) = Signal<Int, NoError>.pipe()
 
 signal
     |> reduce(1) { $0 * $1 }
-    |> observe(next: { println($0) })
+    |> observe(next: println)
 
 sendNext(sink, 1)     // nothing printed
 sendNext(sink, 2)     // nothing printed
@@ -198,7 +198,7 @@ let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
 let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
 
 combineLatest(numbersSignal, lettersSignal)
-    |> observe(next: { println($0) }, completed: { println("Completed") })
+    |> observe(next: println, completed: { println("Completed") })
 
 sendNext(numbersSink, 0)    // nothing printed
 sendNext(numbersSink, 1)    // nothing printed
@@ -221,7 +221,7 @@ let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
 let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
 
 zip(numbersSignal, lettersSignal)
-    |> observe(next: { println($0) }, completed: { println("Completed") })
+    |> observe(next: println, completed: { println("Completed") })
 
 sendNext(numbersSink, 0)    // nothing printed
 sendNext(numbersSink, 1)    // nothing printed
@@ -273,7 +273,7 @@ let (signal, sink) = SignalProducer<SignalProducer<AnyObject, NoError>, NoError>
 
 signal
     |> flatten(FlattenStrategy.Merge)
-    |> start(next: { println($0) })
+    |> start(next: println)
 
 sendNext(sink, numbersSignal)
 sendNext(sink, lettersSignal)
@@ -298,7 +298,7 @@ let (signal, sink) = SignalProducer<SignalProducer<AnyObject, NoError>, NoError>
 
 signal
     |> flatten(FlattenStrategy.Concat)
-    |> start(next: { println($0) })
+    |> start(next: println)
 
 sendNext(sink, numbersSignal)
 sendNext(sink, lettersSignal)
@@ -325,7 +325,7 @@ let (signal, sink) = SignalProducer<SignalProducer<AnyObject, NoError>, NoError>
 
 signal
     |> flatten(FlattenStrategy.Latest)
-    |> start(next: { println($0) })
+    |> start(next: println)
 
 sendNext(sink, numbersSignal)   // nothing printed
 sendNext(numbersSink, 1)        // prints 1
@@ -351,7 +351,7 @@ let (signalB, sinkB) = SignalProducer<String, NSError>.buffer(5)
 
 signalA
     |> catch { error in signalB }
-    |> start(next: { println($0)})
+    |> start(next: println)
 
 let error = NSError(domain: "domain", code: 0, userInfo: nil)
 
@@ -382,8 +382,8 @@ let producer = SignalProducer<String, NSError> { (sink, _) in
 producer
     |> on(error: {e in println("Error")})             // prints "Error" twice
     |> retry(2)
-    |> start(next: { println($0)},                    // prints "Success"
-        error: { error in println("Signal Error")})
+    |> start(next: println,                           // prints "Success"
+            error: { _ in println("Signal Error")})
 ```
 
 If the `SignalProducer` does not succeed after `count` tries, the resulting `SignalProducer` will fail. E.g., if  `retry(1)` is used in the example above instead of `retry(2)`, `"Signal Error"` will be printed instead of `"Success"`.
@@ -411,7 +411,7 @@ let (signal, sink) = Signal<String, CustomError>.pipe()
 
 signal
     |> mapError { $0.nsError }
-    |> observe(error: {println($0)})
+    |> observe(error: println)
 
 sendError(sink, CustomError(404))   // Prints NSError with code 404
 ```

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -238,6 +238,30 @@ The `zipWith` operator works in the same way, but as an operator.
 The `flatten` operators transforms a `SignalProducer`-of-`SignalProducer`s into a single `SignalProducer`.
 There are multiple different semantics of the operation which can be chosen as a `FlattenStrategy`.
 
+To understand, why there are different strategies and how they compare to each other, take a look at this example and
+imagine the column offsets as time:
+
+```Swift
+let values = [
+// imagine column offset as time
+[ 1,    2,      3 ],
+   [ 4,      5,     6 ],
+         [ 7,     8 ],
+]
+
+let merge =
+[ 1, 4, 2, 7,5, 3,8,6 ]
+
+let concat = 
+[ 1,    2,      3,4,      5,     6,7,     8]
+
+let latest =
+[ 1, 4,    7,     8 ]
+```
+
+Note, how the values interleave and which values are even included in the resulting array.
+
+
 ### Merging
 
 The `.Merge` strategy works by immediately forwarding every events of the inner `SignalProducer`s to the outer `SignalProducer`.

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -83,6 +83,29 @@ signal.observe(next: { next in
 
 ### Injecting effects
 
+Side effects can be injected on a `SignalProducer` with the `on` operator without actually subscribing to it. 
+
+```Swift
+producer
+    |> on(started: {
+            println("Started")
+        }, event: { event in
+            println("Event: \(event)")
+        }, error: { error in
+            println("Error: \(error)")
+        }, completed: { () -> () in
+            println("Completed")
+        }, interrupted: { () -> () in
+            println("Interrupted")
+        }, terminated: { () -> () in
+            println("Terminated")
+        }, disposed: { () -> () in
+            println("Disposed")
+        }, next: { next in
+            println("Next: \(next)")
+        })
+```
+
 ## Operator composition
 
 ### Pipe

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -109,7 +109,8 @@ let producer = signalProducer
 ```
 
 Similar to `observe`, all the parameters are optional and you only need to provide callbacks for the events you care about.
-Note, that nothing will be printed until `producer` is started (possibly somewhere else).
+
+Note that nothing will be printed until `producer` is started (possibly somewhere else).
 
 ## Operator composition
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -177,7 +177,7 @@ let (signal, sink) = Signal<Int, NoError>.pipe()
 
 let collected = signal |> collect
 
-collected.observe(next: { println($0) })
+collected.observe(next: println)
 
 sendNext(sink, 1)     // nothing printed
 sendNext(sink, 2)     // nothing printed

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -86,9 +86,9 @@ signal.observe(next: { next in
 Side effects can be injected on a `SignalProducer` with the `on` operator without actually subscribing to it. 
 
 ```Swift
-producer
+let producer = signalProducer
     |> on(started: {
-            println("Started")
+        println("Started")
         }, event: { event in
             println("Event: \(event)")
         }, error: { error in
@@ -103,8 +103,11 @@ producer
             println("Disposed")
         }, next: { next in
             println("Next: \(next)")
-        })
+    })
 ```
+
+Note, that will not print anything unless `producer` is started (possibly somewhere else).
+
 
 ## Operator composition
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -46,8 +46,41 @@ code-style will be used.
 ## Performing side effects with signals
 
 ### Observation
-### Injecting effects
 
+Signals can be observed with the `observe` function. It takes a `Sink` as argument to which any future events are sent. 
+
+```Swift
+signal.observe(Signal.Observer { event in
+    switch event {
+    case let .Next(next):
+        println("Next: \(next)")
+    case let .Error(error):
+        println("Error: \(error)")
+    case .Completed:
+        println("Completed")
+    case .Interrupted:
+        println("Interrupted")
+    }
+})
+```
+
+Alternatively, callbacks for the `Next`, `Error`, `Completed` and `Interrupted` events can be provided which will be called when a corresponding event occurs.
+
+```Swift
+signal.observe(error: { error in
+            println("Error: \(error)")
+        }, completed: {
+            println("Completed")
+        }, interrupted: {
+            println("Interrupted")
+        }, next: { next in
+            println("Next: \(next)")
+    })
+```
+
+`observe` is also available as operator that can be used with [|>][#pipe]
+
+### Injecting effects
 
 ## Operator composition
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -93,13 +93,13 @@ producer
             println("Event: \(event)")
         }, error: { error in
             println("Error: \(error)")
-        }, completed: { () -> () in
+        }, completed: {
             println("Completed")
-        }, interrupted: { () -> () in
+        }, interrupted: {
             println("Interrupted")
-        }, terminated: { () -> () in
+        }, terminated: {
             println("Terminated")
-        }, disposed: { () -> () in
+        }, disposed: {
             println("Disposed")
         }, next: { next in
             println("Next: \(next)")

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -57,9 +57,59 @@ code-style will be used.
 
 ## Transforming signals
 
+These operators transform a signal into a new signal.
+
 ### Mapping
+
+The `map` operator is used to transform the values in a signal, creating a new signal with the results.
+
+```Swift
+let (signal, sink) = Signal<String, NoError>.pipe()
+let mapped = signal |> map { string in
+    string.uppercaseString
+}
+
+mapped.observe(next: { println($0) })
+
+sendNext(sink, "a")     // Prints A
+sendNext(sink, "b")     // Prints B
+sendNext(sink, "c")     // Prints C
+```
+
+
 ### Filtering
+
+The `filter` operator is used to include only values in a signal that satisfy a predicate
+
+```Swift
+let (signal, sink) = Signal<Int, NoError>.pipe()
+let filtered = signal |> filter { number in
+    number % 2 == 0
+}
+
+filtered.observe(next: { println($0) })
+
+sendNext(sink, 1)     // Not printed
+sendNext(sink, 2)     // Prints 2
+sendNext(sink, 3)     // Not printed
+sendNext(sink, 4)     // prints 4
+```
+
 ### Reducing
+
+The `reduce` operator is used to aggregate a signals value into a signle combine value. Note, that the final value is only sended after the source signal completes.
+
+```Swift
+let (signal, sink) = Signal<Int, NoError>.pipe()
+let filtered = signal |> reduce(1) { $0 * $1 }
+
+filtered.observe(next: { println($0) })
+
+sendNext(sink, 1)     // nothing printed
+sendNext(sink, 2)     // nothing printed
+sendNext(sink, 3)     // nothing printed
+sendCompleted(sink)   // prints 6
+```
 
 
 ## Combining signals

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -65,11 +65,9 @@ The `map` operator is used to transform the values in a signal, creating a new s
 
 ```Swift
 let (signal, sink) = Signal<String, NoError>.pipe()
-let mapped = signal |> map { string in
-    string.uppercaseString
-}
-
-mapped.observe(next: { println($0) })
+signal
+    |> map { string in string.uppercaseString }
+    |> observe(next: { println($0) })
 
 sendNext(sink, "a")     // Prints A
 sendNext(sink, "b")     // Prints B
@@ -83,11 +81,9 @@ The `filter` operator is used to include only values in a signal that satisfy a 
 
 ```Swift
 let (signal, sink) = Signal<Int, NoError>.pipe()
-let filtered = signal |> filter { number in
-    number % 2 == 0
-}
-
-filtered.observe(next: { println($0) })
+signal
+    |> filter { number in number % 2 == 0 }
+    |> observe(next: { println($0) })
 
 sendNext(sink, 1)     // Not printed
 sendNext(sink, 2)     // Prints 2
@@ -101,9 +97,10 @@ The `reduce` operator is used to aggregate a signals value into a signle combine
 
 ```Swift
 let (signal, sink) = Signal<Int, NoError>.pipe()
-let filtered = signal |> reduce(1) { $0 * $1 }
 
-filtered.observe(next: { println($0) })
+signal
+    |> reduce(1) { $0 * $1 }
+    |> observe(next: { println($0) })
 
 sendNext(sink, 1)     // nothing printed
 sendNext(sink, 2)     // nothing printed
@@ -124,9 +121,8 @@ The `combineLatest` function combines the latest values of two (or more) signals
 let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
 let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
 
-let combined = combineLatest(numbersSignal, lettersSignal)
-
-combined.observe(next: { println($0) })
+combineLatest(numbersSignal, lettersSignal)
+    |> observe(next: { println($0) })
 
 sendNext(numbersSink, 0)    // nothing printed
 sendNext(numbersSink, 1)    // nothing printed
@@ -146,9 +142,8 @@ The `zip` function combines values of two signals into pairs. The elements of an
 let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
 let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
 
-let combined = zip(numbersSignal, lettersSignal)
-
-combined.observe(next: { println($0) })
+zip(numbersSignal, lettersSignal)
+    |> observe(next: { println($0) })
 
 sendNext(numbersSink, 0)    // nothing printed
 sendNext(numbersSink, 1)    // nothing printed
@@ -174,9 +169,9 @@ let (numbersSignal, numbersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
 let (lettersSignal, lettersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
 let (signal, sink) = SignalProducer<SignalProducer<AnyObject, NoError>, NoError>.buffer(5)
 
-let flattened = signal |> flatten(FlattenStrategy.Merge)
-
-flattened.start(next: { println($0) })
+signal
+    |> flatten(FlattenStrategy.Merge)
+    |> start(next: { println($0) })
 
 sendNext(sink, numbersSignal)
 sendNext(sink, lettersSignal)
@@ -200,9 +195,9 @@ let (numbersSignal, numbersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
 let (lettersSignal, lettersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
 let (signal, sink) = SignalProducer<SignalProducer<AnyObject, NoError>, NoError>.buffer(5)
 
-let flattened = signal |> flatten(FlattenStrategy.Concat)
-
-flattened.start(next: { println($0) })
+signal
+    |> flatten(FlattenStrategy.Concat)
+    |> start(next: { println($0) })
 
 sendNext(sink, numbersSignal)
 sendNext(sink, lettersSignal)
@@ -227,9 +222,9 @@ let (numbersSignal, numbersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
 let (lettersSignal, lettersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
 let (signal, sink) = SignalProducer<SignalProducer<AnyObject, NoError>, NoError>.buffer(5)
 
-let flattened = signal |> flatten(FlattenStrategy.Latest)
-
-flattened.start(next: { println($0) })
+signal
+    |> flatten(FlattenStrategy.Latest)
+    |> start(next: { println($0) })
 
 sendNext(sink, numbersSignal)   // nothing printed
 sendNext(numbersSink, 1)        // prints 1

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -151,6 +151,7 @@ sendNext(sink, "b")     // Prints B
 sendNext(sink, "c")     // Prints C
 ```
 
+[Interactive visualisation of the `map` operator](http://neilpa.me/rac-marbles/#map)
 
 ### Filtering
 
@@ -167,6 +168,8 @@ sendNext(sink, 2)     // Prints 2
 sendNext(sink, 3)     // Not printed
 sendNext(sink, 4)     // prints 4
 ```
+
+[Interactive visualisation of the `filter` operator](http://neilpa.me/rac-marbles/#filter)
 
 ### Aggregating
 
@@ -201,6 +204,7 @@ sendNext(sink, 3)     // nothing printed
 sendCompleted(sink)   // prints 6
 ```
 
+[Interactive visualisation of the `reduce` operator](http://neilpa.me/rac-marbles/#reduce)
 
 ## Combining signals
 
@@ -229,6 +233,8 @@ sendCompleted(lettersSink)  // prints "Completed"
 
 The `combineLatestWith` operator works in the same way, but as an operator.
 
+[Interactive visualisation of the `combineLatest` operator](http://neilpa.me/rac-marbles/#combineLatest)
+
 ### Zipping
 
 The `zip` function combines values of two (or more) signals into pairs. The elements of any Nth pair are the Nth elements of the input signals. That means the output signal will always wait for all input signals to send and output.
@@ -251,6 +257,8 @@ sendNext(lettersSink, "C")  // prints (2, C) & "Completed"
 ```
 
 The `zipWith` operator works in the same way, but as an operator.
+
+[Interactive visualisation of the `zip` operator](http://neilpa.me/rac-marbles/#zip)
 
 ## Flattening producers
 
@@ -302,6 +310,8 @@ sendNext(lettersSink, "c")    // prints "c"
 sendNext(numbersSink, "3")    // prints "3"
 ```
 
+[Interactive visualisation of the `flatten(.Merge)` operator](http://neilpa.me/rac-marbles/#merge)
+
 ### Concatenating
 
 The `.Concat` strategy is used to serialize work of the inner `SignalProducer`s. The outer producer is started immediately. Each subsequent producer is not started until the preceeding one has completed. Errors are immediately forwarded to the flattened producer.
@@ -326,6 +336,8 @@ sendCompleted(lettersSink)    // prints "1", "2"
 sendNext(numbersSink, "3")    // prints "3"
 sendCompleted(numbersSink)
 ```
+
+[Interactive visualisation of the `flatten(.Concat)` operator](http://neilpa.me/rac-marbles/#concat)
 
 ### Switching
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -173,22 +173,6 @@ sendNext(sink, 4)     // prints 4
 
 ### Aggregating
 
-The `collect` operator is used to aggregate a signals values into a single array value. Note, that the final value is only sent after the source signal completes.
-
-```Swift
-let (signal, sink) = Signal<Int, NoError>.pipe()
-
-let collected = signal |> collect
-
-collected.observe(next: println)
-
-sendNext(sink, 1)     // nothing printed
-sendNext(sink, 2)     // nothing printed
-sendNext(sink, 3)     // nothing printed
-sendCompleted(sink)   // prints [1, 2, 3]
-```
-
-
 The `reduce` operator is used to aggregate a signals values into a single combine value. Note, that the final value is only sent after the source signal completes.
 
 ```Swift
@@ -202,6 +186,21 @@ sendNext(sink, 1)     // nothing printed
 sendNext(sink, 2)     // nothing printed
 sendNext(sink, 3)     // nothing printed
 sendCompleted(sink)   // prints 6
+```
+
+The `collect` operator is used to aggregate a signals values into a single array value. Note, that the final value is only sent after the source signal completes.
+
+```Swift
+let (signal, sink) = Signal<Int, NoError>.pipe()
+
+let collected = signal |> collect
+
+collected.observe(next: println)
+
+sendNext(sink, 1)     // nothing printed
+sendNext(sink, 2)     // nothing printed
+sendNext(sink, 3)     // nothing printed
+sendCompleted(sink)   // prints [1, 2, 3]
 ```
 
 [Interactive visualisation of the `reduce` operator.](http://neilpa.me/rac-marbles/#reduce)

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -106,8 +106,7 @@ let producer = signalProducer
     })
 ```
 
-Note, that will not print anything unless `producer` is started (possibly somewhere else).
-
+Note, that nothing will be printed until `producer` is started (possibly somewhere else).
 
 ## Operator composition
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -114,9 +114,51 @@ sendCompleted(sink)   // prints 6
 
 ## Combining signals
 
+These operators combine multiple signals into a single new signal.
+
 ### Combining latest values
+
+The `combineLatest` function combines the latest values of two (or more) signals. The resulting signal will not send a value until both inputs have sent at least one value each.
+
+```Swift
+let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
+let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
+
+let combined = combineLatest(numbersSignal, lettersSignal)
+
+combined.observe(next: { println($0) })
+
+sendNext(numbersSink, 0)    // nothing printed
+sendNext(numbersSink, 1)    // nothing printed
+sendNext(lettersSink, "A")  // prints (1, A)
+sendNext(numbersSink, 2)    // prints (2, A)
+sendNext(lettersSink, "B")  // prints (2, B)
+sendNext(lettersSink, "C")  // prints (2, C)
+```
+
+The `combineLatestWith` operator works in the same way, but as an operator.
+
 ### Zipping
 
+The `zip` function combines values of two signals into pairs. The elements of any Nth pair are the Nth elements of the two input signals.
+
+```Swift
+let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
+let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
+
+let combined = zip(numbersSignal, lettersSignal)
+
+combined.observe(next: { println($0) })
+
+sendNext(numbersSink, 0)    // nothing printed
+sendNext(numbersSink, 1)    // nothing printed
+sendNext(lettersSink, "A")  // prints (0, A)
+sendNext(numbersSink, 2)    // nothing printed
+sendNext(lettersSink, "B")  // prints (1, B)
+sendNext(lettersSink, "C")  // prints (2, C)
+```
+
+The `zipWith` operator works in the same way, but as an operator.
 
 ## Flattening producers
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -79,7 +79,7 @@ signal.observe(next: { next in
 )
 ```
 
-`observe` is also available as operator that can be used with [|>][#pipe]
+`observe` is also available as operator that can be used with [|>](#pipe)
 
 ### Injecting effects
 
@@ -359,7 +359,7 @@ numbersSignal
     |> combineLatestWith(lettersSignal)
 ```
 
-The given signal will still not actually generate errors, but some operators to [combine signals][#combining-signals] require the incoming signals to have matching error types.
+The given signal will still not actually generate errors, but some operators to [combine signals](#combining-signals) require the incoming signals to have matching error types.
 
 
 [Signals]: FrameworkOverview.md#signals

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -68,15 +68,14 @@ Alternatively, callbacks for the `Next`, `Error`, `Completed` and `Interrupted` 
 
 ```Swift
 signal.observe(next: { next in
-        println("Next: \(next)")
-    }, error: { error in
-        println("Error: \(error)")
-    }, completed: {
-        println("Completed")
-    }, interrupted: {
-        println("Interrupted")
-    }
-)
+    println("Next: \(next)")
+}, error: { error in
+    println("Error: \(error)")
+}, completed: {
+    println("Completed")
+}, interrupted: {
+    println("Interrupted")
+})
 ```
 
 Note that it is not necessary to provide all four parameters - all of them are optional, you only need to provide callbacks for the events you care about.
@@ -90,21 +89,21 @@ Side effects can be injected on a `SignalProducer` with the `on` operator withou
 ```Swift
 let producer = signalProducer
     |> on(started: {
-	        println("Started")
-        }, event: { event in
-            println("Event: \(event)")
-        }, error: { error in
-            println("Error: \(error)")
-        }, completed: {
-            println("Completed")
-        }, interrupted: {
-            println("Interrupted")
-        }, terminated: {
-            println("Terminated")
-        }, disposed: {
-            println("Disposed")
-        }, next: { next in
-            println("Next: \(next)")
+        println("Started")
+    }, event: { event in
+        println("Event: \(event)")
+    }, error: { error in
+        println("Error: \(error)")
+    }, completed: {
+        println("Completed")
+    }, interrupted: {
+        println("Interrupted")
+    }, terminated: {
+        println("Terminated")
+    }, disposed: {
+        println("Disposed")
+    }, next: { next in
+        println("Next: \(next)")
     })
 ```
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -194,35 +194,41 @@ let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
 let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
 
 combineLatest(numbersSignal, lettersSignal)
-    |> observe(next: { println($0) })
+    |> observe(next: { println($0) },
+          completed: { println("Completed") })
 
 sendNext(numbersSink, 0)    // nothing printed
 sendNext(numbersSink, 1)    // nothing printed
 sendNext(lettersSink, "A")  // prints (1, A)
 sendNext(numbersSink, 2)    // prints (2, A)
+sendCompleted(numbersSink)  // nothing printed
 sendNext(lettersSink, "B")  // prints (2, B)
 sendNext(lettersSink, "C")  // prints (2, C)
+sendCompleted(lettersSink)  // prints "Completed"
 ```
 
 The `combineLatestWith` operator works in the same way, but as an operator.
 
 ### Zipping
 
-The `zip` function combines values of two signals into pairs. The elements of any Nth pair are the Nth elements of the two input signals. That means the output signal will always wait for both input signals to send and ouptut.
+The `zip` function combines values of two signals into pairs. The elements of any Nth pair are the Nth elements of the two input signals. That means the output signal will always wait for both input signals to send and output.
 
 ```Swift
 let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
 let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
 
 zip(numbersSignal, lettersSignal)
-    |> observe(next: { println($0) })
+    |> observe(next: { println($0) },
+          completed: { println("Completed") })
 
 sendNext(numbersSink, 0)    // nothing printed
 sendNext(numbersSink, 1)    // nothing printed
-sendNext(lettersSink, "A")  // prints (0, A)
-sendNext(numbersSink, 2)    // nothing printed
-sendNext(lettersSink, "B")  // prints (1, B)
-sendNext(lettersSink, "C")  // prints (2, C)
+sendNext(lettersSink, "A")  // prints (1, A)
+sendNext(numbersSink, 2)    // prints (2, A)
+sendCompleted(numbersSink)  // nothing printed
+sendNext(lettersSink, "B")  // prints (2, B)
+sendNext(lettersSink, "C")  // prints (2, C) & "Completed"
+
 ```
 
 The `zipWith` operator works in the same way, but as an operator.

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -167,7 +167,7 @@ There are multiple different semantics of the operation which can be chosen as a
 
 ### Merging
 
-The `.Merge` strategy works by immediately forwarding every events of the inner producers to the outer producer.
+The `.Merge` strategy works by immediately forwarding every events of the inner `SignalProducer`s to the outer `SignalProducer`.
 
 ```Swift
 let (numbersSignal, numbersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
@@ -192,8 +192,8 @@ sendNext(lettersSink, "C")  // prints C
 
 ### Concatenating
 
-The `.Concat` strategy works by concatenating the producers such that their values are sent in the order of the producers themselves. 
-This implies, that values of a producer are only sent, when the preceding producer has completed
+The `.Concat` strategy works by concatenating the `SignalProducer`s such that their values are sent in the order of the `SignalProducer`s themselves. 
+This implies, that values of a `SignalProducer` are only sent, when the preceding `SignalProducer` has completed
 
 ```Swift
 let (numbersSignal, numbersSink) = SignalProducer<AnyObject, NoError>.buffer(5)
@@ -220,7 +220,7 @@ sendCompleted(lettersSink)
 
 ### Switching
 
-The `.Latest` strategy works by forwarding only events from the latest input producer.
+The `.Latest` strategy works by forwarding only events from the latest input `SignalProducer`.
 
 ```Swift
 let (numbersSignal, numbersSink) = SignalProducer<AnyObject, NoError>.buffer(5)

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -357,7 +357,7 @@ signal
         error: { error in println("Signal Error")})
 ```
 
-If the `SignalProducer` does not succeed after `count` tries, the resulting `SignalProducer` will fail. E.g., if only `|> retry(1)` is used in the example above instead of `|> retry(2)`, `"Signal Error"` will be printed instead of `"Success"`.
+If the `SignalProducer` does not succeed after `count` tries, the resulting `SignalProducer` will fail. E.g., if  `retry(1)` is used in the example above instead of `retry(2)`, `"Signal Error"` will be printed instead of `"Success"`.
 
 ### Mapping errors
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -345,20 +345,17 @@ These operators are used to handle errors that might occur on a signal.
 The `catch` operator catches any error that may occur on the input `SignalProducer`, then starts a new `SignalProducer` in its place.
 
 ```Swift
-let (signalA, sinkA) = SignalProducer<String, NSError>.buffer(5)
-let (signalB, sinkB) = SignalProducer<String, NSError>.buffer(5)
-
-signalA
-    |> catch { error in signalB }
-    |> start(next: println)
-
+let (producer, sink) = SignalProducer<String, NSError>.buffer(5)
 let error = NSError(domain: "domain", code: 0, userInfo: nil)
 
-sendNext(sinkA, "A")        // prints A
-sendNext(sinkB, "a")        // nothing printed
-sendError(sinkA, error)     // prints a
-sendNext(sinkA, "B")        // nothing printed
-sendNext(sinkB, "b")        // prints b
+producer
+    |> catch { error in SignalProducer<String, NSError>(value: "Default") }
+    |> start(next: println)
+
+
+sendNext(sink, "First")     // prints "First"
+sendNext(sink, "Second")    // prints "Second"
+sendError(sink, error)      // prints "Default"
 ```
 
 ### Retrying

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -24,7 +24,7 @@ code-style will be used.
 
   1. [Mapping](#mapping)
   1. [Filtering](#filtering)
-  1. [Reducing](#reducing)
+  1. [Aggregating](#aggregating)
 
 **[Combining signals](#combining-signals)**
 
@@ -170,7 +170,21 @@ sendNext(sink, 4)     // prints 4
 
 ### Aggregating
 
-The `reduce` operator is used to aggregate a signals value into a single combine value. Note, that the final value is only sent after the source signal completes.
+The `collect` operator is used to aggregate a signals values into a single array value. Note, that the final value is only sent after the source signal completes.
+
+let (signal, sink) = Signal<Int, NoError>.pipe()
+
+let collected = signal |> collect
+
+collected.observe(next: { println($0) })
+
+sendNext(sink, 1)     // nothing printed
+sendNext(sink, 2)     // nothing printed
+sendNext(sink, 3)     // nothing printed
+sendCompleted(sink)   // prints [1, 2, 3]
+
+
+The `reduce` operator is used to aggregate a signals values into a single combine value. Note, that the final value is only sent after the source signal completes.
 
 ```Swift
 let (signal, sink) = Signal<Int, NoError>.pipe()

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -110,7 +110,7 @@ producer
 
 ### Pipe
 
-The `|>` operator can be used to apply a signal operator to a signal. Multiple operators can be chained after eachother using the `|>` operator
+The `|>` operator can be used to apply a signal operator to a signal. Multiple operators can be chained after each other using the `|>` operator
 
 ```Swift
 intSignal
@@ -125,7 +125,7 @@ Signal operators can be _lifted_ to operate upon `SignalProducer`s instead using
 In other words, this will create a new `SignalProducer` which will apply the given signal operator to _every_ signal created from the incoming `SignalProducer`s
 just if the operator had been applied to each signal yielded from `start()`.
 
-The `|>` operator implicitely lifts signal operators, when used with `SignalProducer`s.
+The `|>` operator implicitly lifts signal operators, when used with `SignalProducer`s.
 
 ## Transforming signals
 
@@ -165,7 +165,7 @@ sendNext(sink, 4)     // prints 4
 
 ### Reducing
 
-The `reduce` operator is used to aggregate a signals value into a signle combine value. Note, that the final value is only sended after the source signal completes.
+The `reduce` operator is used to aggregate a signals value into a single combine value. Note, that the final value is only sent after the source signal completes.
 
 ```Swift
 let (signal, sink) = Signal<Int, NoError>.pipe()

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -172,6 +172,7 @@ sendNext(sink, 4)     // prints 4
 
 The `collect` operator is used to aggregate a signals values into a single array value. Note, that the final value is only sent after the source signal completes.
 
+```Swift
 let (signal, sink) = Signal<Int, NoError>.pipe()
 
 let collected = signal |> collect
@@ -182,6 +183,7 @@ sendNext(sink, 1)     // nothing printed
 sendNext(sink, 2)     // nothing printed
 sendNext(sink, 3)     // nothing printed
 sendCompleted(sink)   // prints [1, 2, 3]
+```
 
 
 The `reduce` operator is used to aggregate a signals values into a single combine value. Note, that the final value is only sent after the source signal completes.

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -151,7 +151,7 @@ sendNext(sink, "b")     // Prints B
 sendNext(sink, "c")     // Prints C
 ```
 
-[Interactive visualisation of the `map` operator](http://neilpa.me/rac-marbles/#map)
+[Interactive visualisation of the `map` operator.](http://neilpa.me/rac-marbles/#map)
 
 ### Filtering
 
@@ -169,7 +169,7 @@ sendNext(sink, 3)     // Not printed
 sendNext(sink, 4)     // prints 4
 ```
 
-[Interactive visualisation of the `filter` operator](http://neilpa.me/rac-marbles/#filter)
+[Interactive visualisation of the `filter` operator.](http://neilpa.me/rac-marbles/#filter)
 
 ### Aggregating
 
@@ -204,7 +204,7 @@ sendNext(sink, 3)     // nothing printed
 sendCompleted(sink)   // prints 6
 ```
 
-[Interactive visualisation of the `reduce` operator](http://neilpa.me/rac-marbles/#reduce)
+[Interactive visualisation of the `reduce` operator.](http://neilpa.me/rac-marbles/#reduce)
 
 ## Combining signals
 
@@ -233,7 +233,7 @@ sendCompleted(lettersSink)  // prints "Completed"
 
 The `combineLatestWith` operator works in the same way, but as an operator.
 
-[Interactive visualisation of the `combineLatest` operator](http://neilpa.me/rac-marbles/#combineLatest)
+[Interactive visualisation of the `combineLatest` operator.](http://neilpa.me/rac-marbles/#combineLatest)
 
 ### Zipping
 
@@ -258,7 +258,7 @@ sendNext(lettersSink, "C")  // prints (2, C) & "Completed"
 
 The `zipWith` operator works in the same way, but as an operator.
 
-[Interactive visualisation of the `zip` operator](http://neilpa.me/rac-marbles/#zip)
+[Interactive visualisation of the `zip` operator.](http://neilpa.me/rac-marbles/#zip)
 
 ## Flattening producers
 
@@ -310,7 +310,7 @@ sendNext(lettersSink, "c")    // prints "c"
 sendNext(numbersSink, "3")    // prints "3"
 ```
 
-[Interactive visualisation of the `flatten(.Merge)` operator](http://neilpa.me/rac-marbles/#merge)
+[Interactive visualisation of the `flatten(.Merge)` operator.](http://neilpa.me/rac-marbles/#merge)
 
 ### Concatenating
 
@@ -337,7 +337,7 @@ sendNext(numbersSink, "3")    // prints "3"
 sendCompleted(numbersSink)
 ```
 
-[Interactive visualisation of the `flatten(.Concat)` operator](http://neilpa.me/rac-marbles/#concat)
+[Interactive visualisation of the `flatten(.Concat)` operator.](http://neilpa.me/rac-marbles/#concat)
 
 ### Switching
 


### PR DESCRIPTION
This adds descriptions and examples for the basic operators to the existing stub. 

I have tried to keep the examples short and similar to the [legacy ObjC Version of this Document](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/swift-development/Documentation/Legacy/BasicOperators.md#injecting-effects)

The examples have been written and tested in a playground, so they should work correctly.

I was also playing around with the idea of providing these examples in a playground, but how that would work specifically is not clear to me (Needs extra workspace with RAC Framework built, how to separate the different Examples?). If you like the idea, I can play around with that later in a separate PR. then again, the rest of the still missing documentation may be more important...

This refs #1486 