### PR TITLE
Add withLatestFrom

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -526,6 +526,38 @@ public func combineLatest<S: SequenceType, T, Error where S.Generator.Element ==
 	return SignalProducer.empty
 }
 
+/// Works the same way as combineLatestWith except that when the given signal producer
+/// sends a value, it won't send a value.
+public func withLatestFrom<A, B, E>(otherSignalProducer: SignalProducer<B, E>) -> SignalProducer<A, E> -> SignalProducer<(A, B), E> {
+	return { producer in
+		return producer.lift(withLatestFrom)(otherSignalProducer)
+	}
+}
+
+/// Works the same way as combineLatestWith except that when the given signal producer
+/// sends a value, it won't send a value.
+public func withLatestFrom<A, B, C, E>(otherSignalProducer: SignalProducer<A, E>) -> SignalProducer<(B, C), E> -> SignalProducer<(B, C, A), E> {
+	return { producer in
+		return withLatestFrom(otherSignalProducer)(producer) |> map(repack)
+	}
+}
+
+/// Works the same way as combineLatestWith except that when the given signal producer
+/// sends a value, it won't send a value.
+public func withLatestFrom<A, B, C, D, E>(otherSignalProducer: SignalProducer<A, E>) -> SignalProducer<(B, C, D), E> -> SignalProducer<(B, C, D, A), E> {
+	return { producer in
+		return withLatestFrom(otherSignalProducer)(producer) |> map(repack)
+	}
+}
+
+/// Works the same way as combineLatestWith except that when the given signal producer
+/// sends a value, it won't send a value.
+public func withLatestFrom<A, B, C, D, F, E>(otherSignalProducer: SignalProducer<A, E>) -> SignalProducer<(B, C, D, F), E> -> SignalProducer<(B, C, D, F, A), E> {
+	return { producer in
+		return withLatestFrom(otherSignalProducer)(producer) |> map(repack)
+	}
+}
+
 /// Zips the values of all the given producers, in the manner described by
 /// `zipWith`.
 public func zip<A, B, Error>(a: SignalProducer<A, Error>, b: SignalProducer<B, Error>) -> SignalProducer<(A, B), Error> {

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -530,6 +530,41 @@ class SignalProducerSpec: QuickSpec {
 			}
 		}
 
+		describe("withLatestFrom") {
+			it("should forward the latest values from both inputs") {
+				let baseProducer = SignalProducer<Int, NoError>(values: [1, 2])
+				let otherProducer = SignalProducer<Int, NoError>(values: [3, 4])
+
+				var result: (Int, Int) = (0, 0)
+				baseProducer
+					|> withLatestFrom(otherProducer)
+					|> start(next: { (a, b) in
+						result = (a, b)
+					})
+
+				expect(result.0).to(equal(2))
+				expect(result.1).to(equal(4))
+			}
+
+			it("should work with three producers") {
+				let baseProducer = SignalProducer<Int, NoError>(values: [1, 2])
+				let otherProducer = SignalProducer<Int, NoError>(values: [3, 4])
+				let thirdProducer = SignalProducer<Int, NoError>(values: [5, 6])
+
+				var result: (Int, Int, Int) = (0, 0, 0)
+				baseProducer
+					|> combineLatestWith(otherProducer)
+					|> withLatestFrom(thirdProducer)
+					|> start(next: { (a, b, c) in
+						result = (a, b, c)
+					})
+
+				expect(result.0).to(equal(2))
+				expect(result.1).to(equal(4))
+				expect(result.2).to(equal(6))
+			}
+		}
+
 		describe("lift") {
 			describe("over unary operators") {
 				it("should invoke transformation once per started signal") {


### PR DESCRIPTION
In a ViewModel I have a situation where the value of a `MutableProperty` affects its next value:

```swift
mutablePropertyA.producer
    |> combineLatestWith(mutablePropertyB.producer)
    |> filter({ (a, b) in
        return fulfilsSomeCondition(a, b)
    })
    |> start(next: {result in
        mutablePropertyB.put(result)
    })
```

Other RAC-like frameworks offer a `withLatestFrom` operator for these cases. Could this be added to RAC as well?