### PR TITLE
Don't use KVO in RACCommand

### DIFF
--- a/ReactiveCocoa/Objective-C/RACCommand.m
+++ b/ReactiveCocoa/Objective-C/RACCommand.m
@@ -54,6 +54,8 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 }
 
 - (void)setAllowsConcurrentExecution:(BOOL)allowed {
+	[self willChangeValueForKey:@keypath(self.allowsConcurrentExecution)];
+	
 	if (allowed) {
 		OSAtomicOr32Barrier(1, &_allowsConcurrentExecution);
 	} else {
@@ -61,6 +63,8 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	}
 
 	[self.allowsConcurrentExecutionSubject sendNext:@(_allowsConcurrentExecution)];
+	
+	[self didChangeValueForKey:@keypath(self.allowsConcurrentExecution)];
 }
 
 #pragma mark Lifecycle

--- a/ReactiveCocoa/Objective-C/RACCommand.m
+++ b/ReactiveCocoa/Objective-C/RACCommand.m
@@ -145,15 +145,14 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	if (enabledSignal == nil) {
 		enabledSignal = [RACSignal return:@YES];
 	} else {
-		enabledSignal = [[[enabledSignal
-			startWith:@YES]
-			takeUntil:self.rac_willDeallocSignal]
-			replayLast];
+		enabledSignal = [enabledSignal startWith:@YES];
 	}
 	
-	_immediateEnabled = [[RACSignal
+	_immediateEnabled = [[[[RACSignal
 		combineLatest:@[ enabledSignal, moreExecutionsAllowed ]]
-		and];
+		and]
+		takeUntil:self.rac_willDeallocSignal]
+		replayLast];
 	
 	_enabled = [[[[[self.immediateEnabled
 		take:1]

--- a/ReactiveCocoa/Objective-C/RACCommand.m
+++ b/ReactiveCocoa/Objective-C/RACCommand.m
@@ -32,7 +32,7 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 /// A subject that sends added execution signals.
 @property (nonatomic, strong, readonly) RACSubject *addedExecutionSignalsSubject;
 
-/// A subject that sends added execution signals.
+/// A subject that sends the new value of `allowsConcurrentExecution` whenever it changes.
 @property (nonatomic, strong, readonly) RACSubject *allowsConcurrentExecutionSubject;
 
 // `enabled`, but without a hop to the main thread.

--- a/ReactiveCocoa/Objective-C/RACCommand.m
+++ b/ReactiveCocoa/Objective-C/RACCommand.m
@@ -54,8 +54,6 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 }
 
 - (void)setAllowsConcurrentExecution:(BOOL)allowed {
-	[self willChangeValueForKey:@keypath(self.allowsConcurrentExecution)];
-	
 	if (allowed) {
 		OSAtomicOr32Barrier(1, &_allowsConcurrentExecution);
 	} else {
@@ -63,8 +61,6 @@ const NSInteger RACCommandErrorNotEnabled = 1;
 	}
 
 	[self.allowsConcurrentExecutionSubject sendNext:@(_allowsConcurrentExecution)];
-	
-	[self didChangeValueForKey:@keypath(self.allowsConcurrentExecution)];
 }
 
 #pragma mark Lifecycle

--- a/ReactiveCocoaTests/Objective-C/RACCommandSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACCommandSpec.m
@@ -245,6 +245,22 @@ qck_it(@"should wait for all signals to complete or error before executing sends
 	expect([command.executing first]).toEventually(equal(@NO));
 });
 
+qck_it(@"should have allowsConcurrentExecution be observable", ^{
+	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
+		return signal;
+	}];
+	
+	RACSubject *completion = [RACSubject subject];
+	RACSignal *allowsConcurrentExecution = [[RACObserve(command, allowsConcurrentExecution)
+		takeUntil:completion]
+		replayLast];
+	
+	command.allowsConcurrentExecution = YES;
+	
+	expect([allowsConcurrentExecution first]).to(beTrue());
+	[completion sendCompleted];
+});
+
 qck_it(@"should not deliver errors from executionSignals", ^{
 	RACSubject *subject = [RACSubject subject];
 	NSMutableArray *receivedEvents = [NSMutableArray array];


### PR DESCRIPTION
`RACCommand` has always been slow/expensive to initialize. Due to some absurd slowness in our app's unit tests, I started profiling and found that in our tests we were spending a lot of time rehashing inside KVO. 

This PR changes `RACCommand` so that it no longer uses KVO, saving on initialization and disposal. The changes here make our app's unit tests run ~15% faster. (We create a lot of `RACCommand`s.) I'm sure the savings won't be as noticeable in the real world, but I think these changes should still improve things.