### PR TITLE
Revert "Remove Objective-C API implementations deprecated in 2.0"

### DIFF
--- a/ReactiveCocoa/Objective-C/NSObject+RACAppKitBindings.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACAppKitBindings.h
@@ -30,11 +30,11 @@
 
 @end
 
-@interface NSObject (RACUnavailableAppKitBindings)
+@interface NSObject (RACAppKitBindingsDeprecated)
 
-- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath __attribute__((unavailable("Use -rac_bind:options: instead")));
-- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath nilValue:(id)nilValue __attribute__((unavailable("Use -rac_bind:options: instead")));
-- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath transform:(id (^)(id value))transformBlock __attribute__((unavailable("Use -rac_bind:options: instead")));
-- (void)rac_bind:(NSString *)binding toObject:(id)object withNegatedKeyPath:(NSString *)keyPath __attribute__((unavailable("Use -rac_bind:options: instead")));
+- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath __attribute__((deprecated("Use -rac_bind:options: instead")));
+- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath nilValue:(id)nilValue __attribute__((deprecated("Use -rac_bind:options: instead")));
+- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath transform:(id (^)(id value))transformBlock __attribute__((deprecated("Use -rac_bind:options: instead")));
+- (void)rac_bind:(NSString *)binding toObject:(id)object withNegatedKeyPath:(NSString *)keyPath __attribute__((deprecated("Use -rac_bind:options: instead")));
 
 @end

--- a/ReactiveCocoa/Objective-C/NSObject+RACAppKitBindings.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACAppKitBindings.m
@@ -145,3 +145,29 @@
 }
 
 @end
+
+@implementation NSObject (RACAppKitBindingsDeprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
+- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath {
+	[self rac_bind:binding toObject:object withKeyPath:keyPath nilValue:nil];
+}
+
+- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath nilValue:(id)nilValue {
+	[self bind:binding toObject:object withKeyPath:keyPath options:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:YES], NSContinuouslyUpdatesValueBindingOption, nilValue, NSNullPlaceholderBindingOption, nil]];
+}
+
+- (void)rac_bind:(NSString *)binding toObject:(id)object withKeyPath:(NSString *)keyPath transform:(id (^)(id value))transformBlock {
+	RACValueTransformer *transformer = [RACValueTransformer transformerWithBlock:transformBlock];
+	[self bind:binding toObject:object withKeyPath:keyPath options:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:YES], NSContinuouslyUpdatesValueBindingOption, transformer, NSValueTransformerBindingOption, nil]];
+}
+
+- (void)rac_bind:(NSString *)binding toObject:(id)object withNegatedKeyPath:(NSString *)keyPath {
+	[self bind:binding toObject:object withKeyPath:keyPath options:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:YES], NSContinuouslyUpdatesValueBindingOption, NSNegateBooleanTransformerName, NSValueTransformerNameBindingOption, nil]];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/NSObject+RACDeallocating.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACDeallocating.h
@@ -25,9 +25,10 @@
 
 @end
 
-@interface NSObject (RACUnavailableDeallocating)
+@interface NSObject (RACDeallocatingDeprecated)
 
-- (RACSignal *)rac_didDeallocSignal __attribute__((unavailable("Use -rac_willDeallocSignal")));
-- (void)rac_addDeallocDisposable:(RACDisposable *)disposable __attribute__((unavailable("Add disposables to -rac_deallocDisposable instead")));
+- (RACSignal *)rac_didDeallocSignal __attribute__((deprecated("Use -rac_willDeallocSignal")));
+
+- (void)rac_addDeallocDisposable:(RACDisposable *)disposable __attribute__((deprecated("Add disposables to -rac_deallocDisposable instead")));
 
 @end

--- a/ReactiveCocoa/Objective-C/NSObject+RACDeallocating.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACDeallocating.m
@@ -101,3 +101,29 @@ static void swizzleDeallocIfNeeded(Class classToSwizzle) {
 }
 
 @end
