### PR TITLE
Fix watchOS compilation due to NSURLConnection

### DIFF
--- a/ReactiveCocoa/Objective-C/NSURLConnection+RACSupport.m
+++ b/ReactiveCocoa/Objective-C/NSURLConnection+RACSupport.m
@@ -16,39 +16,37 @@
 
 + (RACSignal *)rac_sendAsynchronousRequest:(NSURLRequest *)request {
 	NSCParameterAssert(request != nil);
-
+	
 	return [[RACSignal
-		createSignal:^(id<RACSubscriber> subscriber) {
-			NSOperationQueue *queue = [[NSOperationQueue alloc] init];
-			queue.name = @"org.reactivecocoa.ReactiveCocoa.NSURLConnectionRACSupport";
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-			[NSURLConnection sendAsynchronousRequest:request queue:queue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
-				// The docs say that `nil` data means an error occurred, but
-				// `nil` responses can also occur in practice (circumstances
-				// unknown). Consider either to be an error.
-				//
-				// Note that _empty_ data is not necessarily erroneous, as there
-				// may be headers but no HTTP body.
-				if (response == nil || data == nil) {
-					[subscriber sendError:error];
-				} else {
-					[subscriber sendNext:RACTuplePack(response, data)];
-					[subscriber sendCompleted];
-				}
-			}];
-#pragma clang diagnostic pop
-			
-			return [RACDisposable disposableWithBlock:^{
-				// It's not clear if this will actually cancel the connection,
-				// but we can at least prevent _some_ unnecessary work --
-				// without writing all the code for a proper delegate, which
-				// doesn't really belong in RAC.
-				queue.suspended = YES;
-				[queue cancelAllOperations];
-			}];
-		}]
-		setNameWithFormat:@"+rac_sendAsynchronousRequest: %@", request];
+			 createSignal:^(id<RACSubscriber> subscriber) {
+				 NSURLSessionDataTask * task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+					 
+					 // The docs say that `nil` data means an error occurred, but
+					 // `nil` responses can also occur in practice (circumstances
+					 // unknown). Consider either to be an error.
+					 //
+					 // Note that _empty_ data is not necessarily erroneous, as there
+					 // may be headers but no HTTP body.
+					 if (response == nil || data == nil) {
+						 [subscriber sendError:error];
+					 } else {
+						 [subscriber sendNext:RACTuplePack(response, data)];
+						 [subscriber sendCompleted];
+					 }
+				 }];
+				 
+				 [task resume];
+				 
+				 return [RACDisposable disposableWithBlock:^{
+					 // It's not clear if this will actually cancel the connection,
+					 // but we can at least prevent _some_ unnecessary work --
+					 // without writing all the code for a proper delegate, which
+					 // doesn't really belong in RAC.
+					 [task cancel];
+				 }];
+			 }]
+			setNameWithFormat:@"+rac_sendAsynchronousRequest: %@", request];
 }
 
 @end
+


### PR DESCRIPTION
`+[NSURLConnection sendAsynchronousRequest:queue:completionHandler:]` is deprecated on iOS9 and unavailable on watchOS, so watchOS framework fails to build. I think that NSURLConnection support should be directly removed from ReactiveCocoa, since the deprecation.

In case you prefer to keep it for retrocompatibility, I fixed it by replacing it with `-[NSURLSession dataTaskWithRequest:completionHandler:]` method. It isn't a clean solution since this is a category on NSURLConnection, anyway.

By the way, since there are differences between iOS SDK and watchOS SDK, I think that it should be better to have a dedicated unit test target: this problem for example would have been discovered instantly.