### PR TITLE
Add overload to |> operator so it kann be used with PropertyType

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -309,6 +309,16 @@ public func |> <T, E, U, F>(producer: SignalProducer<T, E>, transform: Signal<T,
 	return producer.lift(transform)
 }
 
+/// Applies a Signal operator to a Property.
+///
+/// Example:
+///
+/// 	intProperty
+/// 	|> map { 2 * $0 }
+public func |> <P: PropertyType, X>(property: P, transform: Signal<P.Value, NoError> -> Signal<X, NoError>) -> SignalProducer<X, NoError> {
+	return property.producer.lift(transform)
+}
+
 /// Applies a SignalProducer operator to a SignalProducer.
 ///
 /// Example:
@@ -321,6 +331,21 @@ public func |> <T, E, U, F>(producer: SignalProducer<T, E>, transform: Signal<T,
 public func |> <T, E, X>(producer: SignalProducer<T, E>, @noescape transform: SignalProducer<T, E> -> X) -> X {
 	return transform(producer)
 }
+
+/// Applies a SignalProducer operator to a Property.
+///
+/// Example:
+///
+/// 	intProperty
+/// 	|> startOn(UIScheduler())
+/// 	|> start { signal in
+/// 		signal.observe(next: { num in println(num) })
+/// 	}
+public func |> <P: PropertyType, X>(property: P, @noescape transform: SignalProducer<P.Value, NoError> -> X) -> X {
+	return transform(property.producer)
+}
+
+
 
 /// Creates a repeating timer of the given interval, with a reasonable
 /// default leeway, sending updates on the given scheduler.

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -191,7 +191,7 @@ class PropertySpec: QuickSpec {
 				expect(dynamicProperty).to(beNil())
 			}
 		}
-
+		
 		describe("binding") {
 			describe("from a Signal") {
 				it("should update the property with values sent from the signal") {
@@ -343,6 +343,29 @@ class PropertySpec: QuickSpec {
 					destinationProperty = nil
 
 					expect(bindingDisposable.disposed).to(beTruthy())
+				}
+				
+				describe("applying operators to the other property") {
+					it("should be possible to apply an unary signal operator to a property") {
+						var sourceProperty: MutableProperty<String> = MutableProperty(initialPropertyValue)
+						var destinationProperty: MutableProperty<String> = MutableProperty(initialPropertyValue)
+						
+						destinationProperty <~ sourceProperty
+							|> map { $0 + $0 }
+						
+						expect(destinationProperty.value).to(equal(initialPropertyValue + initialPropertyValue))
+					}
+					
+					it("should be possible to apply an unary signal producer operator to a property") {
+						var sourceProperty: MutableProperty<String> = MutableProperty(initialPropertyValue)
+						var destinationProperty: MutableProperty<String> = MutableProperty(initialPropertyValue)
+
+						destinationProperty <~ sourceProperty
+							|> flatMap(.Latest) { _ in SignalProducer(value: subsequentPropertyValue) }
+						
+						expect(destinationProperty.value).to(equal(subsequentPropertyValue))
+
+					}
 				}
 			}
 		}


### PR DESCRIPTION
With this change, properties can be manipulated with signal operators without the need to manually retrieve the producer first

```Swift
firstIntProperty <~ secondIntProperty.producer |> map { 2 * $0 }
```

can be simplified to

```Swift
firstIntProperty <~ secondIntProperty |> map { 2 * $0 }
```

I think this makes working with properties a lot more intuitive and removes some noise from the code.


Actually, I would like to be able to do something like

```Swift
enabledProperty <~ combineLatest(condition1Property, condition2Property, condition3Property)
    |> map { $0.0 && $0.1 && $0.2 }
```

But for that to work, suspect all the versions of `combineLatest` would need the corresponding version duplicated, and maybe all other similar functions (`zip`) as well for consistency. 

I wanted to test the waters first with this small PR to get some feedback if this is even wanted and, if so, if theres a better way to do it. 
