### PR TITLE
Added framework for WatchOS

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" ~> 0.5
+github "antitypical/Result" "0.6-beta.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "a804949542eb2f299b823ffb36936aec54fe0db6"
 github "Quick/Quick" "e3c802be6c55710b39dba73caab9f234932c2ed7"
-github "antitypical/Result" "0.5"
+github "antitypical/Result" "932ac1aabf6d881ead74c4e6911d1271e95d2859"
 github "jspahrsummers/xcconfigs" "0.8.1"

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -9,6 +9,142 @@
 /* Begin PBXBuildFile section */
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
+		5AC32D511B5FF22B001FEF45 /* RACKVOChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648419EDA41200A782A9 /* RACKVOChannel.m */; };
+		5AC32D521B5FF22B001FEF45 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C54B11A69A2AC00AD8286 /* Signal.swift */; };
+		5AC32D551B5FF22B001FEF45 /* RACScopedDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D037649A19EDA41200A782A9 /* RACScopedDisposable.m */; };
+		5AC32D561B5FF22B001FEF45 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312BF19EF2A5800984962 /* Errors.swift */; };
+		5AC32D571B5FF22B001FEF45 /* NSEnumerator+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643519EDA41200A782A9 /* NSEnumerator+RACSequenceAdditions.m */; };
+		5AC32D591B5FF22B001FEF45 /* RACDynamicPropertySuperclass.m in Sources */ = {isa = PBXBuildFile; fileRef = D43F279F1A9F7E8A00C1AD76 /* RACDynamicPropertySuperclass.m */; };
+		5AC32D5A1B5FF22B001FEF45 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
+		5AC32D5B1B5FF22B001FEF45 /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037642B19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m */; };
+		5AC32D5C1B5FF22B001FEF45 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312BE19EF2A5800984962 /* Disposable.swift */; };
+		5AC32D5D1B5FF22B001FEF45 /* RACScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D037649619EDA41200A782A9 /* RACScheduler.m */; };
+		5AC32D5F1B5FF22B001FEF45 /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648219EDA41200A782A9 /* RACIndexSetSequence.m */; };
+		5AC32D601B5FF22B001FEF45 /* RACSignal+Operations.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764A219EDA41200A782A9 /* RACSignal+Operations.m */; };
+		5AC32D621B5FF22B001FEF45 /* NSFileHandle+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643719EDA41200A782A9 /* NSFileHandle+RACSupport.m */; };
+		5AC32D631B5FF22B001FEF45 /* SignalProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C54B21A69A2AC00AD8286 /* SignalProducer.swift */; };
+		5AC32D641B5FF22B001FEF45 /* RACStream.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764A719EDA41200A782A9 /* RACStream.m */; };
+		5AC32D651B5FF22B001FEF45 /* RACBehaviorSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = D037646119EDA41200A782A9 /* RACBehaviorSubject.m */; };
+		5AC32D671B5FF22B001FEF45 /* RACTestScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764B719EDA41200A782A9 /* RACTestScheduler.m */; };
+		5AC32D681B5FF22B001FEF45 /* RACReplaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = D037649219EDA41200A782A9 /* RACReplaySubject.m */; };
+		5AC32D691B5FF22B001FEF45 /* RACSubject.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764AC19EDA41200A782A9 /* RACSubject.m */; };
+		5AC32D6B1B5FF22B001FEF45 /* RACSerialDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D037649E19EDA41200A782A9 /* RACSerialDisposable.m */; };
+		5AC32D6D1B5FF22B001FEF45 /* NSString+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D037645519EDA41200A782A9 /* NSString+RACSupport.m */; };
+		5AC32D6E1B5FF22B001FEF45 /* NSString+RACKeyPathUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D037645119EDA41200A782A9 /* NSString+RACKeyPathUtilities.m */; };
+		5AC32D6F1B5FF22B001FEF45 /* NSDictionary+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643319EDA41200A782A9 /* NSDictionary+RACSequenceAdditions.m */; };
+		5AC32D701B5FF22B001FEF45 /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D037646A19EDA41200A782A9 /* RACCompoundDisposableProvider.d */; };
+		5AC32D711B5FF22B001FEF45 /* NSString+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037645319EDA41200A782A9 /* NSString+RACSequenceAdditions.m */; };
+		5AC32D731B5FF22B001FEF45 /* RACStringSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764AA19EDA41200A782A9 /* RACStringSequence.m */; };
+		5AC32D741B5FF22B001FEF45 /* RACTupleSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764BB19EDA41200A782A9 /* RACTupleSequence.m */; };
+		5AC32D751B5FF22B001FEF45 /* RACSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764A019EDA41200A782A9 /* RACSignal.m */; };
+		5AC32D781B5FF22B001FEF45 /* NSObject+RACDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644319EDA41200A782A9 /* NSObject+RACDescription.m */; };
+		5AC32D791B5FF22B001FEF45 /* RACMulticastConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648819EDA41200A782A9 /* RACMulticastConnection.m */; };
+		5AC32D7A1B5FF22B001FEF45 /* RACArraySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D037645D19EDA41200A782A9 /* RACArraySequence.m */; };
+		5AC32D7B1B5FF22B001FEF45 /* NSObject+RACLifting.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644719EDA41200A782A9 /* NSObject+RACLifting.m */; };
+		5AC32D7C1B5FF22B001FEF45 /* NSIndexSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643919EDA41200A782A9 /* NSIndexSet+RACSequenceAdditions.m */; };
+		5AC32D7E1B5FF22B001FEF45 /* NSNotificationCenter+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643D19EDA41200A782A9 /* NSNotificationCenter+RACSupport.m */; };
+		5AC32D7F1B5FF22B001FEF45 /* RACSubscriptionScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764B319EDA41200A782A9 /* RACSubscriptionScheduler.m */; };
+		5AC32D801B5FF22B001FEF45 /* RACEmptySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647619EDA41200A782A9 /* RACEmptySequence.m */; };
+		5AC32D811B5FF22B001FEF45 /* RACObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648B19EDA41200A782A9 /* RACObjCRuntime.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		5AC32D821B5FF22B001FEF45 /* ObjectiveCBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312C419EF2A5800984962 /* ObjectiveCBridging.swift */; };
+		5AC32D831B5FF22B001FEF45 /* NSUserDefaults+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D037645B19EDA41200A782A9 /* NSUserDefaults+RACSupport.m */; };
+		5AC32D841B5FF22B001FEF45 /* RACUnarySequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764BD19EDA41200A782A9 /* RACUnarySequence.m */; };
+		5AC32D851B5FF22B001FEF45 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C54B01A69A2AC00AD8286 /* Property.swift */; };
+		5AC32D861B5FF22B001FEF45 /* RACTargetQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764B519EDA41200A782A9 /* RACTargetQueueScheduler.m */; };
+		5AC32D871B5FF22B001FEF45 /* RACSignalSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764A519EDA41200A782A9 /* RACSignalSequence.m */; };
+		5AC32D881B5FF22B001FEF45 /* RACDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = D037646C19EDA41200A782A9 /* RACDelegateProxy.m */; };
+		5AC32D891B5FF22B001FEF45 /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03B4A3C19F4C39A009E02AC /* FoundationExtensions.swift */; };
+		5AC32D8A1B5FF22B001FEF45 /* RACDynamicSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647019EDA41200A782A9 /* RACDynamicSequence.m */; };
+		5AC32D8B1B5FF22B001FEF45 /* RACDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D037646E19EDA41200A782A9 /* RACDisposable.m */; };
+		5AC32D8C1B5FF22B001FEF45 /* TupleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00004081A46864E000E7D41 /* TupleExtensions.swift */; };
+		5AC32D8D1B5FF22B001FEF45 /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D03764A319EDA41200A782A9 /* RACSignalProvider.d */; };
+		5AC32D8E1B5FF22B001FEF45 /* NSSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644F19EDA41200A782A9 /* NSSet+RACSequenceAdditions.m */; };
+		5AC32D911B5FF22B001FEF45 /* RACCompoundDisposable.m in Sources */ = {isa = PBXBuildFile; fileRef = D037646919EDA41200A782A9 /* RACCompoundDisposable.m */; };
+		5AC32D921B5FF22B001FEF45 /* RACBlockTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = D037646319EDA41200A782A9 /* RACBlockTrampoline.m */; };
+		5AC32D931B5FF22B001FEF45 /* RACGroupedSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647E19EDA41200A782A9 /* RACGroupedSignal.m */; };
+		5AC32D941B5FF22B001FEF45 /* RACChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = D037646519EDA41200A782A9 /* RACChannel.m */; };
+		5AC32D951B5FF22B001FEF45 /* RACEagerSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647419EDA41200A782A9 /* RACEagerSequence.m */; };
+		5AC32D961B5FF22B001FEF45 /* RACDynamicSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647219EDA41200A782A9 /* RACDynamicSignal.m */; };
+		5AC32D971B5FF22B001FEF45 /* RACImmediateScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648019EDA41200A782A9 /* RACImmediateScheduler.m */; };
+		5AC32D981B5FF22B001FEF45 /* NSObject+RACDeallocating.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644119EDA41200A782A9 /* NSObject+RACDeallocating.m */; };
+		5AC32D991B5FF22B001FEF45 /* RACEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647819EDA41200A782A9 /* RACEmptySignal.m */; };
+		5AC32D9B1B5FF22B001FEF45 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C54B51A69A3DB00AD8286 /* Event.swift */; };
+		5AC32D9C1B5FF22B001FEF45 /* NSURLConnection+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D037645919EDA41200A782A9 /* NSURLConnection+RACSupport.m */; };
+		5AC32D9D1B5FF22B001FEF45 /* RACSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764AE19EDA41200A782A9 /* RACSubscriber.m */; };
+		5AC32D9E1B5FF22B001FEF45 /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643119EDA41200A782A9 /* NSData+RACSupport.m */; };
+		5AC32D9F1B5FF22B001FEF45 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312BB19EF2A5800984962 /* Atomic.swift */; };
+		5AC32DA01B5FF22B001FEF45 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312C819EF2A5800984962 /* Scheduler.swift */; };
+		5AC32DA11B5FF22B001FEF45 /* RACCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = D037646719EDA41200A782A9 /* RACCommand.m */; };
+		5AC32DA21B5FF22B001FEF45 /* RACErrorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647A19EDA41200A782A9 /* RACErrorSignal.m */; };
+		5AC32DA31B5FF22B001FEF45 /* RACSubscriptingAssignmentTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764B119EDA41200A782A9 /* RACSubscriptingAssignmentTrampoline.m */; };
+		5AC32DA41B5FF22B001FEF45 /* RACUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764BF19EDA41200A782A9 /* RACUnit.m */; };
+		5AC32DA61B5FF22B001FEF45 /* RACKVOTrampoline.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648619EDA41200A782A9 /* RACKVOTrampoline.m */; };
+		5AC32DA81B5FF22B001FEF45 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312BC19EF2A5800984962 /* Bag.swift */; };
+		5AC32DA91B5FF22B001FEF45 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C54AF1A69A2AC00AD8286 /* Action.swift */; };
+		5AC32DAA1B5FF22B001FEF45 /* NSInvocation+RACTypeParsing.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643B19EDA41200A782A9 /* NSInvocation+RACTypeParsing.m */; };
+		5AC32DAB1B5FF22B001FEF45 /* RACTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764B919EDA41200A782A9 /* RACTuple.m */; };
+		5AC32DAC1B5FF22B001FEF45 /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037666819EDA57100A782A9 /* EXTRuntimeExtensions.m */; };
+		5AC32DAD1B5FF22B001FEF45 /* NSObject+RACKVOWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644519EDA41200A782A9 /* NSObject+RACKVOWrapper.m */; };
+		5AC32DAE1B5FF22B001FEF45 /* RACValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764C119EDA41200A782A9 /* RACValueTransformer.m */; };
+		5AC32DAF1B5FF22B001FEF45 /* RACSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D037649C19EDA41200A782A9 /* RACSequence.m */; };
+		5AC32DB11B5FF22B001FEF45 /* NSOrderedSet+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644D19EDA41200A782A9 /* NSOrderedSet+RACSequenceAdditions.m */; };
+		5AC32DB31B5FF22B001FEF45 /* NSObject+RACPropertySubscribing.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644919EDA41200A782A9 /* NSObject+RACPropertySubscribing.m */; };
+		5AC32DB41B5FF22B001FEF45 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */; };
+		5AC32DB51B5FF22B001FEF45 /* RACEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = D037647C19EDA41200A782A9 /* RACEvent.m */; };
+		5AC32DB61B5FF22B001FEF45 /* RACQueueScheduler.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648F19EDA41200A782A9 /* RACQueueScheduler.m */; };
+		5AC32DB81B5FF22B001FEF45 /* NSObject+RACSelectorSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D037644B19EDA41200A782A9 /* NSObject+RACSelectorSignal.m */; };
+		5AC32DB91B5FF22B001FEF45 /* RACPassthroughSubscriber.m in Sources */ = {isa = PBXBuildFile; fileRef = D037648D19EDA41200A782A9 /* RACPassthroughSubscriber.m */; };
+		5AC32DBA1B5FF22B001FEF45 /* RACReturnSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = D037649419EDA41200A782A9 /* RACReturnSignal.m */; };
+		5AC32DBC1B5FF22B001FEF45 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
+		5AC32DBF1B5FF22B001FEF45 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DC01B5FF22B001FEF45 /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644819EDA41200A782A9 /* NSObject+RACPropertySubscribing.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DC11B5FF22B001FEF45 /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648E19EDA41200A782A9 /* RACQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DC31B5FF22B001FEF45 /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646019EDA41200A782A9 /* RACBehaviorSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DC41B5FF22B001FEF45 /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B619EDA41200A782A9 /* RACTestScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DC51B5FF22B001FEF45 /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648719EDA41200A782A9 /* RACMulticastConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DC61B5FF22B001FEF45 /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649119EDA41200A782A9 /* RACReplaySubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DC81B5FF22B001FEF45 /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646D19EDA41200A782A9 /* RACDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DCA1B5FF22B001FEF45 /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645819EDA41200A782A9 /* NSURLConnection+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DCC1B5FF22B001FEF45 /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643C19EDA41200A782A9 /* NSNotificationCenter+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DCD1B5FF22B001FEF45 /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643619EDA41200A782A9 /* NSFileHandle+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DCF1B5FF22B001FEF45 /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648319EDA41200A782A9 /* RACKVOChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD01B5FF22B001FEF45 /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644C19EDA41200A782A9 /* NSOrderedSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD11B5FF22B001FEF45 /* NSDictionary+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643219EDA41200A782A9 /* NSDictionary+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD21B5FF22B001FEF45 /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666919EDA57100A782A9 /* EXTScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD41B5FF22B001FEF45 /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666A19EDA57100A782A9 /* metamacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD51B5FF22B001FEF45 /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643419EDA41200A782A9 /* NSEnumerator+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD61B5FF22B001FEF45 /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644619EDA41200A782A9 /* NSObject+RACLifting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD81B5FF22B001FEF45 /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646819EDA41200A782A9 /* RACCompoundDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DD91B5FF22B001FEF45 /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645419EDA41200A782A9 /* NSString+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DDB1B5FF22B001FEF45 /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B819EDA41200A782A9 /* RACTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DDD1B5FF22B001FEF45 /* NSData+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643019EDA41200A782A9 /* NSData+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DDE1B5FF22B001FEF45 /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645219EDA41200A782A9 /* NSString+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DDF1B5FF22B001FEF45 /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644019EDA41200A782A9 /* NSObject+RACDeallocating.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE01B5FF22B001FEF45 /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647D19EDA41200A782A9 /* RACGroupedSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE11B5FF22B001FEF45 /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649819EDA41200A782A9 /* RACScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE21B5FF22B001FEF45 /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764A619EDA41200A782A9 /* RACStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE31B5FF22B001FEF45 /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764A119EDA41200A782A9 /* RACSignal+Operations.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE61B5FF22B001FEF45 /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649519EDA41200A782A9 /* RACScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE71B5FF22B001FEF45 /* RACDynamicPropertySuperclass.h in Headers */ = {isa = PBXBuildFile; fileRef = D43F279E1A9F7E8A00C1AD76 /* RACDynamicPropertySuperclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE81B5FF22B001FEF45 /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037642A19EDA41200A782A9 /* NSArray+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DE91B5FF22B001FEF45 /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645A19EDA41200A782A9 /* NSUserDefaults+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DEB1B5FF22B001FEF45 /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644E19EDA41200A782A9 /* NSSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DEC1B5FF22B001FEF45 /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649B19EDA41200A782A9 /* RACSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DEE1B5FF22B001FEF45 /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666619EDA57100A782A9 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DEF1B5FF22B001FEF45 /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647B19EDA41200A782A9 /* RACEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF01B5FF22B001FEF45 /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649D19EDA41200A782A9 /* RACSerialDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF11B5FF22B001FEF45 /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643819EDA41200A782A9 /* NSIndexSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF21B5FF22B001FEF45 /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646419EDA41200A782A9 /* RACChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF31B5FF22B001FEF45 /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649019EDA41200A782A9 /* RACQueueScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF61B5FF22B001FEF45 /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644A19EDA41200A782A9 /* NSObject+RACSelectorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF71B5FF22B001FEF45 /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649F19EDA41200A782A9 /* RACSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF81B5FF22B001FEF45 /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B019EDA41200A782A9 /* RACSubscriptingAssignmentTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DF91B5FF22B001FEF45 /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649919EDA41200A782A9 /* RACScopedDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DFA1B5FF22B001FEF45 /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764BE19EDA41200A782A9 /* RACUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DFB1B5FF22B001FEF45 /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B419EDA41200A782A9 /* RACTargetQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32DFF1B5FF22B001FEF45 /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764AB19EDA41200A782A9 /* RACSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32E001B5FF22B001FEF45 /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646619EDA41200A782A9 /* RACCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5AC32E011B5FF22B001FEF45 /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764AD19EDA41200A782A9 /* RACSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7A7065811A3F88B8001E8354 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */; };
 		7A7065821A3F88B8001E8354 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */; };
 		7A7065841A3F8967001E8354 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */; };
