### PR TITLE
Updates for Xcode 7 beta 5

### DIFF
--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa Mac.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa Mac.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa iOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa iOS.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/ReactiveCocoa/Swift/Errors.swift
+++ b/ReactiveCocoa/Swift/Errors.swift
@@ -6,16 +6,11 @@
 //  Copyright (c) 2014 GitHub. All rights reserved.
 //
 
-import Foundation
-
 /// An “error” that is impossible to construct.
 ///
 /// This can be used to describe signals or producers where errors will never
 /// be generated. For example, `Signal<Int, NoError>` describes a signal that
 /// sends integers and is guaranteed never to error out.
 public final class NoError: ErrorType {
-	public let _domain: String = ""
-	public let _code: Int = 0
-
 	private init() {}
 }


### PR DESCRIPTION
> Structs and classes are now allowed to conform to ErrorType. (21867608)