### PR TITLE
[WIP] Memory corruption

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -228,3 +228,19 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 public func <~ <Destination: MutablePropertyType, Source: PropertyType where Source.Value == Destination.Value>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }
+
+
+/// Creates a new property bound to `signal` starting with `initialValue`.
+public func propertyOf<T>(initialValue: T)(signal: Signal<T, NoError>) -> PropertyOf<T> {
+	let mutableProperty = MutableProperty(initialValue)
+	mutableProperty <~ signal
+	return PropertyOf(mutableProperty)
+}
+
+
+/// Creates a new property bound to `producer` starting with `initialValue`.
+public func propertyOf<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> PropertyOf<T> {
+	let mutableProperty = MutableProperty(initialValue)
+	mutableProperty <~ producer
+	return PropertyOf(mutableProperty)
+}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -228,4 +228,3 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 public func <~ <Destination: MutablePropertyType, Source: PropertyType where Source.Value == Destination.Value>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }
-

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -229,18 +229,3 @@ public func <~ <Destination: MutablePropertyType, Source: PropertyType where Sou
 	return destinationProperty <~ sourceProperty.producer
 }
 
-
-/// Creates a new property bound to `signal` starting with `initialValue`.
-public func propertyOf<T>(initialValue: T)(signal: Signal<T, NoError>) -> PropertyOf<T> {
-	let mutableProperty = MutableProperty(initialValue)
-	mutableProperty <~ signal
-	return PropertyOf(mutableProperty)
-}
-
-
-/// Creates a new property bound to `producer` starting with `initialValue`.
-public func propertyOf<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> PropertyOf<T> {
-	let mutableProperty = MutableProperty(initialValue)
-	mutableProperty <~ producer
-	return PropertyOf(mutableProperty)
-}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -369,8 +369,11 @@ class PropertySpec: QuickSpec {
 	}
 }
 
-func f<T>(initialValue: T)(producer: SignalProducer<T, NoError>) {
-	MutableProperty(initialValue)
+func f<T>(initialValue: T) -> SignalProducer<T, NoError> -> () {
+	return { _ in
+		MutableProperty(initialValue)
+		return ()
+	}
 }
 
 private class ObservableObject: NSObject {

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -361,15 +361,18 @@ class PropertySpec: QuickSpec {
 			}
 		}
 		
-		describe("propertyOf") {
-			describe("from a Signal") {
-				it("should initially take on the supplied value") {
-					let property = Signal.never |> propertyOf(initialPropertyValue)
-					expect(property.value).to(equal(initialPropertyValue))
-				}
+		describe("f") {
+			it("should not crash when used with `|>`") {
+				SignalProducer.never |> f(initialPropertyValue)
 			}
 		}
 	}
+}
+
+func f<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> PropertyOf<T> {
+	let mutableProperty = MutableProperty(initialValue)
+	mutableProperty <~ producer
+	return PropertyOf(mutableProperty)
 }
 
 private class ObservableObject: NSObject {

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -360,6 +360,15 @@ class PropertySpec: QuickSpec {
 				}
 			}
 		}
+		
+		describe("propertyOf") {
+			describe("from a Signal") {
+				it("should initially take on the supplied value") {
+					let property = Signal.never |> propertyOf(initialPropertyValue)
+					expect(property.value).to(equal(initialPropertyValue))
+				}
+			}
+		}
 	}
 }
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -369,10 +369,9 @@ class PropertySpec: QuickSpec {
 	}
 }
 
-func f<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> PropertyOf<T> {
+func f<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> SignalProducer<T, NoError> {
 	let mutableProperty = MutableProperty(initialValue)
-	mutableProperty <~ producer
-	return PropertyOf(mutableProperty)
+	return producer
 }
 
 private class ObservableObject: NSObject {

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -369,9 +369,8 @@ class PropertySpec: QuickSpec {
 	}
 }
 
-func f<T>(initialValue: T)(producer: SignalProducer<T, NoError>) -> SignalProducer<T, NoError> {
-	let mutableProperty = MutableProperty(initialValue)
-	return producer
+func f<T>(initialValue: T)(producer: SignalProducer<T, NoError>) {
+	MutableProperty(initialValue)
 }
 
 private class ObservableObject: NSObject {


### PR DESCRIPTION
While working on #2192, I accidentally wrote a test that crashes with memory corruption. In this branch, I'm trying to reduce the crashing test to understand what's going on.

So far, it seems like the prerequisites for the crash include defining a polymorphic, curried function and using `|>` to apply it to a `Signal` or `SignalProducer`. The fact that `a |> f(b)` triggers the crash while `f(b)(a)` does not led me to discover #1953, but I'm not sure yet that this is a `@noescape` issue.