### PR TITLE
Replace start/observe closure syntax with distinct functions

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -168,7 +168,7 @@ public final class CocoaAction: NSObject {
 
 		disposable += action.enabled.producer
 			.observeOn(UIScheduler())
-			.startNext { [weak self] value in
+			.startWithNext { [weak self] value in
 				self?.willChangeValueForKey("enabled")
 				self?._enabled = value
 				self?.didChangeValueForKey("enabled")
@@ -176,7 +176,7 @@ public final class CocoaAction: NSObject {
 
 		disposable += action.executing.producer
 			.observeOn(UIScheduler())
-			.startNext { [weak self] value in
+			.startWithNext { [weak self] value in
 				self?.willChangeValueForKey("executing")
 				self?._executing = value
 				self?.didChangeValueForKey("executing")

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -168,19 +168,19 @@ public final class CocoaAction: NSObject {
 
 		disposable += action.enabled.producer
 			.observeOn(UIScheduler())
-			.start(next: { [weak self] value in
+			.startNext { [weak self] value in
 				self?.willChangeValueForKey("enabled")
 				self?._enabled = value
 				self?.didChangeValueForKey("enabled")
-			})
+			}
 
 		disposable += action.executing.producer
 			.observeOn(UIScheduler())
-			.start(next: { [weak self] value in
+			.startNext { [weak self] value in
 				self?.willChangeValueForKey("executing")
 				self?._executing = value
 				self?.didChangeValueForKey("executing")
-			})
+			}
 	}
 
 	/// Initializes a Cocoa action that will invoke the given Action by

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -94,9 +94,9 @@ public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RAC
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start { event in
 			switch event {
-			case .Next(let value):
+			case let .Next(value):
 				subscriber.sendNext(value)
-			case .Error(let error):
+			case let .Error(error):
 				subscriber.sendError(error as NSError)
 			case .Completed:
 				subscriber.sendCompleted()
@@ -125,9 +125,9 @@ public func toRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = signal.observe { event in
 			switch event {
-			case .Next(let value):
+			case let .Next(value):
 				subscriber.sendNext(value)
-			case .Error(let error):
+			case let .Error(error):
 				subscriber.sendError(error as NSError)
 			case .Completed:
 				subscriber.sendCompleted()

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -92,13 +92,18 @@ public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T, E>) -> RACS
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RACSignal {
 	return RACSignal.createSignal { subscriber in
-		let selfDisposable = producer.start(next: { value in
-			subscriber.sendNext(value)
-		}, error: { error in
-			subscriber.sendError(error as NSError)
-		}, completed: {
-			subscriber.sendCompleted()
-		})
+		let selfDisposable = producer.start { event in
+			switch event {
+			case .Next(let value):
+				subscriber.sendNext(value)
+			case .Error(let error):
+				subscriber.sendError(error as NSError)
+			case .Completed:
+				subscriber.sendCompleted()
+			default:
+				break
+			}
+		}
 
 		return RACDisposable {
 			selfDisposable.dispose()
@@ -118,14 +123,19 @@ public func toRACSignal<T: AnyObject, E>(signal: Signal<T, E>) -> RACSignal {
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
 	return RACSignal.createSignal { subscriber in
-		let selfDisposable = signal.observe(next: { value in
-			subscriber.sendNext(value)
-		}, error: { error in
-			subscriber.sendError(error as NSError)
-		}, completed: {
-			subscriber.sendCompleted()
-		})
-
+		let selfDisposable = signal.observe { event in
+			switch event {
+			case .Next(let value):
+				subscriber.sendNext(value)
+			case .Error(let error):
+				subscriber.sendError(error as NSError)
+			case .Completed:
+				subscriber.sendCompleted()
+			default:
+				break
+			}
+		}
+		
 		return RACDisposable {
 			selfDisposable?.dispose()
 		}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -200,7 +200,7 @@ public func <~ <P: MutablePropertyType>(property: P, signal: Signal<P.Value, NoE
 
 	disposable += signal.observe { [weak property] event in
 		switch event {
-		case .Next(let value):
+		case let .Next(value):
 			property?.value = value
 		case .Completed:
 			disposable.dispose()

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -176,7 +176,7 @@ public final class MutableProperty<T>: MutablePropertyType {
 		/// DynamicProperty stay alive as long as object is alive.
 		/// This is made possible by strong reference cycles.
 		super.init()
-		object?.rac_willDeallocSignal()?.toSignalProducer().startCompleted { self }
+		object?.rac_willDeallocSignal()?.toSignalProducer().startWithCompleted { self }
 	}
 }
 
@@ -194,7 +194,7 @@ infix operator <~ {
 /// or when the signal sends a `Completed` event.
 public func <~ <P: MutablePropertyType>(property: P, signal: Signal<P.Value, NoError>) -> Disposable {
 	let disposable = CompositeDisposable()
-	disposable += property.producer.startCompleted {
+	disposable += property.producer.startWithCompleted {
 		disposable.dispose()
 	}
 
@@ -226,7 +226,7 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 		property <~ signal
 		disposable = signalDisposable
 
-		property.producer.startCompleted {
+		property.producer.startWithCompleted {
 			signalDisposable.dispose()
 		}
 	}

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -328,7 +328,7 @@ private final class CombineLatestState<T> {
 private func observeWithStates<T, U, E>(signal: Signal<T, E>, _ signalState: CombineLatestState<T>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ onBothNext: () -> (), _ onError: E -> (), _ onBothCompleted: () -> (), _ onInterrupted: () -> ()) -> Disposable? {
 	return signal.observe { event in
 		switch event {
-		case .Next(let value):
+		case let .Next(value):
 			lock.lock()
 			
 			signalState.latestValue = value
@@ -337,7 +337,7 @@ private func observeWithStates<T, U, E>(signal: Signal<T, E>, _ signalState: Com
 			}
 			
 			lock.unlock()
-		case .Error(let error):
+		case let .Error(error):
 			onError(error)
 		case .Completed:
 			lock.lock()
@@ -520,12 +520,12 @@ extension SignalType {
 
 			disposable += self.observe { event in
 				switch event {
-				case .Next(let value):
+				case let .Next(value):
 					state.modify { (var st) in
 						st.latestValue = value
 						return st
 					}
-				case .Error(let error):
+				case let .Error(error):
 					sendError(observer, error)
 				case .Completed:
 					let oldState = state.modify { (var st) in
@@ -729,7 +729,7 @@ extension SignalType {
 
 			return self.observe { event in
 				switch event {
-				case .Next(let value):
+				case let .Next(value):
 					// To avoid exceeding the reserved capacity of the buffer, we remove then add.
 					// Remove elements until we have room to add one more.
 					while (buffer.count + 1) > count {
@@ -737,7 +737,7 @@ extension SignalType {
 					}
 					
 					buffer.append(value)
-				case .Error(let error):
+				case let .Error(error):
 					sendError(observer, error)
 				case .Completed:
 					for bufferedValue in buffer {
@@ -822,14 +822,14 @@ extension SignalType {
 
 			disposable += self.observe { event in
 				switch event {
-				case .Next(let value):
+				case let .Next(value):
 					states.modify { (var states) in
 						states.0.values.append(value)
 						return states
 					}
 					
 					flush()
-				case .Error(let error):
+				case let .Error(error):
 					onError(error)
 				case .Completed:
 					states.modify { (var states) in
@@ -845,14 +845,14 @@ extension SignalType {
 
 			disposable += otherSignal.observe { event in
 				switch event {
-				case .Next(let value):
+				case let .Next(value):
 					states.modify { (var states) in
 						states.1.values.append(value)
 						return states
 					}
 					
 					flush()
-				case .Error(let error):
+				case let .Error(error):
 					onError(error)
 				case .Completed:
 					states.modify { (var states) in
@@ -888,13 +888,13 @@ extension SignalType {
 		return Signal { observer in
 			self.observe { event in
 				switch event {
-				case .Next(let value):
+				case let .Next(value):
 					operation(value).analysis(ifSuccess: { value in
 						sendNext(observer, value)
 						}, ifFailure: { error in
 							sendError(observer, error)
 					})
-				case .Error(let error):
+				case let .Error(error):
 					sendError(observer, error)
 				case .Completed:
 					sendCompleted(observer)
@@ -1192,7 +1192,7 @@ extension SignalType where E: NoError {
 		return Signal { observer in
 			return self.observe { event in
 				switch event {
-				case .Next(let value):
+				case let .Next(value):
 					sendNext(observer, value)
 				case .Error(_):
 					fatalError("NoError is impossible to construct")

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -163,37 +163,45 @@ extension Signal: SignalType {
 }
 
 extension SignalType {
-	/// Observes the Signal by invoking the given callbacks when events are
-	/// received. If the Signal has already terminated, the `interrupted`
-	/// callback will be invoked immediately.
+	/// Observes the Signal by invoking the given callback when `next` events are
+	/// received.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeNext(error error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> Disposable? {
-		return observe(Event.sink(error: error, completed: completed, interrupted: interrupted, next: next))
+	public func observeNext(next: T -> ()) -> Disposable? {
+		return observe(Event.sink(next: next))
 	}
 
-	/// Observes the Signal by invoking the given callbacks when events are
-	/// received. If the Signal has already terminated, the `interrupted`
-	/// callback will be invoked immediately.
+	/// Observes the Signal by invoking the given callback when a `completed` event is
+	/// received.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
-	/// callbacks. Disposing of the Disposable will have no effect on the Signal
+	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeCompleted(error error: (E -> ())? = nil, interrupted: (() -> ())? = nil, completed: (() -> ())? = nil) -> Disposable? {
-		return observe(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
+	public func observeCompleted(completed: () -> ()) -> Disposable? {
+		return observe(Event.sink(completed: completed))
 	}
 	
-	/// Observes the Signal by invoking the given callbacks when events are
-	/// received. If the Signal has already terminated, the `interrupted`
-	/// callback will be invoked immediately.
+	/// Observes the Signal by invoking the given callback when an `error` event is
+	/// received.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
-	/// callbacks. Disposing of the Disposable will have no effect on the Signal
+	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeError(completed completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, error: (E -> ())? = nil) -> Disposable? {
-		return observe(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
+	public func observeError(error: E -> ()) -> Disposable? {
+		return observe(Event.sink(error: error))
+	}
+	
+	/// Observes the Signal by invoking the given callback when an `interrupted` event is
+	/// received. If the Signal has already terminated, the callback will be invoked
+	/// immediately.
+	///
+	/// Returns a Disposable which can be used to stop the invocation of the
+	/// callback. Disposing of the Disposable will have no effect on the Signal
+	/// itself.
+	public func observeInterrupted(interrupted: () -> ()) -> Disposable? {
+		return observe(Event.sink(interrupted: interrupted))
 	}
 
 	/// Maps each value in the signal to a new value.

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -163,15 +163,45 @@ extension Signal: SignalType {
 }
 
 extension SignalType {
-	/// Observes the Signal by invoking the given callbacks when events are
-	/// received. If the Signal has already terminated, the `interrupted`
-	/// callback will be invoked immediately.
+	/// Observes the Signal by invoking the given callback when `next` events are
+	/// received.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observe(error error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> Disposable? {
-		return observe(Event.sink(next: next, error: error, completed: completed, interrupted: interrupted))
+	public func observeNext(next: T -> ()) -> Disposable? {
+		return observe(Event.sink(next: next))
+	}
+
+	/// Observes the Signal by invoking the given callback when an `error` event is
+	/// received.
+	///
+	/// Returns a Disposable which can be used to stop the invocation of the
+	/// callback. Disposing of the Disposable will have no effect on the Signal
+	/// itself.
+	public func observeError(error: E -> ()) -> Disposable? {
+		return observe(Event.sink(error: error))
+	}
+
+	/// Observes the Signal by invoking the given callback when a `completed` event is
+	/// received.
+	///
+	/// Returns a Disposable which can be used to stop the invocation of the
+	/// callback. Disposing of the Disposable will have no effect on the Signal
+	/// itself.
+	public func observeCompleted(completed: () -> ()) -> Disposable? {
+		return observe(Event.sink(completed: completed))
+	}
+	
+	/// Observes the Signal by invoking the given callback when an `interrupted` event is
+	/// received. If the Signal has already terminated, the callback will be invoked 
+	/// immediately.
+	///
+	/// Returns a Disposable which can be used to stop the invocation of the
+	/// callback. Disposing of the Disposable will have no effect on the Signal
+	/// itself.
+	public func observeInterrupted(interrupted: () -> ()) -> Disposable? {
+		return observe(Event.sink(interrupted: interrupted))
 	}
 
 	/// Maps each value in the signal to a new value.
@@ -296,25 +326,32 @@ private final class CombineLatestState<T> {
 }
 
 private func observeWithStates<T, U, E>(signal: Signal<T, E>, _ signalState: CombineLatestState<T>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ onBothNext: () -> (), _ onError: E -> (), _ onBothCompleted: () -> (), _ onInterrupted: () -> ()) -> Disposable? {
-	return signal.observe(next: { value in
-		lock.lock()
-
-		signalState.latestValue = value
-		if otherState.latestValue != nil {
-			onBothNext()
+	return signal.observe { event in
+		switch event {
+		case .Next(let value):
+			lock.lock()
+			
+			signalState.latestValue = value
+			if otherState.latestValue != nil {
+				onBothNext()
+			}
+			
+			lock.unlock()
+		case .Error(let error):
+			onError(error)
+		case .Completed:
+			lock.lock()
+			
+			signalState.completed = true
+			if otherState.completed {
+				onBothCompleted()
+			}
+			
+			lock.unlock()
+		case .Interrupted:
+			onInterrupted()
 		}
-
-		lock.unlock()
-	}, error: onError, completed: {
-		lock.lock()
-
-		signalState.completed = true
-		if otherState.completed {
-			onBothCompleted()
-		}
-
-		lock.unlock()
-	}, interrupted: onInterrupted)
+	}
 }
 
 extension SignalType {
@@ -481,42 +518,50 @@ extension SignalType {
 			let state = Atomic(SampleState<T>())
 			let disposable = CompositeDisposable()
 
-			disposable += self.observe(next: { value in
-				state.modify { (var st) in
-					st.latestValue = value
-					return st
+			disposable += self.observe { event in
+				switch event {
+				case .Next(let value):
+					state.modify { (var st) in
+						st.latestValue = value
+						return st
+					}
+				case .Error(let error):
+					sendError(observer, error)
+				case .Completed:
+					let oldState = state.modify { (var st) in
+						st.signalCompleted = true
+						return st
+					}
+					
+					if oldState.samplerCompleted {
+						sendCompleted(observer)
+					}
+				case .Interrupted:
+					sendInterrupted(observer)
 				}
-			}, error: { error in
-				sendError(observer, error)
-			}, completed: {
-				let oldState = state.modify { (var st) in
-					st.signalCompleted = true
-					return st
+			}
+			
+			disposable += sampler.observe { event in
+				switch event {
+				case .Next(_):
+					if let value = state.value.latestValue {
+						sendNext(observer, value)
+					}
+				case .Completed:
+					let oldState = state.modify { (var st) in
+						st.samplerCompleted = true
+						return st
+					}
+					
+					if oldState.signalCompleted {
+						sendCompleted(observer)
+					}
+				case .Interrupted:
+					sendInterrupted(observer)
+				default:
+					break
 				}
-
-				if oldState.samplerCompleted {
-					sendCompleted(observer)
-				}
-			}, interrupted: {
-				sendInterrupted(observer)
-			})
-
-			disposable += sampler.observe(next: { _ in
-				if let value = state.value.latestValue {
-					sendNext(observer, value)
-				}
-			}, completed: {
-				let oldState = state.modify { (var st) in
-					st.samplerCompleted = true
-					return st
-				}
-
-				if oldState.signalCompleted {
-					sendCompleted(observer)
-				}
-			}, interrupted: {
-				sendInterrupted(observer)
-			})
+			}
 
 			return disposable
 		}
@@ -682,25 +727,28 @@ extension SignalType {
 			var buffer = [T]()
 			buffer.reserveCapacity(count)
 
-			return self.observe(next: { value in
-				// To avoid exceeding the reserved capacity of the buffer, we remove then add.
-				// Remove elements until we have room to add one more.
-				while (buffer.count + 1) > count {
-					buffer.removeAtIndex(0)
+			return self.observe { event in
+				switch event {
+				case .Next(let value):
+					// To avoid exceeding the reserved capacity of the buffer, we remove then add.
+					// Remove elements until we have room to add one more.
+					while (buffer.count + 1) > count {
+						buffer.removeAtIndex(0)
+					}
+					
+					buffer.append(value)
+				case .Error(let error):
+					sendError(observer, error)
+				case .Completed:
+					for bufferedValue in buffer {
+						sendNext(observer, bufferedValue)
+					}
+					
+					sendCompleted(observer)
+				case .Interrupted:
+					sendInterrupted(observer)
 				}
-
-				buffer.append(value)
-			}, error: { error in
-				sendError(observer, error)
-			}, completed: {
-				for bufferedValue in buffer {
-					sendNext(observer, bufferedValue)
-				}
-
-				sendCompleted(observer)
-			}, interrupted: {
-				sendInterrupted(observer)
-			})
+			}
 		}
 	}
 
@@ -772,37 +820,51 @@ extension SignalType {
 			let onError = { sendError(observer, $0) }
 			let onInterrupted = { sendInterrupted(observer) }
 
-			disposable += self.observe(next: { value in
-				states.modify { (var states) in
-					states.0.values.append(value)
-					return states
-				}
-				
-				flush()
-			}, error: onError, completed: {
-				states.modify { (var states) in
-					states.0.completed = true
-					return states
-				}
+			disposable += self.observe { event in
+				switch event {
+				case .Next(let value):
+					states.modify { (var states) in
+						states.0.values.append(value)
+						return states
+					}
 					
-				flush()
-			}, interrupted: onInterrupted)
-			
-			disposable += otherSignal.observe(next: { value in
-				states.modify { (var states) in
-					states.1.values.append(value)
-					return states
-				}
-				
-				flush()
-			}, error: onError, completed: {
-				states.modify { (var states) in
-					states.1.completed = true
-					return states
-				}
+					flush()
+				case .Error(let error):
+					onError(error)
+				case .Completed:
+					states.modify { (var states) in
+						states.0.completed = true
+						return states
+					}
 					
-				flush()
-			}, interrupted: onInterrupted)
+					flush()
+				case .Interrupted:
+					onInterrupted()
+				}
+			}
+
+			disposable += otherSignal.observe { event in
+				switch event {
+				case .Next(let value):
+					states.modify { (var states) in
+						states.1.values.append(value)
+						return states
+					}
+					
+					flush()
+				case .Error(let error):
+					onError(error)
+				case .Completed:
+					states.modify { (var states) in
+						states.1.completed = true
+						return states
+					}
+					
+					flush()
+				case .Interrupted:
+					onInterrupted()
+				}
+			}
 			
 			return disposable
 		}
@@ -824,19 +886,22 @@ extension SignalType {
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func attemptMap<U>(operation: T -> Result<U, E>) -> Signal<U, E> {
 		return Signal { observer in
-			self.observe(next: { value in
-				operation(value).analysis(ifSuccess: { value in
-					sendNext(observer, value)
-				}, ifFailure: { error in
+			self.observe { event in
+				switch event {
+				case .Next(let value):
+					operation(value).analysis(ifSuccess: { value in
+						sendNext(observer, value)
+						}, ifFailure: { error in
+							sendError(observer, error)
+					})
+				case .Error(let error):
 					sendError(observer, error)
-				})
-			}, error: { error in
-				sendError(observer, error)
-			}, completed: {
-				sendCompleted(observer)
-			}, interrupted: {
-				sendInterrupted(observer)
-			})
+				case .Completed:
+					sendCompleted(observer)
+				case .Interrupted:
+					sendInterrupted(observer)
+				}
+			}
 		}
 	}
 
@@ -1125,15 +1190,18 @@ extension SignalType where E: NoError {
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func promoteErrors<F: ErrorType>(_: F.Type) -> Signal<T, F> {
 		return Signal { observer in
-			return self.observe(next: { value in
-				sendNext(observer, value)
-			}, completed: {
-				sendCompleted(observer)
-			}, interrupted: {
-				sendInterrupted(observer)
-			}, error: { _ in
-				fatalError("NoError is impossible to construct")
-			})
+			return self.observe { event in
+				switch event {
+				case .Next(let value):
+					sendNext(observer, value)
+				case .Error(_):
+					fatalError("NoError is impossible to construct")
+				case .Completed:
+					sendCompleted(observer)
+				case .Interrupted:
+					sendInterrupted(observer)
+				}
+			}
 		}
 	}
 }

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -163,45 +163,37 @@ extension Signal: SignalType {
 }
 
 extension SignalType {
-	/// Observes the Signal by invoking the given callback when `next` events are
-	/// received.
+	/// Observes the Signal by invoking the given callbacks when events are
+	/// received. If the Signal has already terminated, the `interrupted`
+	/// callback will be invoked immediately.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeNext(next: T -> ()) -> Disposable? {
-		return observe(Event.sink(next: next))
+	public func observeNext(error error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> Disposable? {
+		return observe(Event.sink(error: error, completed: completed, interrupted: interrupted, next: next))
 	}
 
-	/// Observes the Signal by invoking the given callback when an `error` event is
-	/// received.
+	/// Observes the Signal by invoking the given callbacks when events are
+	/// received. If the Signal has already terminated, the `interrupted`
+	/// callback will be invoked immediately.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
-	/// callback. Disposing of the Disposable will have no effect on the Signal
+	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeError(error: E -> ()) -> Disposable? {
-		return observe(Event.sink(error: error))
-	}
-
-	/// Observes the Signal by invoking the given callback when a `completed` event is
-	/// received.
-	///
-	/// Returns a Disposable which can be used to stop the invocation of the
-	/// callback. Disposing of the Disposable will have no effect on the Signal
-	/// itself.
-	public func observeCompleted(completed: () -> ()) -> Disposable? {
-		return observe(Event.sink(completed: completed))
+	public func observeCompleted(error error: (E -> ())? = nil, interrupted: (() -> ())? = nil, completed: (() -> ())? = nil) -> Disposable? {
+		return observe(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
 	}
 	
-	/// Observes the Signal by invoking the given callback when an `interrupted` event is
-	/// received. If the Signal has already terminated, the callback will be invoked 
-	/// immediately.
+	/// Observes the Signal by invoking the given callbacks when events are
+	/// received. If the Signal has already terminated, the `interrupted`
+	/// callback will be invoked immediately.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
-	/// callback. Disposing of the Disposable will have no effect on the Signal
+	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeInterrupted(interrupted: () -> ()) -> Disposable? {
-		return observe(Event.sink(interrupted: interrupted))
+	public func observeError(completed completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, error: (E -> ())? = nil) -> Disposable? {
+		return observe(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
 	}
 
 	/// Maps each value in the signal to a new value.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -311,43 +311,33 @@ extension SignalProducerType {
 	}
 
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callback when `next` events are
+	/// the Signal, which will invoke the given callbacks when events are
 	/// received.
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func startNext(next: T -> ()) -> Disposable {
-		return start(Event.sink(next: next))
+	public func startWithNext(error error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> Disposable {
+		return start(Event.sink(error: error, completed: completed, interrupted: interrupted, next: next))
 	}
 
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callback when an `error` event is
+	/// the Signal, which will invoke the given callbacks when events are
 	/// received.
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
-	/// with the Signal.
-	public func startError(error: E -> ()) -> Disposable {
-		return start(Event.sink(error: error))
+	/// with the Signal, and prevent any future callbacks from being invoked.
+	public func startWithCompleted(error error: (E -> ())? = nil, interrupted: (() -> ())? = nil, completed: (() -> ())? = nil) -> Disposable {
+		return start(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
 	}
 	
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callback when a `completed` event is
+	/// the Signal, which will invoke the given callbacks when events are
 	/// received.
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
-	/// with the Signal.
-	public func startCompleted(completed: () -> ()) -> Disposable {
-		return start(Event.sink(completed: completed))
-	}
-	
-	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callback when an `interrupted` event is
-	/// received.
-	///
-	/// Returns a Disposable which can be used to interrupt the work associated
-	/// with the Signal.
-	public func startInterrupted(interrupted: () -> ()) -> Disposable {
-		return start(Event.sink(interrupted: interrupted))
+	/// with the Signal, and prevent any future callbacks from being invoked.
+	public func startWithError(completed completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, error: (E -> ())? = nil) -> Disposable {
+		return start(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
 	}
 
 	/// Lifts an unary Signal operator to operate upon SignalProducers instead.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -311,33 +311,43 @@ extension SignalProducerType {
 	}
 
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callbacks when events are
+	/// the Signal, which will invoke the given callback when `next` events are
 	/// received.
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func startWithNext(error error: (E -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (T -> ())? = nil) -> Disposable {
-		return start(Event.sink(error: error, completed: completed, interrupted: interrupted, next: next))
+	public func startWithNext(next: T -> ()) -> Disposable {
+		return start(Event.sink(next: next))
 	}
 
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callbacks when events are
+	/// the Signal, which will invoke the given callback when a `completed` event is
 	/// received.
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
-	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func startWithCompleted(error error: (E -> ())? = nil, interrupted: (() -> ())? = nil, completed: (() -> ())? = nil) -> Disposable {
-		return start(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
+	/// with the Signal.
+	public func startWithCompleted(completed: () -> ()) -> Disposable {
+		return start(Event.sink(completed: completed))
 	}
 	
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callbacks when events are
+	/// the Signal, which will invoke the given callback when an `error` event is
 	/// received.
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
-	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func startWithError(completed completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, error: (E -> ())? = nil) -> Disposable {
-		return start(Event.sink(error: error, completed: completed, interrupted: interrupted, next: nil))
+	/// with the Signal.
+	public func startWithError(error: E -> ()) -> Disposable {
+		return start(Event.sink(error: error))
+	}
+	
+	/// Creates a Signal from the producer, then adds exactly one observer to
+	/// the Signal, which will invoke the given callback when an `interrupted` event is
+	/// received.
+	///
+	/// Returns a Disposable which can be used to interrupt the work associated
+	/// with the Signal.
+	public func startWithInterrupted(interrupted: () -> ()) -> Disposable {
+		return start(Event.sink(interrupted: interrupted))
 	}
 
 	/// Lifts an unary Signal operator to operate upon SignalProducers instead.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -927,9 +927,9 @@ extension SignalProducerType {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						sendNext(observer, value)
-					case .Error(let error):
+					case let .Error(error):
 						handler(error).startWithSignal { signal, signalDisposable in
 							serialDisposable.innerDisposable = signalDisposable
 							signal.observe(observer)
@@ -1021,7 +1021,7 @@ extension SignalProducerType {
 
 				signal.observe { event in
 					switch event {
-					case .Error(let error):
+					case let .Error(error):
 						sendError(observer, error)
 					case .Completed:
 						sendCompleted(observer)
@@ -1054,14 +1054,14 @@ extension SignalProducerType {
 
 		take(2).start { event in
 			switch event {
-			case .Next(let value):
+			case let .Next(value):
 				if result != nil {
 					// Move into failure state after recieving another value.
 					result = nil
 					return
 				}
 				result = .Success(value)
-			case .Error(let error):
+			case let .Error(error):
 				result = .Failure(error)
 				dispatch_semaphore_signal(semaphore)
 			case .Completed, .Interrupted:
@@ -1181,9 +1181,9 @@ extension SignalProducer where T: SignalProducerType, E == T.E {
 			
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						state.enqueueSignalProducer(value.producer)
-					case .Error(let error):
+					case let .Error(error):
 						sendError(observer, error)
 					case .Completed:
 						// Add one last producer to the queue, whose sole job is to
@@ -1298,7 +1298,7 @@ extension SignalProducer where T: SignalProducerType, E == T.E {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let producer):
+					case let .Next(producer):
 						producer.startWithSignal { innerSignal, innerDisposable in
 							inFlight.modify { $0 + 1 }
 							
@@ -1318,7 +1318,7 @@ extension SignalProducer where T: SignalProducerType, E == T.E {
 								}
 							}
 						}
-					case .Error(let error):
+					case let .Error(error):
 						sendError(relayObserver, error)
 					case .Completed:
 						decrementInFlight()
@@ -1351,7 +1351,7 @@ extension SignalProducer where T: SignalProducerType, E == T.E {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let innerProducer):
+					case let .Next(innerProducer):
 						innerProducer.startWithSignal { innerSignal, innerDisposable in
 							state.modify { (var state) in
 								// When we replace the disposable below, this prevents the
@@ -1400,7 +1400,7 @@ extension SignalProducer where T: SignalProducerType, E == T.E {
 								}
 							}
 						}
-					case .Error(let error):
+					case let .Error(error):
 						sendError(sink, error)
 					case .Completed:
 						let original = state.modify { (var state) in

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -50,8 +50,8 @@ class ActionSpec: QuickSpec {
 					}
 				}
 
-				action.values.observe(next: { values.append($0) })
-				action.errors.observe(next: { errors.append($0) })
+				action.values.observeNext { values.append($0) }
+				action.errors.observeNext { errors.append($0) }
 			}
 
 			it("should be disabled and not executing after initialization") {
@@ -61,9 +61,9 @@ class ActionSpec: QuickSpec {
 
 			it("should error if executed while disabled") {
 				var receivedError: ActionError<NSError>?
-				action.apply(0).start(error: {
+				action.apply(0).startError {
 					receivedError = $0
-				})
+				}
 
 				expect(receivedError).notTo(beNil())
 				if let error = receivedError {
@@ -90,9 +90,9 @@ class ActionSpec: QuickSpec {
 				it("should execute successfully") {
 					var receivedValue: String?
 
-					action.apply(0).start(next: {
+					action.apply(0).startNext {
 						receivedValue = $0
-					})
+					}
 
 					expect(executionCount).to(equal(1))
 					expect(action.executing.value).to(beTruthy())
@@ -113,9 +113,9 @@ class ActionSpec: QuickSpec {
 				it("should execute with an error") {
 					var receivedError: ActionError<NSError>?
 
-					action.apply(1).start(error: {
+					action.apply(1).startError {
 						receivedError = $0
-					})
+					}
 
 					expect(executionCount).to(equal(1))
 					expect(action.executing.value).to(beTruthy())

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -61,7 +61,7 @@ class ActionSpec: QuickSpec {
 
 			it("should error if executed while disabled") {
 				var receivedError: ActionError<NSError>?
-				action.apply(0).startError {
+				action.apply(0).startWithError {
 					receivedError = $0
 				}
 
@@ -90,7 +90,7 @@ class ActionSpec: QuickSpec {
 				it("should execute successfully") {
 					var receivedValue: String?
 
-					action.apply(0).startNext {
+					action.apply(0).startWithNext {
 						receivedValue = $0
 					}
 
@@ -113,7 +113,7 @@ class ActionSpec: QuickSpec {
 				it("should execute with an error") {
 					var receivedError: ActionError<NSError>?
 
-					action.apply(1).startError {
+					action.apply(1).startWithError {
 						receivedError = $0
 					}
 

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -20,7 +20,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				let producer = center.rac_notifications("rac_notifications_test")
 
 				var notif: NSNotification? = nil
-				let disposable = producer.startNext { notif = $0 }
+				let disposable = producer.startWithNext { notif = $0 }
 
 				center.postNotificationName("some_other_notification", object: nil)
 				expect(notif).to(beNil())

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -20,7 +20,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				let producer = center.rac_notifications("rac_notifications_test")
 
 				var notif: NSNotification? = nil
-				let disposable = producer.start(next: { notif = $0 })
+				let disposable = producer.startNext { notif = $0 }
 
 				center.postNotificationName("some_other_notification", object: nil)
 				expect(notif).to(beNil())

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -189,7 +189,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 				expect(action.enabled.value).to(beTruthy())
 
-				action.values.observe(next: { results.append($0) })
+				action.values.observeNext { results.append($0) }
 
 				command = toRACCommand(action)
 				expect(command).notTo(beNil())

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -31,7 +31,7 @@ class PropertySpec: QuickSpec {
 
 				constantProperty.producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						sentValue = value
 					case .Completed:
 						signalCompleted = true
@@ -119,7 +119,7 @@ class PropertySpec: QuickSpec {
 
 					propertyOf.producer.start { event in
 						switch event {
-						case .Next(let value):
+						case let .Next(value):
 							sentValue = value
 						case .Completed:
 							producerCompleted = true

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -57,7 +57,7 @@ class PropertySpec: QuickSpec {
 
 				var sentValue: String?
 
-				mutableProperty.producer.startNext { value in
+				mutableProperty.producer.startWithNext { value in
 					sentValue = value
 				}
 
@@ -71,7 +71,7 @@ class PropertySpec: QuickSpec {
 
 				var signalCompleted = false
 
-				mutableProperty?.producer.startCompleted {
+				mutableProperty?.producer.startWithCompleted {
 					signalCompleted = true
 				}
 
@@ -85,7 +85,7 @@ class PropertySpec: QuickSpec {
 				var value: Int?
 
 				property <~ producer
-				property.producer.startNext { _ in
+				property.producer.startWithNext { _ in
 					value = property.value
 				}
 
@@ -97,8 +97,8 @@ class PropertySpec: QuickSpec {
 				let property = MutableProperty(0)
 
 				var value: Int?
-				property.producer.startNext { _ in
-					property.producer.startNext { x in value = x }
+				property.producer.startWithNext { _ in
+					property.producer.startWithNext { x in value = x }
 				}
 
 				expect(value).to(equal(0))
@@ -206,7 +206,7 @@ class PropertySpec: QuickSpec {
 
 			it("should observe changes to the property and underlying object") {
 				var values: [Int] = []
-				property.producer.startNext { value in
+				property.producer.startWithNext { value in
 					expect(value).notTo(beNil())
 					values.append((value as? Int) ?? -1)
 				}
@@ -228,7 +228,7 @@ class PropertySpec: QuickSpec {
 					let object = ObservableObject()
 					let property = DynamicProperty(object: object, keyPath: "rac_value")
 
-					property.producer.startCompleted {
+					property.producer.startWithCompleted {
 						completed = true
 					}
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -29,11 +29,16 @@ class PropertySpec: QuickSpec {
 				var sentValue: String?
 				var signalCompleted = false
 
-				constantProperty.producer.start(next: { value in
-					sentValue = value
-				}, completed: {
-					signalCompleted = true
-				})
+				constantProperty.producer.start { event in
+					switch event {
+					case .Next(let value):
+						sentValue = value
+					case .Completed:
+						signalCompleted = true
+					default:
+						break
+					}
+				}
 
 				expect(sentValue).to(equal(initialPropertyValue))
 				expect(signalCompleted).to(beTruthy())
@@ -52,9 +57,9 @@ class PropertySpec: QuickSpec {
 
 				var sentValue: String?
 
-				mutableProperty.producer.start(next: { value in
+				mutableProperty.producer.startNext { value in
 					sentValue = value
-				})
+				}
 
 				expect(sentValue).to(equal(initialPropertyValue))
 				mutableProperty.value = subsequentPropertyValue
@@ -66,9 +71,9 @@ class PropertySpec: QuickSpec {
 
 				var signalCompleted = false
 
-				mutableProperty?.producer.start(completed: {
+				mutableProperty?.producer.startCompleted {
 					signalCompleted = true
-				})
+				}
 
 				mutableProperty = nil
 				expect(signalCompleted).to(beTruthy())
@@ -80,9 +85,9 @@ class PropertySpec: QuickSpec {
 				var value: Int?
 
 				property <~ producer
-				property.producer.start(next: { _ in
+				property.producer.startNext { _ in
 					value = property.value
-				})
+				}
 
 				sendNext(sink, 10)
 				expect(value).to(equal(10))
@@ -92,9 +97,9 @@ class PropertySpec: QuickSpec {
 				let property = MutableProperty(0)
 
 				var value: Int?
-				property.producer.start(next: { _ in
-					property.producer.start(next: { x in value = x })
-				})
+				property.producer.startNext { _ in
+					property.producer.startNext { x in value = x }
+				}
 
 				expect(value).to(equal(0))
 
@@ -112,11 +117,16 @@ class PropertySpec: QuickSpec {
 					var sentValue: String?
 					var producerCompleted = false
 
-					propertyOf.producer.start(next: { value in
-						sentValue = value
-					}, completed: {
-						producerCompleted = true
-					})
+					propertyOf.producer.start { event in
+						switch event {
+						case .Next(let value):
+							sentValue = value
+						case .Completed:
+							producerCompleted = true
+						default:
+							break
+						}
+					}
 
 					expect(sentValue).to(equal(initialPropertyValue))
 					expect(producerCompleted).to(beTruthy())
@@ -196,10 +206,10 @@ class PropertySpec: QuickSpec {
 
 			it("should observe changes to the property and underlying object") {
 				var values: [Int] = []
-				property.producer.start(next: { value in
+				property.producer.startNext { value in
 					expect(value).notTo(beNil())
 					values.append((value as? Int) ?? -1)
-				})
+				}
 
 				expect(values).to(equal([ 0 ]))
 
@@ -218,9 +228,9 @@ class PropertySpec: QuickSpec {
 					let object = ObservableObject()
 					let property = DynamicProperty(object: object, keyPath: "rac_value")
 
-					property.producer.start(completed: {
+					property.producer.startCompleted {
 						completed = true
-					})
+					}
 
 					expect(completed).to(beFalsy())
 					expect(property.value).notTo(beNil())

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -127,7 +127,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -160,7 +160,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -308,7 +308,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var completed = false
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -377,7 +377,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				.take(0)
 				.start { event in
 					switch event {
-					case .Next(let number):
+					case let .Next(number):
 						result.append(number)
 					case .Interrupted:
 						interrupted = true
@@ -463,7 +463,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -519,7 +519,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -574,7 +574,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						latestValue = value
 					case .Completed:
 						completed = true
@@ -600,7 +600,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						latestValue = value
 					case .Completed:
 						completed = true
@@ -655,7 +655,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					.delay(10, onScheduler: testScheduler)
 					.start { event in
 						switch event {
-						case .Next(let number):
+						case let .Next(number):
 							result.append(number)
 						case .Completed:
 							completed = true
@@ -757,7 +757,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						values.append(value)
 					case .Completed:
 						completed = true
@@ -920,7 +920,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				zipped.start { event in
 					switch event {
-					case .Next(let left, let right):
+					case let .Next(left, right):
 						result.append("\(left)\(right)")
 					case .Completed:
 						completed = true
@@ -1057,7 +1057,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var errored = false
 				lastThree.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						result.append(value)
 					case .Error(_):
 						errored = true

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -20,10 +20,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: String?
 
-				mappedProducer.start(next: {
+				mappedProducer.startNext {
 					lastValue = $0
 					return
-				})
+				}
 
 				expect(lastValue).to(beNil())
 
@@ -43,7 +43,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer
 					.mapError { _ in producerError }
-					.start(next: { _ in return }, error: { error = $0 })
+					.startError { error = $0 }
 
 				expect(error).to(beNil())
 
@@ -59,7 +59,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: Int?
 
-				mappedProducer.start(next: { lastValue = $0 })
+				mappedProducer.startNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -81,7 +81,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: Int?
 
-				mappedProducer.start(next: { lastValue = $0 })
+				mappedProducer.startNext { lastValue = $0 }
 				expect(lastValue).to(beNil())
 
 				sendNext(sink, nil)
@@ -105,7 +105,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: String?
 
-				producer.start(next: { lastValue = $0 })
+				producer.startNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -125,11 +125,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var lastValue: Int?
 				var completed = false
 
-				producer.start(next: {
-					lastValue = $0
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						lastValue = value
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				expect(lastValue).to(beNil())
 
@@ -153,11 +158,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var lastValue: Int?
 				var completed = false
 
-				producer.start(next: {
-					lastValue = $0
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						lastValue = value
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
@@ -175,7 +185,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skip(1)
 
 				var lastValue: Int?
-				producer.start(next: { lastValue = $0 })
+				producer.startNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -191,7 +201,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skip(0)
 
 				var lastValue: Int?
-				producer.start(next: { lastValue = $0 })
+				producer.startNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -209,7 +219,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skipRepeats()
 
 				var values: [Bool] = []
-				producer.start(next: { values.append($0) })
+				producer.startNext { values.append($0) }
 
 				expect(values).to(equal([]))
 
@@ -231,7 +241,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skipRepeats { $0.characters.count == $1.characters.count }
 
 				var values: [String] = []
-				producer.start(next: { values.append($0) })
+				producer.startNext { values.append($0) }
 
 				expect(values).to(equal([]))
 
@@ -262,7 +272,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				sink = observer
 				lastValue = nil
 
-				producer.start(next: { lastValue = $0 })
+				producer.startNext { lastValue = $0 }
 			}
 
 			it("should skip while the predicate is true") {
@@ -296,11 +306,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: Int?
 				var completed = false
-				producer.start(next: {
-					lastValue = $0
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						lastValue = value
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
@@ -333,7 +348,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				producer
 					.take(numbers.count)
-					.start(completed: { completed = true })
+					.startCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
 				testScheduler.run()
@@ -360,11 +375,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer
 				.take(0)
-				.start(next: { number in
-					result.append(number)
-				}, interrupted: {
-					interrupted = true
-				})
+				.start { event in
+					switch event {
+					case .Next(let number):
+						result.append(number)
+					case .Interrupted:
+						interrupted = true
+					default:
+						break
+					}
+				}
 
 				expect(interrupted).to(beTruthy())
 
@@ -381,10 +401,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var result: [Int]?
 
-				producer.start(next: { value in
+				producer.startNext { value in
 					expect(result).to(beNil())
 					result = value
-				})
+				}
 
 				for number in expectedResult {
 					sendNext(sink, number)
@@ -401,7 +421,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var result: [Int]?
 
-				producer.start(next: { result = $0 })
+				producer.startNext { result = $0 }
 
 				expect(result).to(beNil())
 				sendCompleted(sink)
@@ -414,7 +434,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var error: TestError?
 
-				producer.start(error: { error = $0 })
+				producer.startError { error = $0 }
 
 				expect(error).to(beNil())
 				sendError(sink, .Default)
@@ -441,10 +461,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				lastValue = nil
 				completed = false
 
-				producer.start(
-					next: { lastValue = $0 },
-					completed: { completed = true }
-				)
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						lastValue = value
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 			}
 
 			it("should take values until the trigger fires") {
@@ -491,10 +517,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				lastValue = nil
 				completed = false
 
-				producer.start(
-					next: { lastValue = $0 },
-					completed: { completed = true }
-				)
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						lastValue = value
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 			}
 
 			it("should take values from the original then the replacement") {
@@ -540,11 +572,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var latestValue: Int!
 				var completed = false
 
-				producer.start(next: { value in
-					latestValue = value
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						latestValue = value
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				for value in -1...4 {
 					sendNext(observer, value)
@@ -561,11 +598,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var latestValue: Int?
 				var completed = false
 
-				producer.start(next: { value in
-					latestValue = value
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						latestValue = value
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				sendNext(observer, 5)
 				expect(latestValue).to(beNil())
@@ -582,7 +624,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer
 					.observeOn(testScheduler)
-					.start(next: { result.append($0) })
+					.startNext { result.append($0) }
 				
 				sendNext(observer, 1)
 				sendNext(observer, 2)
@@ -611,11 +653,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				producer
 					.delay(10, onScheduler: testScheduler)
-					.start(next: { number in
-						result.append(number)
-					}, completed: {
-						completed = true
-					})
+					.start { event in
+						switch event {
+						case .Next(let number):
+							result.append(number)
+						case .Completed:
+							completed = true
+						default:
+							break
+						}
+					}
 				
 				testScheduler.advanceByInterval(4) // send initial value
 				expect(result).to(beEmpty())
@@ -644,7 +691,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				producer
 					.delay(10, onScheduler: testScheduler)
-					.start(error: { _ in errored = true })
+					.startError { _ in errored = true }
 				
 				testScheduler.advance()
 				expect(errored).to(beTruthy())
@@ -667,9 +714,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should send values on the given scheduler at no less than the interval") {
 				var values: [Int] = []
-				producer.start(next: { value in
+				producer.startNext { value in
 					values.append(value)
-				})
+				}
 
 				expect(values).to(equal([]))
 
@@ -708,11 +755,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var values: [Int] = []
 				var completed = false
 
-				producer.start(next: { value in
-					values.append(value)
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						values.append(value)
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				sendNext(observer, 0)
 				scheduler.advance()
@@ -743,7 +795,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should forward the latest value when the sampler fires") {
 				var result: [Int] = []
-				sampledProducer.start(next: { result.append($0) })
+				sampledProducer.startNext { result.append($0) }
 				
 				sendNext(observer, 1)
 				sendNext(observer, 2)
@@ -753,7 +805,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should do nothing if sampler fires before signal receives value") {
 				var result: [Int] = []
-				sampledProducer.start(next: { result.append($0) })
+				sampledProducer.startNext { result.append($0) }
 				
 				sendNext(samplerObserver, ())
 				expect(result).to(beEmpty())
@@ -761,7 +813,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send lates value multiple times when sampler fires multiple times") {
 				var result: [Int] = []
-				sampledProducer.start(next: { result.append($0) })
+				sampledProducer.startNext { result.append($0) }
 				
 				sendNext(observer, 1)
 				sendNext(samplerObserver, ())
@@ -771,7 +823,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should complete when both inputs have completed") {
 				var completed = false
-				sampledProducer.start(completed: { completed = true })
+				sampledProducer.startCompleted { completed = true }
 				
 				sendCompleted(observer)
 				expect(completed).to(beFalsy())
@@ -796,7 +848,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should forward the latest values from both inputs") {
 				var latest: (Int, Double)?
-				combinedProducer.start(next: { latest = $0 })
+				combinedProducer.startNext { latest = $0 }
 				
 				sendNext(observer, 1)
 				expect(latest).to(beNil())
@@ -813,7 +865,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should complete when both inputs have completed") {
 				var completed = false
-				combinedProducer.start(completed: { completed = true })
+				combinedProducer.startCompleted { completed = true }
 				
 				sendCompleted(observer)
 				expect(completed).to(beFalsy())
@@ -839,7 +891,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should combine pairs") {
 				var result: [String] = []
-				zipped.start(next: { (left, right) in result.append("\(left)\(right)") })
+				zipped.startNext { (left, right) in result.append("\(left)\(right)") }
 
 				sendNext(leftSink, 1)
 				sendNext(leftSink, 2)
@@ -866,11 +918,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [String] = []
 				var completed = false
 
-				zipped.start(next: { (left, right) in
-					result.append("\(left)\(right)")
-				}, completed: {
-					completed = true
-				})
+				zipped.start { event in
+					switch event {
+					case .Next(let left, let right):
+						result.append("\(left)\(right)")
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				expect(completed).to(beFalsy())
 
@@ -891,7 +948,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var latestEvent: Event<Int, TestError>?
 				producer
 					.materialize()
-					.start(next: { latestEvent = $0 })
+					.startNext { latestEvent = $0 }
 				
 				sendNext(observer, 2)
 				
@@ -930,7 +987,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send values for Next events") {
 				var result: [Int] = []
-				dematerialized.start(next: { result.append($0) })
+				dematerialized.startNext { result.append($0) }
 				
 				expect(result).to(beEmpty())
 				
@@ -943,7 +1000,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should error out for Error events") {
 				var errored = false
-				dematerialized.start(error: { _ in errored = true })
+				dematerialized.startError { _ in errored = true }
 				
 				expect(errored).to(beFalsy())
 				
@@ -953,7 +1010,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should complete early for Completed events") {
 				var completed = false
-				dematerialized.start(completed: { completed = true })
+				dematerialized.startCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
 				sendNext(sink, IntEvent.Completed)
@@ -973,7 +1030,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send the last N values upon completion") {
 				var result: [Int] = []
-				lastThree.start(next: { result.append($0) })
+				lastThree.startNext { result.append($0) }
 				
 				sendNext(sink, 1)
 				sendNext(sink, 2)
@@ -987,7 +1044,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should send less than N values if not enough were received") {
 				var result: [Int] = []
-				lastThree.start(next: { result.append($0) })
+				lastThree.startNext { result.append($0) }
 				
 				sendNext(sink, 1)
 				sendNext(sink, 2)
@@ -998,8 +1055,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should send nothing when errors") {
 				var result: [Int] = []
 				var errored = false
-				lastThree.start(	next: { result.append($0) },
-									error: { _ in errored = true }	)
+				lastThree.start { event in
+					switch event {
+					case .Next(let value):
+						result.append(value)
+					case .Error(_):
+						errored = true
+					default:
+						break
+					}
+				}
 				
 				sendNext(sink, 1)
 				sendNext(sink, 2)
@@ -1027,11 +1092,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should complete if within the interval") {
 				var completed = false
 				var errored = false
-				producer.start(completed: {
-					completed = true
-				}, error: { _ in
-					errored = true
-				})
+				producer.start { event in
+					switch event {
+					case .Completed:
+						completed = true
+					case .Error(_):
+						errored = true
+					default:
+						break
+					}
+				}
 
 				testScheduler.scheduleAfter(1) {
 					sendCompleted(sink)
@@ -1048,11 +1118,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should error if not completed before the interval has elapsed") {
 				var completed = false
 				var errored = false
-				producer.start(completed: {
-					completed = true
-				}, error: { _ in
-					errored = true
-				})
+				producer.start { event in
+					switch event {
+					case .Completed:
+						completed = true
+					case .Error(_):
+						errored = true
+					default:
+						break
+					}
+				}
 
 				testScheduler.scheduleAfter(3) {
 					sendCompleted(sink)
@@ -1075,9 +1150,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var current: Int?
-				producer.start(next: { value in
+				producer.startNext { value in
 					current = value
-				})
+				}
 				
 				for value in 1...5 {
 					sendNext(sink, value)
@@ -1092,9 +1167,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				producer.start(error: { err in
+				producer.startError { err in
 					error = err
-				})
+				}
 				
 				sendNext(sink, 42)
 				expect(error).to(equal(TestError.Default))
@@ -1109,9 +1184,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var even: Bool?
-				producer.start(next: { value in
+				producer.startNext { value in
 					even = value
-				})
+				}
 				
 				sendNext(sink, 1)
 				expect(even).to(equal(false))
@@ -1127,9 +1202,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				producer.start(error: { err in
+				producer.startError { err in
 					error = err
-				})
+				}
 				
 				sendNext(sink, 42)
 				expect(error).to(equal(TestError.Default))
@@ -1146,7 +1221,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				let (signal, baseSink) = SignalProducer<Int, NoError>.buffer()
 				sink = baseSink
-				signal.combinePrevious(initialValue).start(next: { latestValues = $0 })
+				signal.combinePrevious(initialValue).startNext { latestValues = $0 }
 			}
 			
 			it("should forward the latest value with previous value") {

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -20,7 +20,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: String?
 
-				mappedProducer.startNext {
+				mappedProducer.startWithNext {
 					lastValue = $0
 					return
 				}
@@ -43,7 +43,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer
 					.mapError { _ in producerError }
-					.startError { error = $0 }
+					.startWithError { error = $0 }
 
 				expect(error).to(beNil())
 
@@ -59,7 +59,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: Int?
 
-				mappedProducer.startNext { lastValue = $0 }
+				mappedProducer.startWithNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -81,7 +81,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: Int?
 
-				mappedProducer.startNext { lastValue = $0 }
+				mappedProducer.startWithNext { lastValue = $0 }
 				expect(lastValue).to(beNil())
 
 				sendNext(sink, nil)
@@ -105,7 +105,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var lastValue: String?
 
-				producer.startNext { lastValue = $0 }
+				producer.startWithNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -185,7 +185,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skip(1)
 
 				var lastValue: Int?
-				producer.startNext { lastValue = $0 }
+				producer.startWithNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -201,7 +201,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skip(0)
 
 				var lastValue: Int?
-				producer.startNext { lastValue = $0 }
+				producer.startWithNext { lastValue = $0 }
 
 				expect(lastValue).to(beNil())
 
@@ -219,7 +219,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skipRepeats()
 
 				var values: [Bool] = []
-				producer.startNext { values.append($0) }
+				producer.startWithNext { values.append($0) }
 
 				expect(values).to(equal([]))
 
@@ -241,7 +241,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let producer = baseProducer.skipRepeats { $0.characters.count == $1.characters.count }
 
 				var values: [String] = []
-				producer.startNext { values.append($0) }
+				producer.startWithNext { values.append($0) }
 
 				expect(values).to(equal([]))
 
@@ -272,7 +272,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				sink = observer
 				lastValue = nil
 
-				producer.startNext { lastValue = $0 }
+				producer.startWithNext { lastValue = $0 }
 			}
 
 			it("should skip while the predicate is true") {
@@ -348,7 +348,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				producer
 					.take(numbers.count)
-					.startCompleted { completed = true }
+					.startWithCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
 				testScheduler.run()
@@ -401,7 +401,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var result: [Int]?
 
-				producer.startNext { value in
+				producer.startWithNext { value in
 					expect(result).to(beNil())
 					result = value
 				}
@@ -421,7 +421,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var result: [Int]?
 
-				producer.startNext { result = $0 }
+				producer.startWithNext { result = $0 }
 
 				expect(result).to(beNil())
 				sendCompleted(sink)
@@ -434,7 +434,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var error: TestError?
 
-				producer.startError { error = $0 }
+				producer.startWithError { error = $0 }
 
 				expect(error).to(beNil())
 				sendError(sink, .Default)
@@ -624,7 +624,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer
 					.observeOn(testScheduler)
-					.startNext { result.append($0) }
+					.startWithNext { result.append($0) }
 				
 				sendNext(observer, 1)
 				sendNext(observer, 2)
@@ -691,7 +691,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				producer
 					.delay(10, onScheduler: testScheduler)
-					.startError { _ in errored = true }
+					.startWithError { _ in errored = true }
 				
 				testScheduler.advance()
 				expect(errored).to(beTruthy())
@@ -714,7 +714,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should send values on the given scheduler at no less than the interval") {
 				var values: [Int] = []
-				producer.startNext { value in
+				producer.startWithNext { value in
 					values.append(value)
 				}
 
@@ -795,7 +795,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should forward the latest value when the sampler fires") {
 				var result: [Int] = []
-				sampledProducer.startNext { result.append($0) }
+				sampledProducer.startWithNext { result.append($0) }
 				
 				sendNext(observer, 1)
 				sendNext(observer, 2)
@@ -805,7 +805,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should do nothing if sampler fires before signal receives value") {
 				var result: [Int] = []
-				sampledProducer.startNext { result.append($0) }
+				sampledProducer.startWithNext { result.append($0) }
 				
 				sendNext(samplerObserver, ())
 				expect(result).to(beEmpty())
@@ -813,7 +813,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send lates value multiple times when sampler fires multiple times") {
 				var result: [Int] = []
-				sampledProducer.startNext { result.append($0) }
+				sampledProducer.startWithNext { result.append($0) }
 				
 				sendNext(observer, 1)
 				sendNext(samplerObserver, ())
@@ -823,7 +823,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should complete when both inputs have completed") {
 				var completed = false
-				sampledProducer.startCompleted { completed = true }
+				sampledProducer.startWithCompleted { completed = true }
 				
 				sendCompleted(observer)
 				expect(completed).to(beFalsy())
@@ -848,7 +848,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should forward the latest values from both inputs") {
 				var latest: (Int, Double)?
-				combinedProducer.startNext { latest = $0 }
+				combinedProducer.startWithNext { latest = $0 }
 				
 				sendNext(observer, 1)
 				expect(latest).to(beNil())
@@ -865,7 +865,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should complete when both inputs have completed") {
 				var completed = false
-				combinedProducer.startCompleted { completed = true }
+				combinedProducer.startWithCompleted { completed = true }
 				
 				sendCompleted(observer)
 				expect(completed).to(beFalsy())
@@ -891,7 +891,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should combine pairs") {
 				var result: [String] = []
-				zipped.startNext { (left, right) in result.append("\(left)\(right)") }
+				zipped.startWithNext { (left, right) in result.append("\(left)\(right)") }
 
 				sendNext(leftSink, 1)
 				sendNext(leftSink, 2)
@@ -948,7 +948,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var latestEvent: Event<Int, TestError>?
 				producer
 					.materialize()
-					.startNext { latestEvent = $0 }
+					.startWithNext { latestEvent = $0 }
 				
 				sendNext(observer, 2)
 				
@@ -987,7 +987,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send values for Next events") {
 				var result: [Int] = []
-				dematerialized.startNext { result.append($0) }
+				dematerialized.startWithNext { result.append($0) }
 				
 				expect(result).to(beEmpty())
 				
@@ -1000,7 +1000,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should error out for Error events") {
 				var errored = false
-				dematerialized.startError { _ in errored = true }
+				dematerialized.startWithError { _ in errored = true }
 				
 				expect(errored).to(beFalsy())
 				
@@ -1010,7 +1010,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should complete early for Completed events") {
 				var completed = false
-				dematerialized.startCompleted { completed = true }
+				dematerialized.startWithCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
 				sendNext(sink, IntEvent.Completed)
@@ -1030,7 +1030,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send the last N values upon completion") {
 				var result: [Int] = []
-				lastThree.startNext { result.append($0) }
+				lastThree.startWithNext { result.append($0) }
 				
 				sendNext(sink, 1)
 				sendNext(sink, 2)
@@ -1044,7 +1044,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should send less than N values if not enough were received") {
 				var result: [Int] = []
-				lastThree.startNext { result.append($0) }
+				lastThree.startWithNext { result.append($0) }
 				
 				sendNext(sink, 1)
 				sendNext(sink, 2)
@@ -1150,7 +1150,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var current: Int?
-				producer.startNext { value in
+				producer.startWithNext { value in
 					current = value
 				}
 				
@@ -1167,7 +1167,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				producer.startError { err in
+				producer.startWithError { err in
 					error = err
 				}
 				
@@ -1184,7 +1184,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var even: Bool?
-				producer.startNext { value in
+				producer.startWithNext { value in
 					even = value
 				}
 				
@@ -1202,7 +1202,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				producer.startError { err in
+				producer.startWithError { err in
 					error = err
 				}
 				
@@ -1221,7 +1221,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				let (signal, baseSink) = SignalProducer<Int, NoError>.buffer()
 				sink = baseSink
-				signal.combinePrevious(initialValue).startNext { latestValues = $0 }
+				signal.combinePrevious(initialValue).startWithNext { latestValues = $0 }
 			}
 			
 			it("should forward the latest value with previous value") {

--- a/ReactiveCocoaTests/Swift/SignalProducerNimbleMatchers.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerNimbleMatchers.swift
@@ -29,11 +29,11 @@ public func sendValues<T: Equatable, E: Equatable>(values: [T], sendError maybeS
 
 			signalProducer.start { event in
 				switch event {
-				case .Next(let value):
+				case let .Next(value):
 					sentValues.append(value)
 				case .Completed:
 					signalCompleted = true
-				case .Error(let error):
+				case let .Error(error):
 					sentError = error
 				default:
 					break

--- a/ReactiveCocoaTests/Swift/SignalProducerNimbleMatchers.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerNimbleMatchers.swift
@@ -27,13 +27,18 @@ public func sendValues<T: Equatable, E: Equatable>(values: [T], sendError maybeS
 			var sentError: E?
 			var signalCompleted = false
 
-			signalProducer.start(next: { value in
-				sentValues.append(value)
-			}, error: { error in
-				sentError = error
-			}, completed: {
-				signalCompleted = true
-			})
+			signalProducer.start { event in
+				switch event {
+				case .Next(let value):
+					sentValues.append(value)
+				case .Completed:
+					signalCompleted = true
+				case .Error(let error):
+					sentError = error
+				default:
+					break
+				}
+			}
 
 			if sentValues != values {
 				return false

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -47,7 +47,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.startWithSignal { signal, _ in
 					let object = NSObject()
 					objectRetainedByObserver = object
-					signal.observe { _ in object }
+					signal.observeNext { _ in object }
 				}
 
 				expect(objectRetainedByObserver).toNot(beNil())
@@ -191,11 +191,16 @@ class SignalProducerSpec: QuickSpec {
 
 				var values: [Int] = []
 				var completed = false
-				producer.start(next: {
-					values.append($0)
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						values.append(value)
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				expect(values).to(equal([1, 2, 3]))
 				expect(completed).to(beFalsy())
@@ -220,11 +225,16 @@ class SignalProducerSpec: QuickSpec {
 
 				var values: [Int] = []
 				var error: TestError?
-				producer.start(next: {
-					values.append($0)
-				}, error: {
-					error = $0
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						values.append(value)
+					case .Error(let err):
+						error = err
+					default:
+						break
+					}
+				}
 				
 				expect(values).to(equal([2]))
 				expect(error).to(beNil())
@@ -247,9 +257,9 @@ class SignalProducerSpec: QuickSpec {
 				
 				sendCompleted(sink)
 				
-				producer.start(completed: {
+				producer.startCompleted {
 					completed = true
-				})
+				}
 				
 				expect(completed).to(beTruthy())
 			}
@@ -262,11 +272,16 @@ class SignalProducerSpec: QuickSpec {
 				sendNext(sink, 123)
 				sendCompleted(sink)
 				
-				producer.start(next: {val in
-					value = val
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let val):
+						value = val
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 				
 				expect(value).to(equal(123))
 				expect(completed).to(beTruthy())
@@ -280,13 +295,13 @@ class SignalProducerSpec: QuickSpec {
 				sendNext(sink, 3)
 
 				var values: [Int] = []
-				producer.start(completed: {
+				producer.startCompleted {
 					values = []
 
-					producer.start(next: { value in
+					producer.startNext { value in
 						values.append(value)
-					})
-				})
+					}
+				}
 
 				sendCompleted(sink)
 				expect(values).to(equal([ 1, 2, 3 ]))
@@ -298,18 +313,18 @@ class SignalProducerSpec: QuickSpec {
 				var values: [Int] = []
 				var lastBufferedValues: [Int] = []
 
-				producer.start(next: { newValue in
+				producer.startNext { newValue in
 					values.append(newValue)
 
 					var bufferedValues: [Int] = []
 					
-					producer.start(next: { bufferedValue in
+					producer.startNext { bufferedValue in
 						bufferedValues.append(bufferedValue)
-					})
+					}
 
 					expect(bufferedValues).to(equal(values))
 					lastBufferedValues = bufferedValues
-				})
+				}
 
 				sendNext(sink, 1)
 				expect(values).to(equal([ 1 ]))
@@ -331,7 +346,7 @@ class SignalProducerSpec: QuickSpec {
 				let (producer, sink) = SignalProducer<Int, NoError>.buffer(1)
 				sendNext(sink, 1)
 
-				producer.start { next in
+				producer.startNext { next in
 					values.append(next)
 				}
 
@@ -423,9 +438,9 @@ class SignalProducerSpec: QuickSpec {
 				SignalProducer<Int, NoError>(value: 42)
 					.startOn(TestScheduler())
 					.startWithSignal { signal, innerDisposable in
-						signal.observe(interrupted: {
+						signal.observeInterrupted {
 							interrupted = true
-						})
+						}
 
 						disposable = innerDisposable
 					}
@@ -444,7 +459,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.startWithSignal { signal, innerDisposable in
 					let object = NSObject()
 					objectRetainedByObserver = object
-					signal.observe { _ in object.description }
+					signal.observeNext { _ in object.description }
 					disposable = innerDisposable
 				}
 
@@ -482,9 +497,9 @@ class SignalProducerSpec: QuickSpec {
 					.startWithSignal { signal, disposable in
 						expect(interrupted).to(beFalsy())
 
-						signal.observe(interrupted: {
+						signal.observeInterrupted {
 							interrupted = true
-						})
+						}
 
 						disposable.dispose()
 					}
@@ -531,11 +546,16 @@ class SignalProducerSpec: QuickSpec {
 
 				var values: [Int] = []
 				var completed = false
-				producer.start(next: {
-					values.append($0)
-				}, completed: {
-					completed = true
-				})
+				producer.start { event in
+					switch event {
+					case .Next(let value):
+						values.append(value)
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
 
 				expect(values).to(equal([1, 2]))
 				expect(completed).to(beTruthy())
@@ -545,9 +565,9 @@ class SignalProducerSpec: QuickSpec {
 				let producer = SignalProducer<(), NoError>.never
 
 				var interrupted = false
-				let disposable = producer.start(interrupted: {
+				let disposable = producer.startInterrupted {
 					interrupted = true
-				})
+				}
 
 				expect(interrupted).to(beFalsy())
 
@@ -562,7 +582,7 @@ class SignalProducerSpec: QuickSpec {
 					let producer = SignalProducer<Int, NoError>.never
 					let object = NSObject()
 					objectRetainedByObserver = object
-					disposable = producer.start { _ in object }
+					disposable = producer.startNext { _ in object }
 				}
 
 				test()
@@ -577,9 +597,9 @@ class SignalProducerSpec: QuickSpec {
 					var values = [Int]()
 					let (producer, sink) = SignalProducer<Int, NoError>.buffer()
 
-					producer.start(next: { next in
+					producer.startNext { next in
 						values.append(next)
-					})
+					}
 
 					sendNext(sink, 1)
 					sendNext(sink, 2)
@@ -696,7 +716,7 @@ class SignalProducerSpec: QuickSpec {
 				let producer = timer(1, onScheduler: scheduler, withLeeway: 0)
 
 				var dates: [NSDate] = []
-				producer.start(next: { dates.append($0) })
+				producer.startNext { dates.append($0) }
 
 				scheduler.advanceByInterval(0.9)
 				expect(dates).to(equal([]))
@@ -798,7 +818,7 @@ class SignalProducerSpec: QuickSpec {
 				let producer = timer(2, onScheduler: testScheduler, withLeeway: 0)
 
 				var next: NSDate?
-				producer.startOn(startScheduler).start(next: { next = $0 })
+				producer.startOn(startScheduler).startNext { next = $0 }
 
 				startScheduler.advanceByInterval(2)
 				expect(next).to(beNil())
@@ -830,11 +850,16 @@ class SignalProducerSpec: QuickSpec {
 						sendCompleted(innerSink)
 						return innerProducer
 					}
-					.start(next: {
-						values.append($0)
-					}, completed: {
-						completed = true
-					})
+					.start { event in
+						switch event {
+						case .Next(let value):
+							values.append(value)
+						case .Completed:
+							completed = true
+						default:
+							break
+						}
+					}
 
 				expect(values).to(equal([1, 2]))
 				expect(completed).to(beTruthy())
@@ -898,9 +923,9 @@ class SignalProducerSpec: QuickSpec {
 					let outerProducer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: errorProducer)
 
 					var error: TestError?
-					(outerProducer.flatten(.Concat)).start(error: { e in
+					(outerProducer.flatten(.Concat)).startError { e in
 						error = e
-					})
+					}
 
 					expect(error).to(equal(TestError.Default))
 				}
@@ -909,9 +934,9 @@ class SignalProducerSpec: QuickSpec {
 					let (outerProducer, outerSink) = SignalProducer<SignalProducer<Int, TestError>, TestError>.buffer()
 
 					var error: TestError?
-					outerProducer.flatten(.Concat).start(error: { e in
+					outerProducer.flatten(.Concat).startError { e in
 						error = e
-					})
+					}
 
 					sendError(outerSink, TestError.Default)
 					expect(error).to(equal(TestError.Default))
@@ -931,9 +956,9 @@ class SignalProducerSpec: QuickSpec {
 						completeInner = { sendCompleted(innerSink) }
 
 						completed = false
-						outerProducer.flatten(.Concat).start(completed: {
+						outerProducer.flatten(.Concat).startCompleted {
 							completed = true
-						})
+						}
 
 						sendNext(outerSink, innerProducer)
 					}
@@ -984,11 +1009,16 @@ class SignalProducerSpec: QuickSpec {
 						sendNext(outerSink, producerA)
 						sendNext(outerSink, producerB)
 
-						outerProducer.flatten(.Merge).start(next: { i in
-							recv.append(i)
-						}, error: { _ in () }, completed: {
-							outerCompleted = true
-						})
+						outerProducer.flatten(.Merge).start { event in
+							switch event {
+							case .Next(let i):
+								recv.append(i)
+							case .Completed:
+								outerCompleted = true
+							default:
+								break
+							}
+						}
 
 						sendCompleted(outerSink)
 					}
@@ -1016,9 +1046,9 @@ class SignalProducerSpec: QuickSpec {
 						let outerProducer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: errorProducer)
 
 						var error: TestError?
-						outerProducer.flatten(.Merge).start(error: { e in
+						outerProducer.flatten(.Merge).startError { e in
 							error = e
-						})
+						}
 						expect(error).to(equal(TestError.Default))
 					}
 
@@ -1026,9 +1056,9 @@ class SignalProducerSpec: QuickSpec {
 						let (outerProducer, outerSink) = SignalProducer<SignalProducer<Int, TestError>, TestError>.buffer()
 
 						var error: TestError?
-						outerProducer.flatten(.Merge).start(error: { e in
+						outerProducer.flatten(.Merge).startError { e in
 							error = e
-						})
+						}
 
 						sendError(outerSink, TestError.Default)
 						expect(error).to(equal(TestError.Default))
@@ -1046,16 +1076,18 @@ class SignalProducerSpec: QuickSpec {
 					var errored = false
 					var completed = false
 
-					outer.flatten(.Latest).start(
-						next: {
-							receivedValues.append($0)
-						},
-						error: { _ in
-							errored = true
-						},
-						completed: {
+					outer.flatten(.Latest).start { event in
+						switch event {
+						case .Next(let value):
+							receivedValues.append(value)
+						case .Completed:
 							completed = true
-					})
+						case .Error(_):
+							errored = true
+						default:
+							break
+						}
+					}
 
 					sendNext(firstInnerSink, 1)
 					sendNext(secondInnerSink, 2)
@@ -1098,9 +1130,9 @@ class SignalProducerSpec: QuickSpec {
 					let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: inner)
 
 					var completed = false
-					outer.flatten(.Latest).start(completed: {
+					outer.flatten(.Latest).startCompleted {
 						completed = true
-					})
+					}
 
 					expect(completed).to(beTruthy())
 				}
@@ -1109,9 +1141,9 @@ class SignalProducerSpec: QuickSpec {
 					let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>.empty
 
 					var completed = false
-					outer.flatten(.Latest).start(completed: {
+					outer.flatten(.Latest).startCompleted {
 						completed = true
-					})
+					}
 
 					expect(completed).to(beTruthy())
 				}
@@ -1146,11 +1178,16 @@ class SignalProducerSpec: QuickSpec {
 
 						outerProducer
 							.flatten(strategy)
-							.start(interrupted: { _ in
-								interrupted = true
-							}, completed: { _ in
-								completed = true
-							})
+							.start { event in
+								switch event {
+								case .Interrupted:
+									interrupted = true
+								case .Completed:
+									completed = true
+								default:
+									break
+								}
+							}
 					}
 
 					sendNext(outerSink, innerProducer)
@@ -1369,9 +1406,9 @@ class SignalProducerSpec: QuickSpec {
 				let producer = original.then(subsequent)
 
 				var completed = false
-				producer.start(completed: {
+				producer.startCompleted {
 					completed = true
-				})
+				}
 
 				sendCompleted(originalSink)
 				expect(completed).to(beFalsy())

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -193,7 +193,7 @@ class SignalProducerSpec: QuickSpec {
 				var completed = false
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						values.append(value)
 					case .Completed:
 						completed = true
@@ -227,9 +227,9 @@ class SignalProducerSpec: QuickSpec {
 				var error: TestError?
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						values.append(value)
-					case .Error(let err):
+					case let .Error(err):
 						error = err
 					default:
 						break
@@ -274,7 +274,7 @@ class SignalProducerSpec: QuickSpec {
 				
 				producer.start { event in
 					switch event {
-					case .Next(let val):
+					case let .Next(val):
 						value = val
 					case .Completed:
 						completed = true
@@ -548,7 +548,7 @@ class SignalProducerSpec: QuickSpec {
 				var completed = false
 				producer.start { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						values.append(value)
 					case .Completed:
 						completed = true
@@ -852,7 +852,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 					.start { event in
 						switch event {
-						case .Next(let value):
+						case let .Next(value):
 							values.append(value)
 						case .Completed:
 							completed = true
@@ -1011,7 +1011,7 @@ class SignalProducerSpec: QuickSpec {
 
 						outerProducer.flatten(.Merge).start { event in
 							switch event {
-							case .Next(let i):
+							case let .Next(i):
 								recv.append(i)
 							case .Completed:
 								outerCompleted = true
@@ -1078,7 +1078,7 @@ class SignalProducerSpec: QuickSpec {
 
 					outer.flatten(.Latest).start { event in
 						switch event {
-						case .Next(let value):
+						case let .Next(value):
 							receivedValues.append(value)
 						case .Completed:
 							completed = true

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -438,10 +438,8 @@ class SignalProducerSpec: QuickSpec {
 				SignalProducer<Int, NoError>(value: 42)
 					.startOn(TestScheduler())
 					.startWithSignal { signal, innerDisposable in
-						signal.observe { event in
-							if case .Interrupted = event {
-								interrupted = true
-							}
+						signal.observeInterrupted {
+							interrupted = true
 						}
 
 						disposable = innerDisposable
@@ -499,10 +497,8 @@ class SignalProducerSpec: QuickSpec {
 					.startWithSignal { signal, disposable in
 						expect(interrupted).to(beFalsy())
 
-						signal.observe { event in
-							if case .Interrupted = event {
-								interrupted = true
-							}
+						signal.observeInterrupted {
+							interrupted = true
 						}
 
 						disposable.dispose()
@@ -569,10 +565,8 @@ class SignalProducerSpec: QuickSpec {
 				let producer = SignalProducer<(), NoError>.never
 
 				var interrupted = false
-				let disposable = producer.start { event in
-					if case .Interrupted = event {
-						interrupted = true
-					}
+				let disposable = producer.startWithInterrupted {
+					interrupted = true
 				}
 
 				expect(interrupted).to(beFalsy())

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -88,7 +88,11 @@ class SignalSpec: QuickSpec {
 				}
 
 				var interrupted = false
-				signal?.observeInterrupted { interrupted = true }
+				signal?.observe { event in
+					if case .Interrupted = event {
+						interrupted = true
+					}
+				}
 
 				expect(interrupted).to(beFalsy())
 				expect(signal).toNot(beNil())
@@ -192,7 +196,11 @@ class SignalSpec: QuickSpec {
 				}
 
 				var interrupted = false
-				signal.observeInterrupted { interrupted = true }
+				signal.observe { event in
+					if case .Interrupted = event {
+						interrupted = true
+					}
+				}
 
 				expect(interrupted).to(beFalsy())
 				expect(disposable.disposed).to(beFalsy())

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -119,7 +119,7 @@ class SignalSpec: QuickSpec {
 				
 				signal.observe { event in
 					switch event {
-					case .Next(let number):
+					case let .Next(number):
 						fromSignal.append(number)
 					case .Completed:
 						completed = true
@@ -285,7 +285,7 @@ class SignalSpec: QuickSpec {
 				
 				signal.observe { event in
 					switch event {
-					case .Next(let number):
+					case let .Next(number):
 						fromSignal.append(number)
 					case .Completed:
 						completed = true
@@ -535,7 +535,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -568,7 +568,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -716,7 +716,7 @@ class SignalSpec: QuickSpec {
 				var completed = false
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -780,7 +780,7 @@ class SignalSpec: QuickSpec {
 				.take(0)
 				.observe { event in
 					switch event {
-					case .Next(let number):
+					case let .Next(number):
 						result.append(number)
 					case .Interrupted:
 						interrupted = true
@@ -866,7 +866,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -922,7 +922,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						lastValue = value
 					case .Completed:
 						completed = true
@@ -977,7 +977,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						latestValue = value
 					case .Completed:
 						completed = true
@@ -1003,7 +1003,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						latestValue = value
 					case .Completed:
 						completed = true
@@ -1059,7 +1059,7 @@ class SignalSpec: QuickSpec {
 					.delay(10, onScheduler: testScheduler)
 					.observe { event in
 						switch event {
-						case .Next(let number):
+						case let .Next(number):
 							result.append(number)
 						case .Completed:
 							completed = true
@@ -1160,7 +1160,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						values.append(value)
 					case .Completed:
 						completed = true
@@ -1323,7 +1323,7 @@ class SignalSpec: QuickSpec {
 
 				zipped.observe { event in
 					switch event {
-					case .Next(let left, let right):
+					case let .Next(left, right):
 						result.append("\(left)\(right)")
 					case .Completed:
 						completed = true
@@ -1460,7 +1460,7 @@ class SignalSpec: QuickSpec {
 				var errored = false
 				lastThree.observe { event in
 					switch event {
-					case .Next(let value):
+					case let .Next(value):
 						result.append(value)
 					case .Error(_):
 						errored = true
@@ -1712,7 +1712,7 @@ class SignalSpec: QuickSpec {
 					combineLatest(signalA, signalB, signalC)
 						.observe { event in
 							switch event {
-							case .Next(let value):
+							case let .Next(value):
 								combinedValues = [value.0, value.1, value.2]
 							case .Completed:
 								completed = true
@@ -1730,7 +1730,7 @@ class SignalSpec: QuickSpec {
 					combineLatest([signalA, signalB, signalC])
 					.observe { event in
 						switch event {
-						case .Next(let values):
+						case let .Next(values):
 							combinedValues = values
 						case .Completed:
 							completed = true
@@ -1818,7 +1818,7 @@ class SignalSpec: QuickSpec {
 					zip(signalA, signalB, signalC)
 						.observe { event in
 							switch event {
-							case .Next(let value):
+							case let .Next(value):
 								zippedValues = [value.0, value.1, value.2]
 							case .Completed:
 								completed = true
@@ -1836,7 +1836,7 @@ class SignalSpec: QuickSpec {
 					zip([signalA, signalB, signalC])
 						.observe { event in
 							switch event {
-							case .Next(let values):
+							case let .Next(values):
 								zippedValues = values
 							case .Completed:
 								completed = true

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -88,10 +88,8 @@ class SignalSpec: QuickSpec {
 				}
 
 				var interrupted = false
-				signal?.observe { event in
-					if case .Interrupted = event {
-						interrupted = true
-					}
+				signal?.observeInterrupted {
+					interrupted = true
 				}
 
 				expect(interrupted).to(beFalsy())
@@ -196,10 +194,8 @@ class SignalSpec: QuickSpec {
 				}
 
 				var interrupted = false
-				signal.observe { event in
-					if case .Interrupted = event {
-						interrupted = true
-					}
+				signal.observeInterrupted {
+					interrupted = true
 				}
 
 				expect(interrupted).to(beFalsy())


### PR DESCRIPTION
Issues #2311 contains the background discussion for this change.

In Swift 2 (and the swift2 branch of this repo), the `SinkOf<T>` type is gone and instead a normal closure `T -> ()` is used. This is great but it introduces a potential risk due to the behaviour change when calling `SignalProducer.start()` with a trailing closure. In Swift 1.x, the trailing closure would default to the next argument, and in order to provide a sink you would need to pass in a `SinkOf<Event<T>>`. In Swift 2 however, the trailing closure will match the new sink type `T -> ()`. From the call site, the call looks identical after migrating to the swift2 branch but the behaviour is different. This could potentially introduce issues in cases where the argument to start is ignored `(_)`, as the type checker will not catch it and the closure will be called on next/interrupted/error/completed and not just on next.

Since Box is no longer needed with Swift 2, this PR replaces the `start(next:_:completed:_:error:_:interrupted)` syntax with only one `start` and `observe` that takes a sink when handling multiple cases, as well as separate functions `startNext()`, `startCompleted()`, `startError()`, `startInterrupted()` for handling a single case.