### PR TITLE
SignalProducer.merge: checking if event isTerminating outside of switch

### DIFF
--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -36,13 +36,7 @@ public enum Event<T, E: ErrorType> {
 		case .Next:
 			return false
 
-		case .Error:
-			return true
-
-		case .Completed:
-			return true
-
-		case .Interrupted:
+		case .Error, .Completed, .Interrupted:
 			return true
 		}
 	}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1261,12 +1261,12 @@ extension SignalProducer where T: SignalProducerType, E == T.E {
 						let handle = disposable.addDisposable(innerDisposable)
 
 						innerSignal.observe { event in
+							if event.isTerminating {
+								handle.remove()
+							}
+							
 							switch event {
 							case .Completed, .Interrupted:
-								if event.isTerminating {
-									handle.remove()
-								}
-
 								decrementInFlight()
 
 							default:


### PR DESCRIPTION
I noticed that we were checking `event.isTerminating` inside of the `switch`, but only for `.Completed` and `.Interrupted`, missing `.Error`!

I also simplified the definition of this function.

*NOTE: I haven't been able to run tests because `carthage update` is failing at the moment: something about one of the `Cartfile.private` frameworks being built for `watchOS`. I'll take a look at that tomorrow.*