### PR TITLE
Don't lose the concatted disposable.

### DIFF
--- a/ReactiveCocoa/Objective-C/RACSignal.m
+++ b/ReactiveCocoa/Objective-C/RACSignal.m
@@ -186,7 +186,7 @@
 
 - (RACSignal *)concat:(RACSignal *)signal {
 	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
-		RACSerialDisposable *serialDisposable = [[RACSerialDisposable alloc] init];
+		RACCompoundDisposable *compoundDisposable = [[RACCompoundDisposable alloc] init];
 
 		RACDisposable *sourceDisposable = [self subscribeNext:^(id x) {
 			[subscriber sendNext:x];
@@ -194,11 +194,11 @@
 			[subscriber sendError:error];
 		} completed:^{
 			RACDisposable *concattedDisposable = [signal subscribe:subscriber];
-			serialDisposable.disposable = concattedDisposable;
+			[compoundDisposable addDisposable:concattedDisposable];
 		}];
 
-		serialDisposable.disposable = sourceDisposable;
-		return serialDisposable;
+		[compoundDisposable addDisposable:sourceDisposable];
+		return compoundDisposable;
 	}] setNameWithFormat:@"[%@] -concat: %@", self.name, signal];
 }
 


### PR DESCRIPTION
If the source signal completes synchronously (e.g., `-startWith:`), then we overwrite the disposable for the new signal (`concattedDisposable`) with the disposable for the already completed source signal.

This means we end up with disposables that are never disposed of, even if the subscription is disposed of.

I tried to write a test for this, but it’s Really Tricky® as the disposables we leak are down in RAC’s innards.