### PR TITLE
Added Signal & SignalProducer silent feature

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1068,6 +1068,28 @@ public func zip<S: SequenceType, T, Error where S.Generator.Element == Signal<T,
 	return Signal.never
 }
 
+/// Silents the Signal errors.
+/// It's useful to bind a Signal into a property (binding operator supports only Signals of ErrorType == NoError)
+///
+/// Returns a Signal that propagates all the source Signal events but the error event
+public func silent<T, E>() -> Signal<T, E> -> Signal<T, NoError> {
+    return { signal in
+        return Signal { observer in
+            signal.observe { (event) -> Void in
+                switch event {
+                    case .Error(_): break
+                case .Completed:
+                    observer(.Completed)
+                case .Interrupted:
+                    observer(.Interrupted)
+                case .Next(let next):
+                    observer(.Next(next))
+                }
+            }
+        }
+    }
+}
+
 /// Forwards events from `signal` until `interval`. Then if signal isn't completed yet,
 /// errors with `error` on `scheduler`.
 ///

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -871,6 +871,16 @@ public func start<T, E>(error: (E -> ())? = nil, completed: (() -> ())? = nil, i
 	}
 }
 
+/// Silents the SignalProducer errors
+/// It's useful to bind a SignalProducer into a property (binding operator supports only Signals of ErrorType == NoError)
+///
+/// Returns a SignalProducer that propagates all the source SignalProducer events but the error event
+public func silent<T, E>() -> SignalProducer<T, E> -> SignalProducer<T, NoError> {
+    return { producer in
+        producer.lift(silent())
+    }
+}
+
 /// Describes how multiple producers should be joined together.
 public enum FlattenStrategy: Equatable {
 	/// The producers should be merged, so that any value received on any of the


### PR DESCRIPTION
### Context?
ReactiveCocoa supports a custom ErrorType defined as `NoError`. Some features make use of that kind of signals like for example the property binding between Signal and SignalProducers and properties. 

If you work with Signal/Producers that report errors they cannot be directly binded to the properties. In that case you have to convert it into a new Signal/Producer<T, NoError> in order to being able to bind it. 

### Proposal
I was thinking about the best way to integrate it with ReactiveCocoa and I thought about a method called *silent* that propagates all the events except the error event. That way the developer can do something like:

```swift
property <~ my_signal().silent()
```

### Doubts
- Don't know if it's the best approach, and if it's aligned with the API at all but I've faced that problem and I guess more developers are doing.
- I thought about passing an error block that way we force the developer to decide what to do with errors before silencing the Signal/Producer
