### PR TITLE
propertyOf operator

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -228,3 +228,19 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 public func <~ <Destination: MutablePropertyType, Source: PropertyType where Source.Value == Destination.Value>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }
+
+
+/// Creates a new property bound to `signal` starting with `initialValue`.
+public func propertyOf<T>(initialValue: T)(signal: Signal<T, NoError>) -> PropertyOf<T> {
+	let mutableProperty = MutableProperty(initialValue)
+	mutableProperty <~ signal
+	return PropertyOf(mutableProperty)
+}
+
+
+/// Creates a new property bound to `producer` starting with `initialValue`.
+public func propertyOf<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> PropertyOf<T> {
+	let mutableProperty = MutableProperty(initialValue)
+	mutableProperty <~ producer
+	return PropertyOf(mutableProperty)
+}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -25,21 +25,25 @@ public struct PropertyOf<T>: PropertyType {
 		return _producer()
 	}
 	
-	/// Initializes the receiver as a read-only view of the given property.
+	/// Initializes a property as a read-only view of the given property.
 	public init<P: PropertyType where P.Value == T>(_ property: P) {
 		_value = { property.value }
 		_producer = { property.producer }
 	}
 	
+	/// Initializes a property that first takes on `initialValue`, then each value 
+	/// sent on a signal created by `producer`.
 	public init(initialValue: T, producer: SignalProducer<T, NoError>) {
 		let mutableProperty = MutableProperty(initialValue)
 		mutableProperty <~ producer
 		self.init(mutableProperty)
 	}
 	
-	public init(initialValue: T, producer: Signal<T, NoError>) {
+	/// Initializes a property that first takes on `initialValue`, then each value
+	/// sent on `signal`.
+	public init(initialValue: T, signal: Signal<T, NoError>) {
 		let mutableProperty = MutableProperty(initialValue)
-		mutableProperty <~ producer
+		mutableProperty <~ signal
 		self.init(mutableProperty)
 	}
 }

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -364,7 +364,7 @@ class PropertySpec: QuickSpec {
 		describe("propertyOf") {
 			describe("from a Signal") {
 				it("should initially take on the supplied value") {
-					let property = Signal.never |> propertyOf(initialPropertyValue)
+					let property = PropertyOf(initialValue: initialPropertyValue, producer: Signal.never)
 					expect(property.value).to(equal(initialPropertyValue))
 				}
 			}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -360,6 +360,15 @@ class PropertySpec: QuickSpec {
 				}
 			}
 		}
+		
+		describe("propertyOf") {
+			describe("from a Signal") {
+				it("should initially take on the supplied value") {
+					let property = Signal.never |> propertyOf(initialPropertyValue)
+					expect(property.value).to(equal(initialPropertyValue))
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Reopening #2185 against `master`:

> I observed today that @neilpa and I have both written almost the same function propertyOf<T>(initialValue: T)(signal: Signal<T, NoError>) -> PropertyOf<T> in RAC3 projects. I've actually pasted it into two of my projects.

> This adds propertyOf to RAC, using @neilpa's documentation and function signature from Rex (which I prefer because it's curried for use with |>) and my implementation from Sukhasana (which I don't strongly prefer over @neilpa's).

> @jspahrsummers did once give some reasons for not including a function like this: https://reactivex.slack.com/archives/reactivecocoa/p1424118385000915

> This is currently crashing tests, possibly because of memory corruption introduced by @noescape.

@jspahrsummers said:
> Could this instead be a PropertyOf initializer?

To do:
- [x] Documentation for new functions/methods
- [x] More tests 
- [x] Separate issue and repro for the memory corruption issue