### PR TITLE
[Swift 2] Fix preprocessor directive for iOS build

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -99,7 +99,6 @@
 		A9B315C91B3940980001CB9C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		A9B315CA1B3940AB0001CB9C /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315CB1B3940AB0001CB9C /* EXTKeyPathCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666619EDA57100A782A9 /* EXTKeyPathCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315CC1B3940AB0001CB9C /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315CD1B3940AB0001CB9C /* EXTScope.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666919EDA57100A782A9 /* EXTScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315CE1B3940AB0001CB9C /* metamacros.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666A19EDA57100A782A9 /* metamacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315D01B3940AB0001CB9C /* NSArray+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037642A19EDA41200A782A9 /* NSArray+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -108,73 +107,44 @@
 		A9B315D51B3940AB0001CB9C /* NSEnumerator+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643419EDA41200A782A9 /* NSEnumerator+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315D61B3940AB0001CB9C /* NSFileHandle+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643619EDA41200A782A9 /* NSFileHandle+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315D71B3940AB0001CB9C /* NSIndexSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643819EDA41200A782A9 /* NSIndexSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315D81B3940AB0001CB9C /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643A19EDA41200A782A9 /* NSInvocation+RACTypeParsing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315D91B3940AB0001CB9C /* NSNotificationCenter+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037643C19EDA41200A782A9 /* NSNotificationCenter+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315DB1B3940AB0001CB9C /* NSObject+RACDeallocating.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644019EDA41200A782A9 /* NSObject+RACDeallocating.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315DC1B3940AB0001CB9C /* NSObject+RACDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644219EDA41200A782A9 /* NSObject+RACDescription.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315DD1B3940AB0001CB9C /* NSObject+RACKVOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644419EDA41200A782A9 /* NSObject+RACKVOWrapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315DE1B3940AB0001CB9C /* NSObject+RACLifting.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644619EDA41200A782A9 /* NSObject+RACLifting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315DF1B3940AB0001CB9C /* NSObject+RACPropertySubscribing.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644819EDA41200A782A9 /* NSObject+RACPropertySubscribing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315E01B3940AB0001CB9C /* NSObject+RACSelectorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644A19EDA41200A782A9 /* NSObject+RACSelectorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315E11B3940AB0001CB9C /* NSOrderedSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644C19EDA41200A782A9 /* NSOrderedSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315E21B3940AB0001CB9C /* NSSet+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037644E19EDA41200A782A9 /* NSSet+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315E31B3940AB0001CB9C /* NSString+RACKeyPathUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645019EDA41200A782A9 /* NSString+RACKeyPathUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315E41B3940AB0001CB9C /* NSString+RACSequenceAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645219EDA41200A782A9 /* NSString+RACSequenceAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315E51B3940AB0001CB9C /* NSString+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645419EDA41200A782A9 /* NSString+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315E71B3940AB0001CB9C /* NSURLConnection+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645819EDA41200A782A9 /* NSURLConnection+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315E81B3940AB0001CB9C /* NSUserDefaults+RACSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645A19EDA41200A782A9 /* NSUserDefaults+RACSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315E91B3940AB0001CB9C /* RACArraySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D037645C19EDA41200A782A9 /* RACArraySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315EA1B3940AB0001CB9C /* RACBehaviorSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646019EDA41200A782A9 /* RACBehaviorSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315EB1B3940AB0001CB9C /* RACBlockTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646219EDA41200A782A9 /* RACBlockTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315EC1B3940AB0001CB9C /* RACChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646419EDA41200A782A9 /* RACChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315ED1B3940AC0001CB9C /* RACCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646619EDA41200A782A9 /* RACCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315EE1B3940AC0001CB9C /* RACCompoundDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646819EDA41200A782A9 /* RACCompoundDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315EF1B3940AC0001CB9C /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646B19EDA41200A782A9 /* RACDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315F01B3940AC0001CB9C /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646D19EDA41200A782A9 /* RACDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315F11B3940AC0001CB9C /* RACDynamicSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646F19EDA41200A782A9 /* RACDynamicSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315F21B3940AC0001CB9C /* RACDynamicSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647119EDA41200A782A9 /* RACDynamicSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315F31B3940AC0001CB9C /* RACEagerSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647319EDA41200A782A9 /* RACEagerSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315F41B3940AC0001CB9C /* RACEmptySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647519EDA41200A782A9 /* RACEmptySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315F51B3940AC0001CB9C /* RACEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647719EDA41200A782A9 /* RACEmptySignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315F61B3940AC0001CB9C /* RACErrorSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647919EDA41200A782A9 /* RACErrorSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315F71B3940AC0001CB9C /* RACEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647B19EDA41200A782A9 /* RACEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315F81B3940AC0001CB9C /* RACGroupedSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647D19EDA41200A782A9 /* RACGroupedSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315F91B3940AC0001CB9C /* RACImmediateScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D037647F19EDA41200A782A9 /* RACImmediateScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315FA1B3940AC0001CB9C /* RACIndexSetSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648119EDA41200A782A9 /* RACIndexSetSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315FB1B3940AC0001CB9C /* RACKVOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648319EDA41200A782A9 /* RACKVOChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315FC1B3940AC0001CB9C /* RACKVOProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A70657D1A3F88B8001E8354 /* RACKVOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315FD1B3940AC0001CB9C /* RACKVOTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648519EDA41200A782A9 /* RACKVOTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B315FE1B3940AC0001CB9C /* RACMulticastConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648719EDA41200A782A9 /* RACMulticastConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B315FF1B3940AD0001CB9C /* RACMulticastConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648919EDA41200A782A9 /* RACMulticastConnection+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B316001B3940AD0001CB9C /* RACObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648A19EDA41200A782A9 /* RACObjCRuntime.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316021B3940AD0001CB9C /* RACQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D037648E19EDA41200A782A9 /* RACQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316031B3940AD0001CB9C /* RACQueueScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649019EDA41200A782A9 /* RACQueueScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316041B3940AD0001CB9C /* RACReplaySubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649119EDA41200A782A9 /* RACReplaySubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B316051B3940AD0001CB9C /* RACReturnSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649319EDA41200A782A9 /* RACReturnSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316061B3940AD0001CB9C /* RACScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649519EDA41200A782A9 /* RACScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B316071B3940AD0001CB9C /* RACScheduler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649719EDA41200A782A9 /* RACScheduler+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316081B3940AD0001CB9C /* RACScheduler+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649819EDA41200A782A9 /* RACScheduler+Subclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316091B3940AD0001CB9C /* RACScopedDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649919EDA41200A782A9 /* RACScopedDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B3160A1B3940AD0001CB9C /* RACSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649B19EDA41200A782A9 /* RACSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B3160B1B3940AD0001CB9C /* RACSerialDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649D19EDA41200A782A9 /* RACSerialDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B3160C1B3940AE0001CB9C /* RACSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = D037649F19EDA41200A782A9 /* RACSignal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B3160D1B3940AE0001CB9C /* RACSignal+Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764A119EDA41200A782A9 /* RACSignal+Operations.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B3160E1B3940AE0001CB9C /* RACSignalSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764A419EDA41200A782A9 /* RACSignalSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B3160F1B3940AE0001CB9C /* RACStream.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764A619EDA41200A782A9 /* RACStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B316101B3940AE0001CB9C /* RACStream+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764A819EDA41200A782A9 /* RACStream+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B316111B3940AE0001CB9C /* RACStringSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764A919EDA41200A782A9 /* RACStringSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316121B3940AE0001CB9C /* RACSubject.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764AB19EDA41200A782A9 /* RACSubject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316131B3940AE0001CB9C /* RACSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764AD19EDA41200A782A9 /* RACSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B316141B3940AE0001CB9C /* RACSubscriber+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764AF19EDA41200A782A9 /* RACSubscriber+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316151B3940AE0001CB9C /* RACSubscriptingAssignmentTrampoline.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B019EDA41200A782A9 /* RACSubscriptingAssignmentTrampoline.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B316161B3940AF0001CB9C /* RACSubscriptionScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B219EDA41200A782A9 /* RACSubscriptionScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316171B3940AF0001CB9C /* RACTargetQueueScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B419EDA41200A782A9 /* RACTargetQueueScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316181B3940AF0001CB9C /* RACTestScheduler.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B619EDA41200A782A9 /* RACTestScheduler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316191B3940AF0001CB9C /* RACTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764B819EDA41200A782A9 /* RACTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B3161A1B3940AF0001CB9C /* RACTupleSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764BA19EDA41200A782A9 /* RACTupleSequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B3161B1B3940AF0001CB9C /* RACUnarySequence.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764BC19EDA41200A782A9 /* RACUnarySequence.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B3161C1B3940AF0001CB9C /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764BE19EDA41200A782A9 /* RACUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9B3161D1B3940AF0001CB9C /* RACValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764C019EDA41200A782A9 /* RACValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316311B3940B20001CB9C /* RACDynamicPropertySuperclass.h in Headers */ = {isa = PBXBuildFile; fileRef = D43F279E1A9F7E8A00C1AD76 /* RACDynamicPropertySuperclass.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9B316341B394C7F0001CB9C /* RACCompoundDisposableProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D037646A19EDA41200A782A9 /* RACCompoundDisposableProvider.d */; };
 		A9B316351B394C7F0001CB9C /* RACSignalProvider.d in Sources */ = {isa = PBXBuildFile; fileRef = D03764A319EDA41200A782A9 /* RACSignalProvider.d */; };
