### PR TITLE
Shorten NSComparisonResult cases

### DIFF
--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -190,7 +190,7 @@ public final class TestScheduler: DateSchedulerType {
 		}
 
 		func less(rhs: ScheduledAction) -> Bool {
-			return date.compare(rhs.date) == NSComparisonResult.OrderedAscending
+			return date.compare(rhs.date) == .OrderedAscending
 		}
 	}
 
@@ -292,11 +292,11 @@ public final class TestScheduler: DateSchedulerType {
 	public func advanceToDate(newDate: NSDate) {
 		lock.lock()
 
-		assert(currentDate.compare(newDate) != NSComparisonResult.OrderedDescending)
+		assert(currentDate.compare(newDate) != .OrderedDescending)
 		_currentDate = newDate
 
 		while scheduledActions.count > 0 {
-			if newDate.compare(scheduledActions[0].date) == NSComparisonResult.OrderedAscending {
+			if newDate.compare(scheduledActions[0].date) == .OrderedAscending {
 				break
 			}
 


### PR DESCRIPTION
`.OrderedAscending` instead of `NSComparisonResult.OrderedAscending`.