### PR TITLE
Change scheduler on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ search strings:
 let searchStrings = textField.rac_textSignal()
     |> toSignalProducer()
     |> map { text in text as! String }
-    |> throttle(0.5, onScheduler: UIScheduler())
+    |> throttle(0.5, onScheduler: QueueScheduler.mainQueueScheduler)
 ```
 
 This prevents values from being sent less than 0.5 seconds apart, so the user


### PR DESCRIPTION
In [this](https://github.com/ReactiveCocoa/ReactiveCocoa#throttling-requests) section of README it makes use of `throttle` like this:
```
    |> throttle(0.5, onScheduler: UIScheduler())
```
However, `throttle` takes `DateSchedulerType` as second parameter, which `UIScheduler` doesn't confirms to.