### PR TITLE
Fix backticks in unsafeCocoaAction documentation

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -44,7 +44,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 	/// Whether the instantiator of this action wants it to be enabled.
 	private let userEnabled: PropertyOf<Bool>
 
-	/// Lazy creation and storage of a UI bindable `CocoaAction``. The default behavior
+	/// Lazy creation and storage of a UI bindable `CocoaAction`. The default behavior
 	/// force casts the AnyObject? input to match the action's `Input` type. This makes
 	/// it unsafe for use when the action is paramerterized for something like `Void`
 	/// input. In those cases, explicitly assign a value to this property that transforms

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -46,7 +46,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 
 	/// Lazy creation and storage of a UI bindable `CocoaAction`. The default behavior
 	/// force casts the AnyObject? input to match the action's `Input` type. This makes
-	/// it unsafe for use when the action is paramerterized for something like `Void`
+	/// it unsafe for use when the action is parameterized for something like `Void`
 	/// input. In those cases, explicitly assign a value to this property that transforms
 	/// the input to suit your needs.
 	public lazy var unsafeCocoaAction: CocoaAction = { _ in


### PR DESCRIPTION
Xcode's Quick Help (for example) doesn't like the second backtick:

<img width="497" alt="screenshot 2015-08-24 23 18 05" src="https://cloud.githubusercontent.com/assets/2218519/9452981/b86d808e-4ab7-11e5-8de9-8c42002a541d.png">
