### PR TITLE
[WIP] propertyOf operator

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -228,3 +228,19 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 public func <~ <Destination: MutablePropertyType, Source: PropertyType where Source.Value == Destination.Value>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }
+
+
+/// Creates a new property bound to `signal` starting with `initialValue`.
+public func propertyOf<T>(initialValue: T)(signal: Signal<T, NoError>) -> PropertyOf<T> {
+	let mutableProperty = MutableProperty(initialValue)
+	mutableProperty <~ signal
+	return PropertyOf(mutableProperty)
+}
+
+
+/// Creates a new property bound to `producer` starting with `initialValue`.
+public func propertyOf<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> PropertyOf<T> {
+	let mutableProperty = MutableProperty(initialValue)
+	mutableProperty <~ producer
+	return PropertyOf(mutableProperty)
+}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -360,6 +360,15 @@ class PropertySpec: QuickSpec {
 				}
 			}
 		}
+		
+		describe("propertyOf") {
+			describe("from a Signal") {
+				it("should initially take on the supplied value") {
+					let property = Signal.never |> propertyOf(initialPropertyValue)
+					expect(property.value).to(equal(initialPropertyValue))
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
I [observed](https://reactivex.slack.com/archives/reactivecocoa/p1437252176000002) today that @neilpa and I have both written almost the same function `propertyOf<T>(initialValue: T)(signal: Signal<T, NoError>) -> PropertyOf<T>` in RAC3 projects. I've actually pasted it into two of my projects.

This adds `propertyOf` to RAC, using @neilpa's documentation and function signature from [Rex](https://github.com/neilpa/Rex) (which I prefer because it's curried for use with `|>`) and my implementation from [Sukhasana](https://github.com/brow/Sukhasana) (which I don't strongly prefer over @neilpa's).

@jspahrsummers did once give some reasons for not including a function like this: https://reactivex.slack.com/archives/reactivecocoa/p1424118385000915

This is currently crashing tests, possibly because of memory corruption introduced by @noescape.