@@ -490,6 +626,7 @@
 /* Begin PBXFileReference section */
 		314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		5AC32E081B5FF22B001FEF45 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7A70657D1A3F88B8001E8354 /* RACKVOProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACKVOProxy.h; sourceTree = "<group>"; };
 		7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxy.m; sourceTree = "<group>"; };
 		7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxySpec.m; sourceTree = "<group>"; };
@@ -807,6 +944,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5AC32DBB1B5FF22B001FEF45 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AC32DBC1B5FF22B001FEF45 /* Result.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D04725E619E49ED7006002AA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1175,6 +1320,7 @@
 				D04725F519E49ED7006002AA /* ReactiveCocoa-MacTests.xctest */,
 				D047260C19E49F82006002AA /* ReactiveCocoa.framework */,
 				D047261619E49F82006002AA /* ReactiveCocoa-iOSTests.xctest */,
+				5AC32E081B5FF22B001FEF45 /* ReactiveCocoa.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1326,6 +1472,62 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		5AC32DBD1B5FF22B001FEF45 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AC32DBF1B5FF22B001FEF45 /* ReactiveCocoa.h in Headers */,
+				5AC32DC01B5FF22B001FEF45 /* NSObject+RACPropertySubscribing.h in Headers */,
+				5AC32DC11B5FF22B001FEF45 /* RACQueueScheduler.h in Headers */,
+				5AC32DC31B5FF22B001FEF45 /* RACBehaviorSubject.h in Headers */,
+				5AC32DC41B5FF22B001FEF45 /* RACTestScheduler.h in Headers */,
+				5AC32DC51B5FF22B001FEF45 /* RACMulticastConnection.h in Headers */,
+				5AC32DC61B5FF22B001FEF45 /* RACReplaySubject.h in Headers */,
+				5AC32DC81B5FF22B001FEF45 /* RACDisposable.h in Headers */,
+				5AC32DCA1B5FF22B001FEF45 /* NSURLConnection+RACSupport.h in Headers */,
+				5AC32DCC1B5FF22B001FEF45 /* NSNotificationCenter+RACSupport.h in Headers */,
+				5AC32DCD1B5FF22B001FEF45 /* NSFileHandle+RACSupport.h in Headers */,
+				5AC32DCF1B5FF22B001FEF45 /* RACKVOChannel.h in Headers */,
+				5AC32DD01B5FF22B001FEF45 /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
+				5AC32DD11B5FF22B001FEF45 /* NSDictionary+RACSequenceAdditions.h in Headers */,
+				5AC32DD21B5FF22B001FEF45 /* EXTScope.h in Headers */,
+				5AC32DD41B5FF22B001FEF45 /* metamacros.h in Headers */,
+				5AC32DD51B5FF22B001FEF45 /* NSEnumerator+RACSequenceAdditions.h in Headers */,
+				5AC32DD61B5FF22B001FEF45 /* NSObject+RACLifting.h in Headers */,
+				5AC32DD81B5FF22B001FEF45 /* RACCompoundDisposable.h in Headers */,
+				5AC32DD91B5FF22B001FEF45 /* NSString+RACSupport.h in Headers */,
+				5AC32DDB1B5FF22B001FEF45 /* RACTuple.h in Headers */,
+				5AC32DDD1B5FF22B001FEF45 /* NSData+RACSupport.h in Headers */,
+				5AC32DDE1B5FF22B001FEF45 /* NSString+RACSequenceAdditions.h in Headers */,
+				5AC32DDF1B5FF22B001FEF45 /* NSObject+RACDeallocating.h in Headers */,
+				5AC32DE01B5FF22B001FEF45 /* RACGroupedSignal.h in Headers */,
+				5AC32DE11B5FF22B001FEF45 /* RACScheduler+Subclass.h in Headers */,
+				5AC32DE21B5FF22B001FEF45 /* RACStream.h in Headers */,
+				5AC32DE31B5FF22B001FEF45 /* RACSignal+Operations.h in Headers */,
+				5AC32DE61B5FF22B001FEF45 /* RACScheduler.h in Headers */,
+				5AC32DE71B5FF22B001FEF45 /* RACDynamicPropertySuperclass.h in Headers */,
+				5AC32DE81B5FF22B001FEF45 /* NSArray+RACSequenceAdditions.h in Headers */,
+				5AC32DE91B5FF22B001FEF45 /* NSUserDefaults+RACSupport.h in Headers */,
+				5AC32DEB1B5FF22B001FEF45 /* NSSet+RACSequenceAdditions.h in Headers */,
+				5AC32DEC1B5FF22B001FEF45 /* RACSequence.h in Headers */,
+				5AC32DEE1B5FF22B001FEF45 /* EXTKeyPathCoding.h in Headers */,
+				5AC32DEF1B5FF22B001FEF45 /* RACEvent.h in Headers */,
+				5AC32DF01B5FF22B001FEF45 /* RACSerialDisposable.h in Headers */,
+				5AC32DF11B5FF22B001FEF45 /* NSIndexSet+RACSequenceAdditions.h in Headers */,
+				5AC32DF21B5FF22B001FEF45 /* RACChannel.h in Headers */,
+				5AC32DF31B5FF22B001FEF45 /* RACQueueScheduler+Subclass.h in Headers */,
+				5AC32DF61B5FF22B001FEF45 /* NSObject+RACSelectorSignal.h in Headers */,
+				5AC32DF71B5FF22B001FEF45 /* RACSignal.h in Headers */,
+				5AC32DF81B5FF22B001FEF45 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
+				5AC32DF91B5FF22B001FEF45 /* RACScopedDisposable.h in Headers */,
+				5AC32DFA1B5FF22B001FEF45 /* RACUnit.h in Headers */,
+				5AC32DFB1B5FF22B001FEF45 /* RACTargetQueueScheduler.h in Headers */,
+				5AC32DFF1B5FF22B001FEF45 /* RACSubject.h in Headers */,
+				5AC32E001B5FF22B001FEF45 /* RACCommand.h in Headers */,
+				5AC32E011B5FF22B001FEF45 /* RACSubscriber.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D04725E719E49ED7006002AA /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1464,6 +1666,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		5AC32D4F1B5FF22B001FEF45 /* ReactiveCocoa-WatchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5AC32E031B5FF22B001FEF45 /* Build configuration list for PBXNativeTarget "ReactiveCocoa-WatchOS" */;
+			buildPhases = (
+				5AC32D501B5FF22B001FEF45 /* Sources */,
+				5AC32DBB1B5FF22B001FEF45 /* Frameworks */,
+				5AC32DBD1B5FF22B001FEF45 /* Headers */,
+				5AC32E021B5FF22B001FEF45 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ReactiveCocoa-WatchOS";
+			productName = ReactiveCocoa;
+			productReference = 5AC32E081B5FF22B001FEF45 /* ReactiveCocoa.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D04725E919E49ED7006002AA /* ReactiveCocoa-Mac */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D047260019E49ED7006002AA /* Build configuration list for PBXNativeTarget "ReactiveCocoa-Mac" */;
@@ -1577,11 +1797,19 @@
 				D04725F419E49ED7006002AA /* ReactiveCocoa-MacTests */,
 				D047260B19E49F82006002AA /* ReactiveCocoa-iOS */,
 				D047261519E49F82006002AA /* ReactiveCocoa-iOSTests */,
+				5AC32D4F1B5FF22B001FEF45 /* ReactiveCocoa-WatchOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5AC32E021B5FF22B001FEF45 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D04725E819E49ED7006002AA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1615,6 +1843,99 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		5AC32D501B5FF22B001FEF45 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AC32D511B5FF22B001FEF45 /* RACKVOChannel.m in Sources */,
+				5AC32D521B5FF22B001FEF45 /* Signal.swift in Sources */,
+				5AC32D551B5FF22B001FEF45 /* RACScopedDisposable.m in Sources */,
+				5AC32D561B5FF22B001FEF45 /* Errors.swift in Sources */,
+				5AC32D571B5FF22B001FEF45 /* NSEnumerator+RACSequenceAdditions.m in Sources */,
+				5AC32D591B5FF22B001FEF45 /* RACDynamicPropertySuperclass.m in Sources */,
+				5AC32D5A1B5FF22B001FEF45 /* Optional.swift in Sources */,
+				5AC32D5B1B5FF22B001FEF45 /* NSArray+RACSequenceAdditions.m in Sources */,
+				5AC32D5C1B5FF22B001FEF45 /* Disposable.swift in Sources */,
+				5AC32D5D1B5FF22B001FEF45 /* RACScheduler.m in Sources */,
+				5AC32D5F1B5FF22B001FEF45 /* RACIndexSetSequence.m in Sources */,
+				5AC32D601B5FF22B001FEF45 /* RACSignal+Operations.m in Sources */,
+				5AC32D621B5FF22B001FEF45 /* NSFileHandle+RACSupport.m in Sources */,
+				5AC32D631B5FF22B001FEF45 /* SignalProducer.swift in Sources */,
+				5AC32D641B5FF22B001FEF45 /* RACStream.m in Sources */,
+				5AC32D651B5FF22B001FEF45 /* RACBehaviorSubject.m in Sources */,
+				5AC32D671B5FF22B001FEF45 /* RACTestScheduler.m in Sources */,
+				5AC32D681B5FF22B001FEF45 /* RACReplaySubject.m in Sources */,
+				5AC32D691B5FF22B001FEF45 /* RACSubject.m in Sources */,
+				5AC32D6B1B5FF22B001FEF45 /* RACSerialDisposable.m in Sources */,
+				5AC32D6D1B5FF22B001FEF45 /* NSString+RACSupport.m in Sources */,
+				5AC32D6E1B5FF22B001FEF45 /* NSString+RACKeyPathUtilities.m in Sources */,
+				5AC32D6F1B5FF22B001FEF45 /* NSDictionary+RACSequenceAdditions.m in Sources */,
+				5AC32D701B5FF22B001FEF45 /* RACCompoundDisposableProvider.d in Sources */,
+				5AC32D711B5FF22B001FEF45 /* NSString+RACSequenceAdditions.m in Sources */,
+				5AC32D731B5FF22B001FEF45 /* RACStringSequence.m in Sources */,
+				5AC32D741B5FF22B001FEF45 /* RACTupleSequence.m in Sources */,
+				5AC32D751B5FF22B001FEF45 /* RACSignal.m in Sources */,
+				5AC32D781B5FF22B001FEF45 /* NSObject+RACDescription.m in Sources */,
+				5AC32D791B5FF22B001FEF45 /* RACMulticastConnection.m in Sources */,
+				5AC32D7A1B5FF22B001FEF45 /* RACArraySequence.m in Sources */,
+				5AC32D7B1B5FF22B001FEF45 /* NSObject+RACLifting.m in Sources */,
+				5AC32D7C1B5FF22B001FEF45 /* NSIndexSet+RACSequenceAdditions.m in Sources */,
+				5AC32D7E1B5FF22B001FEF45 /* NSNotificationCenter+RACSupport.m in Sources */,
+				5AC32D7F1B5FF22B001FEF45 /* RACSubscriptionScheduler.m in Sources */,
+				5AC32D801B5FF22B001FEF45 /* RACEmptySequence.m in Sources */,
+				5AC32D811B5FF22B001FEF45 /* RACObjCRuntime.m in Sources */,
+				5AC32D821B5FF22B001FEF45 /* ObjectiveCBridging.swift in Sources */,
+				5AC32D831B5FF22B001FEF45 /* NSUserDefaults+RACSupport.m in Sources */,
+				5AC32D841B5FF22B001FEF45 /* RACUnarySequence.m in Sources */,
+				5AC32D851B5FF22B001FEF45 /* Property.swift in Sources */,
+				5AC32D861B5FF22B001FEF45 /* RACTargetQueueScheduler.m in Sources */,
+				5AC32D871B5FF22B001FEF45 /* RACSignalSequence.m in Sources */,
+				5AC32D881B5FF22B001FEF45 /* RACDelegateProxy.m in Sources */,
+				5AC32D891B5FF22B001FEF45 /* FoundationExtensions.swift in Sources */,
+				5AC32D8A1B5FF22B001FEF45 /* RACDynamicSequence.m in Sources */,
+				5AC32D8B1B5FF22B001FEF45 /* RACDisposable.m in Sources */,
+				5AC32D8C1B5FF22B001FEF45 /* TupleExtensions.swift in Sources */,
+				5AC32D8D1B5FF22B001FEF45 /* RACSignalProvider.d in Sources */,
+				5AC32D8E1B5FF22B001FEF45 /* NSSet+RACSequenceAdditions.m in Sources */,
+				5AC32D911B5FF22B001FEF45 /* RACCompoundDisposable.m in Sources */,
+				5AC32D921B5FF22B001FEF45 /* RACBlockTrampoline.m in Sources */,
+				5AC32D931B5FF22B001FEF45 /* RACGroupedSignal.m in Sources */,
+				5AC32D941B5FF22B001FEF45 /* RACChannel.m in Sources */,
+				5AC32D951B5FF22B001FEF45 /* RACEagerSequence.m in Sources */,
+				5AC32D961B5FF22B001FEF45 /* RACDynamicSignal.m in Sources */,
+				5AC32D971B5FF22B001FEF45 /* RACImmediateScheduler.m in Sources */,
+				5AC32D981B5FF22B001FEF45 /* NSObject+RACDeallocating.m in Sources */,
+				5AC32D991B5FF22B001FEF45 /* RACEmptySignal.m in Sources */,
+				5AC32D9B1B5FF22B001FEF45 /* Event.swift in Sources */,
+				5AC32D9C1B5FF22B001FEF45 /* NSURLConnection+RACSupport.m in Sources */,
+				5AC32D9D1B5FF22B001FEF45 /* RACSubscriber.m in Sources */,
+				5AC32D9E1B5FF22B001FEF45 /* NSData+RACSupport.m in Sources */,
+				5AC32D9F1B5FF22B001FEF45 /* Atomic.swift in Sources */,
+				5AC32DA01B5FF22B001FEF45 /* Scheduler.swift in Sources */,
+				5AC32DA11B5FF22B001FEF45 /* RACCommand.m in Sources */,
+				5AC32DA21B5FF22B001FEF45 /* RACErrorSignal.m in Sources */,
+				5AC32DA31B5FF22B001FEF45 /* RACSubscriptingAssignmentTrampoline.m in Sources */,
+				5AC32DA41B5FF22B001FEF45 /* RACUnit.m in Sources */,
+				5AC32DA61B5FF22B001FEF45 /* RACKVOTrampoline.m in Sources */,
+				5AC32DA81B5FF22B001FEF45 /* Bag.swift in Sources */,
+				5AC32DA91B5FF22B001FEF45 /* Action.swift in Sources */,
+				5AC32DAA1B5FF22B001FEF45 /* NSInvocation+RACTypeParsing.m in Sources */,
+				5AC32DAB1B5FF22B001FEF45 /* RACTuple.m in Sources */,
+				5AC32DAC1B5FF22B001FEF45 /* EXTRuntimeExtensions.m in Sources */,
+				5AC32DAD1B5FF22B001FEF45 /* NSObject+RACKVOWrapper.m in Sources */,
+				5AC32DAE1B5FF22B001FEF45 /* RACValueTransformer.m in Sources */,
+				5AC32DAF1B5FF22B001FEF45 /* RACSequence.m in Sources */,
+				5AC32DB11B5FF22B001FEF45 /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
+				5AC32DB31B5FF22B001FEF45 /* NSObject+RACPropertySubscribing.m in Sources */,
+				5AC32DB41B5FF22B001FEF45 /* RACKVOProxy.m in Sources */,
+				5AC32DB51B5FF22B001FEF45 /* RACEvent.m in Sources */,
+				5AC32DB61B5FF22B001FEF45 /* RACQueueScheduler.m in Sources */,
+				5AC32DB81B5FF22B001FEF45 /* NSObject+RACSelectorSignal.m in Sources */,
+				5AC32DB91B5FF22B001FEF45 /* RACPassthroughSubscriber.m in Sources */,
+				5AC32DBA1B5FF22B001FEF45 /* RACReturnSignal.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D04725E519E49ED7006002AA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1967,6 +2288,86 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		5AC32E041B5FF22B001FEF45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"DTRACE_PROBES_DISABLED=1",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = watchos;
+				USER_HEADER_SEARCH_PATHS = ReactiveCocoa/extobjc;
+			};
+			name = Debug;
+		};
+		5AC32E051B5FF22B001FEF45 /* Test */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"DTRACE_PROBES_DISABLED=1",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = watchos;
+				USER_HEADER_SEARCH_PATHS = ReactiveCocoa/extobjc;
+			};
+			name = Test;
+		};
+		5AC32E061B5FF22B001FEF45 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NDEBUG=1",
+					"DTRACE_PROBES_DISABLED=1",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = watchos;
+				USER_HEADER_SEARCH_PATHS = ReactiveCocoa/extobjc;
+			};
+			name = Release;
+		};
+		5AC32E071B5FF22B001FEF45 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"NDEBUG=1",
+					"DTRACE_PROBES_DISABLED=1",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = watchos;
+				USER_HEADER_SEARCH_PATHS = ReactiveCocoa/extobjc;
+			};
+			name = Profile;
+		};
 		D04725FE19E49ED7006002AA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047262919E49FE8006002AA /* Debug.xcconfig */;