+
+@implementation NSObject (RACDeallocatingDeprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
+- (RACSignal *)rac_didDeallocSignal {
+	RACSubject *subject = [RACSubject subject];
+
+	RACScopedDisposable *disposable = [[RACDisposable
+		disposableWithBlock:^{
+			[subject sendCompleted];
+		}]
+		asScopedDisposable];
+	
+	objc_setAssociatedObject(self, (__bridge void *)disposable, disposable, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	return subject;
+}
+
+- (void)rac_addDeallocDisposable:(RACDisposable *)disposable {
+	[self.rac_deallocDisposable addDisposable:disposable];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/NSObject+RACKVOWrapper.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACKVOWrapper.h
@@ -39,8 +39,8 @@
 
 typedef void (^RACKVOBlock)(id target, id observer, NSDictionary *change);
 
-@interface NSObject (RACUnavailableKVOWrapper)
+@interface NSObject (RACKVOWrapperDeprecated)
 
-- (RACKVOTrampoline *)rac_addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block __attribute((unavailable("Use rac_observeKeyPath:options:observer:block: instead.")));
+- (RACKVOTrampoline *)rac_addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block __attribute((deprecated("Use rac_observeKeyPath:options:observer:block: instead.")));
 
 @end

--- a/ReactiveCocoa/Objective-C/NSObject+RACKVOWrapper.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACKVOWrapper.m
@@ -198,3 +198,16 @@
 }
 
 @end
+
+@implementation NSObject (RACKVOWrapperDeprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
+- (RACKVOTrampoline *)rac_addObserver:(NSObject *)observer forKeyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(RACKVOBlock)block {
+	return [[RACKVOTrampoline alloc] initWithTarget:self observer:observer keyPath:keyPath options:options block:block];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/NSObject+RACLifting.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACLifting.h
@@ -45,12 +45,16 @@
 
 @end
 
-@interface NSObject (RACUnavailableLifting)
+@interface NSObject (RACLiftingDeprecated)
 
-- (RACSignal *)rac_liftSelector:(SEL)selector withObjects:(id)arg, ... __attribute__((unavailable("Use -rac_liftSelector:withSignals: instead")));
-- (RACSignal *)rac_liftSelector:(SEL)selector withObjectsFromArray:(NSArray *)args __attribute__((unavailable("Use -rac_liftSelector:withSignalsFromArray: instead")));
-- (RACSignal *)rac_liftBlock:(id)block withArguments:(id)arg, ... NS_REQUIRES_NIL_TERMINATION __attribute__((unavailable("Use +combineLatest:reduce: instead")));
-- (RACSignal *)rac_liftBlock:(id)block withArgumentsFromArray:(NSArray *)args __attribute__((unavailable("Use +combineLatest:reduce: instead")));
+- (RACSignal *)rac_liftSelector:(SEL)selector withObjects:(id)arg, ... __attribute__((deprecated("Use -rac_liftSelector:withSignals: instead")));
+- (RACSignal *)rac_liftSelector:(SEL)selector withObjectsFromArray:(NSArray *)args __attribute__((deprecated("Use -rac_liftSelector:withSignalsFromArray: instead")));
+- (RACSignal *)rac_liftBlock:(id)block withArguments:(id)arg, ... NS_REQUIRES_NIL_TERMINATION __attribute__((deprecated("Use +combineLatest:reduce: instead")));
+- (RACSignal *)rac_liftBlock:(id)block withArgumentsFromArray:(NSArray *)args __attribute__((deprecated("Use +combineLatest:reduce: instead")));
+
+@end
+
+@interface NSObject (RACLiftingUnavailable)
 
 - (instancetype)rac_lift __attribute__((unavailable("Use -rac_liftSelector:withSignals: instead")));
 

--- a/ReactiveCocoa/Objective-C/NSObject+RACLifting.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACLifting.m
@@ -76,3 +76,67 @@
 }
 
 @end
+
+@implementation NSObject (RACLiftingDeprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
+static NSArray *RACMapArgumentsToSignals(NSArray *args) {
+	NSMutableArray *mappedArgs = [NSMutableArray array];
+	for (id arg in args) {
+		if ([arg isEqual:RACTupleNil.tupleNil]) {
+			[mappedArgs addObject:[RACSignal return:nil]];
+		} else if ([arg isKindOfClass:RACSignal.class]) {
+			[mappedArgs addObject:arg];
+		} else {
+			[mappedArgs addObject:[RACSignal return:arg]];
+		}
+	}
+
+	return mappedArgs;
+}
+
+- (RACSignal *)rac_liftSelector:(SEL)selector withObjects:(id)arg, ... {
+	NSMethodSignature *methodSignature = [self methodSignatureForSelector:selector];
+	NSMutableArray *arguments = [NSMutableArray array];
+
+	va_list args;
+	va_start(args, arg);
+	for (NSUInteger i = 2; i < methodSignature.numberOfArguments; i++) {
+		id currentObject = (i == 2 ? arg : va_arg(args, id));
+		[arguments addObject:currentObject ?: RACTupleNil.tupleNil];
+	}
+
+	va_end(args);
+	return [self rac_liftSelector:selector withObjectsFromArray:arguments];
+}
+
+- (RACSignal *)rac_liftSelector:(SEL)selector withObjectsFromArray:(NSArray *)args {
+	return [self rac_liftSelector:selector withSignalsFromArray:RACMapArgumentsToSignals(args)];
+}
+
+- (RACSignal *)rac_liftBlock:(id)block withArguments:(id)arg, ... {
+	NSMutableArray *arguments = [NSMutableArray array];
+
+	va_list args;
+	va_start(args, arg);
+	for (id currentObject = arg; currentObject != nil; currentObject = va_arg(args, id)) {
+		[arguments addObject:currentObject];
+	}
+
+	va_end(args);
+	return [self rac_liftBlock:block withArgumentsFromArray:arguments];
+}
+
+- (RACSignal *)rac_liftBlock:(id)block withArgumentsFromArray:(NSArray *)args {
+	return [[[[RACSignal
+		combineLatest:RACMapArgumentsToSignals(args)]
+		reduceEach:block]
+		takeUntil:self.rac_willDeallocSignal]
+		replayLast];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
@@ -105,13 +105,13 @@
 
 #define _RACAbleWithStartObject(object, property) [object rac_signalWithStartingValueForKeyPath:@keypath(object, property) observer:self]
 
-@interface NSObject (RACUnavailablePropertySubscribing)
+@interface NSObject (RACPropertySubscribingDeprecated)
 
-+ (RACSignal *)rac_signalFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-+ (RACSignal *)rac_signalWithStartingValueFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-+ (RACSignal *)rac_signalWithChangesFor:(NSObject *)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesAndChangesForKeyPath:options:observer: instead.")));
-- (RACSignal *)rac_signalForKeyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-- (RACSignal *)rac_signalWithStartingValueForKeyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((unavailable("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
-- (RACDisposable *)rac_deriveProperty:(NSString *)keyPath from:(RACSignal *)signal __attribute__((unavailable("Use -[RACSignal setKeyPath:onObject:] instead")));
++ (RACSignal *)rac_signalFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((deprecated("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
++ (RACSignal *)rac_signalWithStartingValueFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((deprecated("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
++ (RACSignal *)rac_signalWithChangesFor:(NSObject *)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer __attribute__((deprecated("Use -rac_valuesAndChangesForKeyPath:options:observer: instead.")));
+- (RACSignal *)rac_signalForKeyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((deprecated("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
+- (RACSignal *)rac_signalWithStartingValueForKeyPath:(NSString *)keyPath observer:(NSObject *)observer __attribute__((deprecated("Use -rac_valuesForKeyPath:observer: or RACObserve() instead.")));
+- (RACDisposable *)rac_deriveProperty:(NSString *)keyPath from:(RACSignal *)signal __attribute__((deprecated("Use -[RACSignal setKeyPath:onObject:] instead")));
 
 @end

--- a/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.m
@@ -82,3 +82,78 @@
 }
 
 @end
+
+static RACSignal *signalWithoutChangesFor(Class class, NSObject *object, NSString *keyPath, NSKeyValueObservingOptions options, NSObject *observer) {
+	NSCParameterAssert(object != nil);
+	NSCParameterAssert(keyPath != nil);
+	NSCParameterAssert(observer != nil);
+
+	keyPath = [keyPath copy];
+
+	@unsafeify(object);
+
+	return [[class
+		rac_signalWithChangesFor:object keyPath:keyPath options:options observer:observer]
+		map:^(NSDictionary *change) {
+			@strongify(object);
+			return [object valueForKeyPath:keyPath];
+		}];
+}
+
+@implementation NSObject (RACPropertySubscribingDeprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
++ (RACSignal *)rac_signalFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer {
+	return signalWithoutChangesFor(self, object, keyPath, 0, observer);
+}
+
++ (RACSignal *)rac_signalWithStartingValueFor:(NSObject *)object keyPath:(NSString *)keyPath observer:(NSObject *)observer {
+	return signalWithoutChangesFor(self, object, keyPath, NSKeyValueObservingOptionInitial, observer);
+}
+
++ (RACSignal *)rac_signalWithChangesFor:(NSObject *)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options observer:(NSObject *)observer {
+	@unsafeify(observer, object);
+	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+
+		@strongify(observer, object);
+		RACKVOTrampoline *KVOTrampoline = [object rac_addObserver:observer forKeyPath:keyPath options:options block:^(id target, id observer, NSDictionary *change) {
+			[subscriber sendNext:change];
+		}];
+
+		@weakify(subscriber);
+		RACDisposable *deallocDisposable = [RACDisposable disposableWithBlock:^{
+			@strongify(subscriber);
+			[KVOTrampoline dispose];
+			[subscriber sendCompleted];
+		}];
+
+		[observer.rac_deallocDisposable addDisposable:deallocDisposable];
+		[object.rac_deallocDisposable addDisposable:deallocDisposable];
+
+		RACCompoundDisposable *observerDisposable = observer.rac_deallocDisposable;
+		RACCompoundDisposable *objectDisposable = object.rac_deallocDisposable;
+		return [RACDisposable disposableWithBlock:^{
+			[observerDisposable removeDisposable:deallocDisposable];
+			[objectDisposable removeDisposable:deallocDisposable];
+			[KVOTrampoline dispose];
+		}];
+	}] setNameWithFormat:@"RACAble(%@, %@)", RACDescription(object), keyPath];
+}
+
+- (RACSignal *)rac_signalForKeyPath:(NSString *)keyPath observer:(NSObject *)observer {
+	return [self.class rac_signalFor:self keyPath:keyPath observer:observer];
+}
+
+- (RACSignal *)rac_signalWithStartingValueForKeyPath:(NSString *)keyPath observer:(NSObject *)observer {
+	return [self.class rac_signalWithStartingValueFor:self keyPath:keyPath observer:observer];
+}
+
+- (RACDisposable *)rac_deriveProperty:(NSString *)keyPath from:(RACSignal *)signal {
+	return [signal setKeyPath:keyPath onObject:self];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/RACScheduler.h
+++ b/ReactiveCocoa/Objective-C/RACScheduler.h
@@ -141,8 +141,8 @@ typedef void (^RACSchedulerRecursiveBlock)(void (^reschedule)(void));
 
 @end
 
-@interface RACScheduler (Unavailable)
+@interface RACScheduler (Deprecated)
 
-+ (RACScheduler *)schedulerWithQueue:(dispatch_queue_t)queue name:(NSString *)name __attribute__((unavailable("Use -[RACTargetQueueScheduler initWithName:targetQueue:] instead.")));
++ (RACScheduler *)schedulerWithQueue:(dispatch_queue_t)queue name:(NSString *)name __attribute__((deprecated("Use -[RACTargetQueueScheduler initWithName:targetQueue:] instead.")));
 
 @end

--- a/ReactiveCocoa/Objective-C/RACScheduler.m
+++ b/ReactiveCocoa/Objective-C/RACScheduler.m
@@ -210,3 +210,18 @@ NSString * const RACSchedulerCurrentSchedulerKey = @"RACSchedulerCurrentSchedule
 }
 
 @end
+
+@implementation RACScheduler (Deprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
++ (instancetype)schedulerWithQueue:(dispatch_queue_t)queue name:(NSString *)name {
+	NSCParameterAssert(queue != NULL);
+
+	return [[RACTargetQueueScheduler alloc] initWithName:name targetQueue:queue];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/RACSequence.h
+++ b/ReactiveCocoa/Objective-C/RACSequence.h
@@ -146,9 +146,9 @@
 
 @end
 
-@interface RACSequence (Unavailable)
+@interface RACSequence (Deprecated)
 
-- (id)foldLeftWithStart:(id)start combine:(id (^)(id accumulator, id value))combine __attribute__((unavailable("Renamed to -foldLeftWithStart:reduce:")));
-- (id)foldRightWithStart:(id)start combine:(id (^)(id first, RACSequence *rest))combine __attribute__((unavailable("Renamed to -foldRightWithStart:reduce:")));
+- (id)foldLeftWithStart:(id)start combine:(id (^)(id accumulator, id value))combine __attribute__((deprecated("Renamed to -foldLeftWithStart:reduce:")));
+- (id)foldRightWithStart:(id)start combine:(id (^)(id first, RACSequence *rest))combine __attribute__((deprecated("Renamed to -foldRightWithStart:reduce:")));
 
 @end

--- a/ReactiveCocoa/Objective-C/RACSequence.m
+++ b/ReactiveCocoa/Objective-C/RACSequence.m
@@ -365,3 +365,20 @@
 }
 
 @end
+
+@implementation RACSequence (Deprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
+- (id)foldLeftWithStart:(id)start combine:(id (^)(id accumulator, id value))combine {
+	return [self foldLeftWithStart:start reduce:combine];
+}
+
+- (id)foldRightWithStart:(id)start combine:(id (^)(id first, RACSequence *rest))combine {
+	return [self foldRightWithStart:start reduce:combine];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/RACSignal+Operations.h
+++ b/ReactiveCocoa/Objective-C/RACSignal+Operations.h
@@ -705,20 +705,20 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 
 @end
 
-@interface RACSignal (UnavailableOperations)
+@interface RACSignal (OperationsDeprecated)
 
-- (RACSignal *)windowWithStart:(RACSignal *)openSignal close:(RACSignal * (^)(RACSignal *start))closeBlock __attribute__((unavailable("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
-- (RACSignal *)buffer:(NSUInteger)bufferCount __attribute__((unavailable("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
-- (RACSignal *)let:(RACSignal * (^)(RACSignal *sharedSignal))letBlock __attribute__((unavailable("Use -publish instead")));
-+ (RACSignal *)interval:(NSTimeInterval)interval __attribute__((unavailable("Use +interval:onScheduler: instead")));
-+ (RACSignal *)interval:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway __attribute__((unavailable("Use +interval:onScheduler:withLeeway: instead")));
-- (RACSignal *)bufferWithTime:(NSTimeInterval)interval __attribute__((unavailable("Use -bufferWithTime:onScheduler: instead")));
-- (RACSignal *)timeout:(NSTimeInterval)interval __attribute__((unavailable("Use -timeout:onScheduler: instead")));
-- (RACDisposable *)toProperty:(NSString *)keyPath onObject:(NSObject *)object __attribute__((unavailable("Renamed to -setKeyPath:onObject:")));
-- (RACSignal *)ignoreElements __attribute__((unavailable("Renamed to -ignoreValues")));
-- (RACSignal *)sequenceNext:(RACSignal * (^)(void))block __attribute__((unavailable("Renamed to -then:")));
-- (RACSignal *)aggregateWithStart:(id)start combine:(id (^)(id running, id next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStart:reduce:")));
-- (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory combine:(id (^)(id running, id next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStartFactory:reduce:")));
-- (RACDisposable *)executeCommand:(RACCommand *)command __attribute__((unavailable("Use -flattenMap: or -subscribeNext: instead")));
+- (RACSignal *)windowWithStart:(RACSignal *)openSignal close:(RACSignal * (^)(RACSignal *start))closeBlock __attribute__((deprecated("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
+- (RACSignal *)buffer:(NSUInteger)bufferCount __attribute__((deprecated("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
+- (RACSignal *)let:(RACSignal * (^)(RACSignal *sharedSignal))letBlock __attribute__((deprecated("Use -publish instead")));
++ (RACSignal *)interval:(NSTimeInterval)interval __attribute__((deprecated("Use +interval:onScheduler: instead")));
++ (RACSignal *)interval:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway __attribute__((deprecated("Use +interval:onScheduler:withLeeway: instead")));
+- (RACSignal *)bufferWithTime:(NSTimeInterval)interval __attribute__((deprecated("Use -bufferWithTime:onScheduler: instead")));
+- (RACSignal *)timeout:(NSTimeInterval)interval __attribute__((deprecated("Use -timeout:onScheduler: instead")));
+- (RACDisposable *)toProperty:(NSString *)keyPath onObject:(NSObject *)object __attribute__((deprecated("Renamed to -setKeyPath:onObject:")));
+- (RACSignal *)ignoreElements __attribute__((deprecated("Renamed to -ignoreValues")));
+- (RACSignal *)sequenceNext:(RACSignal * (^)(void))block __attribute__((deprecated("Renamed to -then:")));
+- (RACSignal *)aggregateWithStart:(id)start combine:(id (^)(id running, id next))combineBlock __attribute__((deprecated("Renamed to -aggregateWithStart:reduce:")));
+- (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory combine:(id (^)(id running, id next))combineBlock __attribute__((deprecated("Renamed to -aggregateWithStartFactory:reduce:")));
+- (RACDisposable *)executeCommand:(RACCommand *)command __attribute__((deprecated("Use -flattenMap: or -subscribeNext: instead")));
 
 @end

--- a/ReactiveCocoa/Objective-C/RACSignal+Operations.m
+++ b/ReactiveCocoa/Objective-C/RACSignal+Operations.m
@@ -1329,3 +1329,165 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 }
 
 @end
+
+@implementation RACSignal (OperationsDeprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
+- (RACSignal *)windowWithStart:(RACSignal *)openSignal close:(RACSignal * (^)(RACSignal *start))closeBlock {
+	NSCParameterAssert(openSignal != nil);
+	NSCParameterAssert(closeBlock != NULL);
+
+	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+		__block RACSubject *currentWindow = nil;
+		__block RACSignal *currentCloseWindow = nil;
+		__block RACDisposable *closeObserverDisposable = NULL;
+
+		void (^closeCurrentWindow)(void) = ^{
+			[currentWindow sendCompleted];
+			currentWindow = nil;
+			currentCloseWindow = nil;
+			[closeObserverDisposable dispose], closeObserverDisposable = nil;
+		};
+
+		RACDisposable *openObserverDisposable = [openSignal subscribe:[RACSubscriber subscriberWithNext:^(id x) {
+			if(currentWindow == nil) {
+				currentWindow = [RACSubject subject];
+				[subscriber sendNext:currentWindow];
+
+				currentCloseWindow = closeBlock(currentWindow);
+				closeObserverDisposable = [currentCloseWindow subscribe:[RACSubscriber subscriberWithNext:^(id x) {
+					closeCurrentWindow();
+				} error:^(NSError *error) {
+					closeCurrentWindow();
+				} completed:^{
+					closeCurrentWindow();
+				}]];
+			}
+		} error:^(NSError *error) {
+
+		} completed:^{
+
+		}]];
+
+		RACDisposable *selfObserverDisposable = [self subscribeNext:^(id x) {
+			[currentWindow sendNext:x];
+		} error:^(NSError *error) {
+			[subscriber sendError:error];
+		} completed:^{
+			[subscriber sendCompleted];
+		}];
+
+		return [RACDisposable disposableWithBlock:^{
+			[closeObserverDisposable dispose];
+			[openObserverDisposable dispose];
+			[selfObserverDisposable dispose];
+		}];
+	}] setNameWithFormat:@"[%@] -windowWithStart: %@ close:", self.name, openSignal];
+}
+
+- (RACSignal *)buffer:(NSUInteger)bufferCount {
+	NSCParameterAssert(bufferCount > 0);
+	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+		NSMutableArray *values = [NSMutableArray arrayWithCapacity:bufferCount];
+		RACSubject *windowCloseSubject = [RACSubject subject];
+
+		RACDisposable *closeDisposable = [windowCloseSubject subscribeNext:^(id x) {
+			[subscriber sendNext:[RACTuple tupleWithObjectsFromArray:values]];
+			[values removeAllObjects];
+		}];
+
+		__block RACDisposable *innerDisposable = nil;
+		RACDisposable *outerDisposable = [[self windowWithStart:self close:^(RACSignal *start) {
+			return windowCloseSubject;
+		}] subscribeNext:^(id x) {
+			innerDisposable = [x subscribeNext:^(id x) {
+				[values addObject:x ? : [RACTupleNil tupleNil]];
+				if(values.count % bufferCount == 0) {
+					[windowCloseSubject sendNext:[RACUnit defaultUnit]];
+				}
+			}];
+		} error:^(NSError *error) {
+			[subscriber sendError:error];
+		} completed:^{
+			[subscriber sendCompleted];
+		}];
+
+		return [RACDisposable disposableWithBlock:^{
+			[innerDisposable dispose];
+			[outerDisposable dispose];
+			[closeDisposable dispose];
+		}];
+	}] setNameWithFormat:@"[%@] -buffer: %lu", self.name, (unsigned long)bufferCount];
+}
+
+- (RACSignal *)let:(RACSignal * (^)(RACSignal *sharedSignal))letBlock {
+	NSCParameterAssert(letBlock != NULL);
+
+	return [[RACSignal createSignal:^(id<RACSubscriber> subscriber) {
+		RACMulticastConnection *connection = [self publish];
+		RACDisposable *finalDisposable = [letBlock(connection.signal) subscribeNext:^(id x) {
+			[subscriber sendNext:x];
+		} error:^(NSError *error) {
+			[subscriber sendError:error];
+		} completed:^{
+			[subscriber sendCompleted];
+		}];
+
+		RACDisposable *connectionDisposable = [connection connect];
+
+		return [RACDisposable disposableWithBlock:^{
+			[connectionDisposable dispose];
+			[finalDisposable dispose];
+		}];
+	}] setNameWithFormat:@"[%@] -let:", self.name];
+}
+
++ (RACSignal *)interval:(NSTimeInterval)interval {
+	return [RACSignal interval:interval onScheduler:[RACScheduler schedulerWithPriority:RACSchedulerPriorityHigh]];
+}
+
++ (RACSignal *)interval:(NSTimeInterval)interval withLeeway:(NSTimeInterval)leeway {
+	return [RACSignal interval:interval onScheduler:[RACScheduler schedulerWithPriority:RACSchedulerPriorityHigh] withLeeway:leeway];
+}
+
+- (RACSignal *)timeout:(NSTimeInterval)interval {
+	return [self timeout:interval onScheduler:[RACScheduler schedulerWithPriority:RACSchedulerPriorityHigh]];
+}
+
+- (RACSignal *)bufferWithTime:(NSTimeInterval)interval {
+	return [self bufferWithTime:interval onScheduler:[RACScheduler schedulerWithPriority:RACSchedulerPriorityHigh]];
+}
+
+- (RACDisposable *)toProperty:(NSString *)keyPath onObject:(NSObject *)object {
+	return [self setKeyPath:keyPath onObject:object];
+}
+
+- (RACSignal *)ignoreElements {
+	return [self ignoreValues];
+}
+
+- (RACSignal *)sequenceNext:(RACSignal * (^)(void))block {
+	return [self then:block];
+}
+
+- (RACSignal *)aggregateWithStart:(id)start combine:(id (^)(id running, id next))combineBlock {
+	return [self aggregateWithStart:start reduce:combineBlock];
+}
+
+- (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory combine:(id (^)(id running, id next))combineBlock {
+	return [self aggregateWithStartFactory:startFactory reduce:combineBlock];
+}
+
+- (RACDisposable *)executeCommand:(RACCommand *)command {
+	NSCParameterAssert(command != nil);
+
+	return [self subscribeNext:^(id x) {
+		[command execute:x];
+	}];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/RACSignal.h
+++ b/ReactiveCocoa/Objective-C/RACSignal.h
@@ -210,10 +210,10 @@
 
 @end
 
-@interface RACSignal (Unavailable)
+@interface RACSignal (Deprecated)
 
-+ (RACSignal *)start:(id (^)(BOOL *success, NSError **error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
-+ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler subjectBlock:(void (^)(RACSubject *subject))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
-+ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError **error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
++ (RACSignal *)start:(id (^)(BOOL *success, NSError **error))block __attribute__((deprecated("Use +startEagerlyWithScheduler:block: instead")));
++ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler subjectBlock:(void (^)(RACSubject *subject))block __attribute__((deprecated("Use +startEagerlyWithScheduler:block: instead")));
++ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError **error))block __attribute__((deprecated("Use +startEagerlyWithScheduler:block: instead")));
 
 @end

--- a/ReactiveCocoa/Objective-C/RACSignal.m
+++ b/ReactiveCocoa/Objective-C/RACSignal.m
@@ -408,3 +408,43 @@ static const NSTimeInterval RACSignalAsynchronousWaitTimeout = 10;
 }
 
 @end
+
+@implementation RACSignal (Deprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
++ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler subjectBlock:(void (^)(RACSubject *subject))block {
+	NSCParameterAssert(block != NULL);
+
+	RACReplaySubject *subject = [[RACReplaySubject subject] setNameWithFormat:@"+startWithScheduler:subjectBlock:"];
+
+	[scheduler schedule:^{
+		block(subject);
+	}];
+
+	return subject;
+}
+
++ (RACSignal *)start:(id (^)(BOOL *success, NSError **error))block {
+	return [[self startWithScheduler:[RACScheduler scheduler] block:block] setNameWithFormat:@"+start:"];
+}
+
++ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError **error))block {
+	return [[self startWithScheduler:scheduler subjectBlock:^(id<RACSubscriber> subscriber) {
+		BOOL success = YES;
+		NSError *error = nil;
+		id returned = block(&success, &error);
+
+		if (!success) {
+			[subscriber sendError:error];
+		} else {
+			[subscriber sendNext:returned];
+			[subscriber sendCompleted];
+		}
+	}] setNameWithFormat:@"+startWithScheduler:block:"];
+}
+
+#pragma clang diagnostic pop
+
+@end

--- a/ReactiveCocoa/Objective-C/RACStream.h
+++ b/ReactiveCocoa/Objective-C/RACStream.h
@@ -326,10 +326,10 @@ typedef RACStream * (^RACStreamBindBlock)(id value, BOOL *stop);
 
 @end
 
-@interface RACStream (Unavailable)
+@interface RACStream (Deprecated)
 
-- (instancetype)sequenceMany:(RACStream * (^)(void))block __attribute__((unavailable("Use -flattenMap: instead")));
-- (instancetype)scanWithStart:(id)startingValue combine:(id (^)(id running, id next))block __attribute__((unavailable("Renamed to -scanWithStart:reduce:")));
-- (instancetype)mapPreviousWithStart:(id)start reduce:(id (^)(id previous, id current))combineBlock __attribute__((unavailable("Renamed to -combinePreviousWithStart:reduce:")));
+- (instancetype)sequenceMany:(RACStream * (^)(void))block __attribute__((deprecated("Use -flattenMap: instead")));
+- (instancetype)scanWithStart:(id)startingValue combine:(id (^)(id running, id next))block __attribute__((deprecated("Renamed to -scanWithStart:reduce:")));
+- (instancetype)mapPreviousWithStart:(id)start reduce:(id (^)(id previous, id current))combineBlock __attribute__((deprecated("Renamed to -combinePreviousWithStart:reduce:")));
 
 @end

--- a/ReactiveCocoa/Objective-C/RACStream.m
+++ b/ReactiveCocoa/Objective-C/RACStream.m
@@ -350,3 +350,28 @@
 }
 
 @end
+
+@implementation RACStream (Deprecated)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
+- (instancetype)sequenceMany:(RACStream * (^)(void))block {
+	NSCParameterAssert(block != NULL);
+
+	return [[self flattenMap:^(id _) {
+		return block();
+	}] setNameWithFormat:@"[%@] -sequenceMany:", self.name];
+}
+
+- (instancetype)scanWithStart:(id)startingValue combine:(id (^)(id running, id next))block {
+	return [self scanWithStart:startingValue reduce:block];
+}
+
+- (instancetype)mapPreviousWithStart:(id)start reduce:(id (^)(id previous, id current))combineBlock {
+	return [self combinePreviousWithStart:start reduce:combineBlock];
+}
+
+#pragma clang diagnostic pop
+
+@end


### PR DESCRIPTION
This is _technically_ a breaking change for RAC3 so I'm going to revert it since it was already in RC1. I'll merge this into the `swift2` branch though so it's on the RAC4 train.

/cc @ikesyo 