@@ -1524,7 +1494,6 @@
 			files = (
 				A9B315CA1B3940AB0001CB9C /* ReactiveCocoa.h in Headers */,
 				A9B315CB1B3940AB0001CB9C /* EXTKeyPathCoding.h in Headers */,
-				A9B315CC1B3940AB0001CB9C /* EXTRuntimeExtensions.h in Headers */,
 				A9B315CD1B3940AB0001CB9C /* EXTScope.h in Headers */,
 				A9B315CE1B3940AB0001CB9C /* metamacros.h in Headers */,
 				A9B315D01B3940AB0001CB9C /* NSArray+RACSequenceAdditions.h in Headers */,
@@ -1533,73 +1502,44 @@
 				A9B315D51B3940AB0001CB9C /* NSEnumerator+RACSequenceAdditions.h in Headers */,
 				A9B315D61B3940AB0001CB9C /* NSFileHandle+RACSupport.h in Headers */,
 				A9B315D71B3940AB0001CB9C /* NSIndexSet+RACSequenceAdditions.h in Headers */,
-				A9B315D81B3940AB0001CB9C /* NSInvocation+RACTypeParsing.h in Headers */,
 				A9B315D91B3940AB0001CB9C /* NSNotificationCenter+RACSupport.h in Headers */,
 				A9B315DB1B3940AB0001CB9C /* NSObject+RACDeallocating.h in Headers */,
-				A9B315DC1B3940AB0001CB9C /* NSObject+RACDescription.h in Headers */,
-				A9B315DD1B3940AB0001CB9C /* NSObject+RACKVOWrapper.h in Headers */,
 				A9B315DE1B3940AB0001CB9C /* NSObject+RACLifting.h in Headers */,
 				A9B315DF1B3940AB0001CB9C /* NSObject+RACPropertySubscribing.h in Headers */,
 				A9B315E01B3940AB0001CB9C /* NSObject+RACSelectorSignal.h in Headers */,
 				A9B315E11B3940AB0001CB9C /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
 				A9B315E21B3940AB0001CB9C /* NSSet+RACSequenceAdditions.h in Headers */,
-				A9B315E31B3940AB0001CB9C /* NSString+RACKeyPathUtilities.h in Headers */,
 				A9B315E41B3940AB0001CB9C /* NSString+RACSequenceAdditions.h in Headers */,
 				A9B315E51B3940AB0001CB9C /* NSString+RACSupport.h in Headers */,
 				A9B315E71B3940AB0001CB9C /* NSURLConnection+RACSupport.h in Headers */,
 				A9B315E81B3940AB0001CB9C /* NSUserDefaults+RACSupport.h in Headers */,
-				A9B315E91B3940AB0001CB9C /* RACArraySequence.h in Headers */,
 				A9B315EA1B3940AB0001CB9C /* RACBehaviorSubject.h in Headers */,
-				A9B315EB1B3940AB0001CB9C /* RACBlockTrampoline.h in Headers */,
 				A9B315EC1B3940AB0001CB9C /* RACChannel.h in Headers */,
 				A9B315ED1B3940AC0001CB9C /* RACCommand.h in Headers */,
 				A9B315EE1B3940AC0001CB9C /* RACCompoundDisposable.h in Headers */,
-				A9B315EF1B3940AC0001CB9C /* RACDelegateProxy.h in Headers */,
 				A9B315F01B3940AC0001CB9C /* RACDisposable.h in Headers */,
-				A9B315F11B3940AC0001CB9C /* RACDynamicSequence.h in Headers */,
-				A9B315F21B3940AC0001CB9C /* RACDynamicSignal.h in Headers */,
-				A9B315F31B3940AC0001CB9C /* RACEagerSequence.h in Headers */,
-				A9B315F41B3940AC0001CB9C /* RACEmptySequence.h in Headers */,
-				A9B315F51B3940AC0001CB9C /* RACEmptySignal.h in Headers */,
-				A9B315F61B3940AC0001CB9C /* RACErrorSignal.h in Headers */,
 				A9B315F71B3940AC0001CB9C /* RACEvent.h in Headers */,
 				A9B315F81B3940AC0001CB9C /* RACGroupedSignal.h in Headers */,
-				A9B315F91B3940AC0001CB9C /* RACImmediateScheduler.h in Headers */,
-				A9B315FA1B3940AC0001CB9C /* RACIndexSetSequence.h in Headers */,
 				A9B315FB1B3940AC0001CB9C /* RACKVOChannel.h in Headers */,
-				A9B315FC1B3940AC0001CB9C /* RACKVOProxy.h in Headers */,
-				A9B315FD1B3940AC0001CB9C /* RACKVOTrampoline.h in Headers */,
 				A9B315FE1B3940AC0001CB9C /* RACMulticastConnection.h in Headers */,
-				A9B315FF1B3940AD0001CB9C /* RACMulticastConnection+Private.h in Headers */,
-				A9B316001B3940AD0001CB9C /* RACObjCRuntime.h in Headers */,
 				A9B316021B3940AD0001CB9C /* RACQueueScheduler.h in Headers */,
 				A9B316031B3940AD0001CB9C /* RACQueueScheduler+Subclass.h in Headers */,
 				A9B316041B3940AD0001CB9C /* RACReplaySubject.h in Headers */,
-				A9B316051B3940AD0001CB9C /* RACReturnSignal.h in Headers */,
 				A9B316061B3940AD0001CB9C /* RACScheduler.h in Headers */,
-				A9B316071B3940AD0001CB9C /* RACScheduler+Private.h in Headers */,
 				A9B316081B3940AD0001CB9C /* RACScheduler+Subclass.h in Headers */,
 				A9B316091B3940AD0001CB9C /* RACScopedDisposable.h in Headers */,
 				A9B3160A1B3940AD0001CB9C /* RACSequence.h in Headers */,
 				A9B3160B1B3940AD0001CB9C /* RACSerialDisposable.h in Headers */,
 				A9B3160C1B3940AE0001CB9C /* RACSignal.h in Headers */,
 				A9B3160D1B3940AE0001CB9C /* RACSignal+Operations.h in Headers */,
-				A9B3160E1B3940AE0001CB9C /* RACSignalSequence.h in Headers */,
 				A9B3160F1B3940AE0001CB9C /* RACStream.h in Headers */,
-				A9B316101B3940AE0001CB9C /* RACStream+Private.h in Headers */,
-				A9B316111B3940AE0001CB9C /* RACStringSequence.h in Headers */,
 				A9B316121B3940AE0001CB9C /* RACSubject.h in Headers */,
 				A9B316131B3940AE0001CB9C /* RACSubscriber.h in Headers */,
-				A9B316141B3940AE0001CB9C /* RACSubscriber+Private.h in Headers */,
 				A9B316151B3940AE0001CB9C /* RACSubscriptingAssignmentTrampoline.h in Headers */,
-				A9B316161B3940AF0001CB9C /* RACSubscriptionScheduler.h in Headers */,
 				A9B316171B3940AF0001CB9C /* RACTargetQueueScheduler.h in Headers */,
 				A9B316181B3940AF0001CB9C /* RACTestScheduler.h in Headers */,
 				A9B316191B3940AF0001CB9C /* RACTuple.h in Headers */,
-				A9B3161A1B3940AF0001CB9C /* RACTupleSequence.h in Headers */,
-				A9B3161B1B3940AF0001CB9C /* RACUnarySequence.h in Headers */,
 				A9B3161C1B3940AF0001CB9C /* RACUnit.h in Headers */,
-				A9B3161D1B3940AF0001CB9C /* RACValueTransformer.h in Headers */,
 				A9B316311B3940B20001CB9C /* RACDynamicPropertySuperclass.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-watchOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-watchOS.xcscheme
@@ -23,21 +23,21 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -55,10 +55,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Profile"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoa/ReactiveCocoa.h
@@ -63,7 +63,7 @@ FOUNDATION_EXPORT const unsigned char ReactiveCocoaVersionString[];
 #import <ReactiveCocoa/RACUnit.h>
 
 #if TARGET_OS_WATCH
-#elif defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#elif TARGET_OS_IPHONE
 	#import <ReactiveCocoa/MKAnnotationView+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIActionSheet+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIAlertView+RACSignalSupport.h>

--- a/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoa/ReactiveCocoa.h
@@ -62,8 +62,8 @@ FOUNDATION_EXPORT const unsigned char ReactiveCocoaVersionString[];
 #import <ReactiveCocoa/RACTuple.h>
 #import <ReactiveCocoa/RACUnit.h>
 
-#ifdef TARGET_OS_WATCH
-#elif __IPHONE_OS_VERSION_MIN_REQUIRED
+#if TARGET_OS_WATCH
+#elif defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 	#import <ReactiveCocoa/MKAnnotationView+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIActionSheet+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIAlertView+RACSignalSupport.h>


### PR DESCRIPTION
Fixes #2216.

```objc
#ifdef TARGET_OS_WATCH
#elif defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
```

does not work well.