@@ -2250,6 +2651,17 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5AC32E031B5FF22B001FEF45 /* Build configuration list for PBXNativeTarget "ReactiveCocoa-WatchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5AC32E041B5FF22B001FEF45 /* Debug */,
+				5AC32E051B5FF22B001FEF45 /* Test */,
+				5AC32E061B5FF22B001FEF45 /* Release */,
+				5AC32E071B5FF22B001FEF45 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D04725E419E49ED7006002AA /* Build configuration list for PBXProject "ReactiveCocoa" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-WatchOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-WatchOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5AC32D4F1B5FF22B001FEF45"
+               BuildableName = "ReactiveCocoa.framework"
+               BlueprintName = "ReactiveCocoa-WatchOS"
+               ReferencedContainer = "container:ReactiveCocoa.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5AC32E0A1B5FF22E001FEF45"
+               BuildableName = "ReactiveCocoa-WatchOSTests.xctest"
+               BlueprintName = "ReactiveCocoa-WatchOSTests"
+               ReferencedContainer = "container:ReactiveCocoa.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5AC32D4F1B5FF22B001FEF45"
+            BuildableName = "ReactiveCocoa.framework"
+            BlueprintName = "ReactiveCocoa-WatchOS"
+            ReferencedContainer = "container:ReactiveCocoa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5AC32D4F1B5FF22B001FEF45"
+            BuildableName = "ReactiveCocoa.framework"
+            BlueprintName = "ReactiveCocoa-WatchOS"
+            ReferencedContainer = "container:ReactiveCocoa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5AC32D4F1B5FF22B001FEF45"
+            BuildableName = "ReactiveCocoa.framework"
+            BlueprintName = "ReactiveCocoa-WatchOS"
+            ReferencedContainer = "container:ReactiveCocoa.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoa/ReactiveCocoa.h
@@ -62,7 +62,8 @@ FOUNDATION_EXPORT const unsigned char ReactiveCocoaVersionString[];
 #import <ReactiveCocoa/RACTuple.h>
 #import <ReactiveCocoa/RACUnit.h>
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if TARGET_OS_WATCH
+#elif TARGET_OS_IOS
 	#import <ReactiveCocoa/MKAnnotationView+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIActionSheet+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIAlertView+RACSignalSupport.h>

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1020,9 +1020,9 @@ extension SignalProducerType {
 					result = nil
 					return
 				}
-				result = .success(value)
+				result = .Success(value)
 			}, error: { error in
-				result = .failure(error)
+				result = .Failure(error)
 				dispatch_semaphore_signal(semaphore)
 			}, completed: {
 				dispatch_semaphore_signal(semaphore)
@@ -1043,7 +1043,7 @@ extension SignalProducerType {
 	/// Starts the producer, then blocks, waiting for completion.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func wait() -> Result<(), E> {
-		return then(SignalProducer<(), E>(value: ())).last() ?? .success(())
+		return then(SignalProducer<(), E>(value: ())).last() ?? .Success(())
 	}
 }
 

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -92,7 +92,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					var subscriptions = 0
 
 					let producer = SignalProducer<NSNumber, NoError>.attempt {
-						return .success(subscriptions++)
+						return .Success(subscriptions++)
 					}
 					let racSignal = toRACSignal(producer)
 

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -1071,7 +1071,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should forward original values upon success") {
 				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attempt { _ in
-					return .success()
+					return .Success()
 				}
 				
 				var current: Int?
@@ -1088,7 +1088,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should error if an attempt fails") {
 				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attempt { _ in
-					return .failure(.Default)
+					return .Failure(.Default)
 				}
 				
 				var error: TestError?
@@ -1105,7 +1105,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should forward mapped values upon success") {
 				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attemptMap { num -> Result<Bool, TestError> in
-					return .success(num % 2 == 0)
+					return .Success(num % 2 == 0)
 				}
 				
 				var even: Bool?
@@ -1123,7 +1123,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should error if a mapping fails") {
 				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attemptMap { _ -> Result<Bool, TestError> in
-					return .failure(.Default)
+					return .Failure(.Default)
 				}
 				
 				var error: TestError?

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -141,7 +141,7 @@ class SignalProducerSpec: QuickSpec {
 		describe("init(result:)") {
 			it("should immediately send the value then complete") {
 				let producerValue = "StringValue"
-				let producerResult = .success(producerValue) as Result<String, NSError>
+				let producerResult = .Success(producerValue) as Result<String, NSError>
 				let signalProducer = SignalProducer(result: producerResult)
 
 				expect(signalProducer).to(sendValue(producerValue, sendError: nil, complete: true))
@@ -149,7 +149,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should immediately send the error") {
 				let producerError = NSError(domain: "com.reactivecocoa.errordomain", code: 4815, userInfo: nil)
-				let producerResult = .failure(producerError) as Result<String, NSError>
+				let producerResult = .Failure(producerError) as Result<String, NSError>
 				let signalProducer = SignalProducer(result: producerResult)
 
 				expect(signalProducer).to(sendValue(nil, sendError: producerError, complete: false))
@@ -345,7 +345,7 @@ class SignalProducerSpec: QuickSpec {
 				let operation: () -> Result<String, NSError> = {
 					operationRunTimes++
 
-					return .success("OperationValue")
+					return .Success("OperationValue")
 				}
 
 				SignalProducer.attempt(operation).start()
@@ -357,7 +357,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should send the value then complete") {
 				let operationReturnValue = "OperationValue"
 				let operation: () -> Result<String, NSError> = {
-					return .success(operationReturnValue)
+					return .Success(operationReturnValue)
 				}
 
 				let signalProducer = SignalProducer.attempt(operation)
@@ -368,7 +368,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should send the error") {
 				let operationError = NSError(domain: "com.reactivecocoa.errordomain", code: 4815, userInfo: nil)
 				let operation: () -> Result<String, NSError> = {
-					return .failure(operationError)
+					return .Failure(operationError)
 				}
 
 				let signalProducer = SignalProducer.attempt(operation)
@@ -1242,9 +1242,9 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should not repeat upon error") {
 				let results: [Result<Int, TestError>] = [
-					.success(1),
-					.success(2),
-					.failure(.Default)
+					.Success(1),
+					.Success(2),
+					.Failure(.Default)
 				]
 
 				let original = SignalProducer.attemptWithResults(results)
@@ -1286,9 +1286,9 @@ class SignalProducerSpec: QuickSpec {
 		describe("retry") {
 			it("should start a signal N times upon error") {
 				let results: [Result<Int, TestError>] = [
-					.failure(.Error1),
-					.failure(.Error2),
-					.success(1)
+					.Failure(.Error1),
+					.Failure(.Error2),
+					.Success(1)
 				]
 
 				let original = SignalProducer.attemptWithResults(results)
@@ -1301,9 +1301,9 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should forward errors that occur after all retries") {
 				let results: [Result<Int, TestError>] = [
-					.failure(.Default),
-					.failure(.Error1),
-					.failure(.Error2),
+					.Failure(.Default),
+					.Failure(.Error1),
+					.Failure(.Error2),
 				]
 
 				let original = SignalProducer.attemptWithResults(results)
@@ -1316,9 +1316,9 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should not retry upon completion") {
 				let results: [Result<Int, TestError>] = [
-					.success(1),
-					.success(2),
-					.success(3)
+					.Success(1),
+					.Success(2),
+					.Success(3)
 				]
 
 				let original = SignalProducer.attemptWithResults(results)

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1460,7 +1460,7 @@ class SignalSpec: QuickSpec {
 			it("should forward original values upon success") {
 				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attempt { _ in
-					return .success()
+					return .Success()
 				}
 				
 				var current: Int?
@@ -1477,7 +1477,7 @@ class SignalSpec: QuickSpec {
 			it("should error if an attempt fails") {
 				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attempt { _ in
-					return .failure(.Default)
+					return .Failure(.Default)
 				}
 				
 				var error: TestError?
@@ -1494,7 +1494,7 @@ class SignalSpec: QuickSpec {
 			it("should forward mapped values upon success") {
 				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attemptMap { num -> Result<Bool, TestError> in
-					return .success(num % 2 == 0)
+					return .Success(num % 2 == 0)
 				}
 				
 				var even: Bool?
@@ -1512,7 +1512,7 @@ class SignalSpec: QuickSpec {
 			it("should error if a mapping fails") {
 				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attemptMap { _ -> Result<Bool, TestError> in
-					return .failure(.Default)
+					return .Failure(.Default)
 				}
 				
 				var error: TestError?


### PR DESCRIPTION
Updated Result to version supporting WatchKit.
Added New WatchKit target (no test target, as tests are not supported against watch targets at the moment)
Disable DTrace on WatchKit due to compilation errors relating to embedded assembly code