### PR TITLE
Workaround to prevent NSError from losing its UserInfo in toRACSignal

### DIFF
--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -97,7 +97,18 @@ public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RAC
 			case let .Next(value):
 				subscriber.sendNext(value)
 			case let .Error(error):
-				subscriber.sendError(error as NSError)
+				
+				// This is a workaround for rdar://22708537 which causes an NSError's
+				// UserInfo dictionary to get discarded during a cast from
+				// ErrorType to NSError in a generic function
+				let nsError: NSError
+				if error.dynamicType == NSError.self {
+					nsError = unsafeBitCast(error, NSError.self)
+				} else {
+					nsError = error as NSError
+				}
+				
+				subscriber.sendError(nsError)
 			case .Completed:
 				subscriber.sendCompleted()
 			default:
@@ -128,7 +139,18 @@ public func toRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
 			case let .Next(value):
 				subscriber.sendNext(value)
 			case let .Error(error):
-				subscriber.sendError(error as NSError)
+				
+				// This is a workaround for rdar://22708537 which causes an NSError's
+				// UserInfo dictionary to get discarded during a cast from
+				// ErrorType to NSError in a generic function
+				let nsError: NSError
+				if error.dynamicType == NSError.self {
+					nsError = unsafeBitCast(error, NSError.self)
+				} else {
+					nsError = error as NSError
+				}
+				
+				subscriber.sendError(nsError)
 			case .Completed:
 				subscriber.sendCompleted()
 			default:

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -90,25 +90,33 @@ public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T, E>) -> RACS
 /// subscription.
 ///
 /// Any `Interrupted` events will be silently discarded.
+public func toRACSignal<T: AnyObject, E: NSError>(producer: SignalProducer<T, E>) -> RACSignal {
+	return toRACSignal(producer.lift { $0.optionalize() })
+}
+
+/// Creates a RACSignal that will start() the producer once for each
+/// subscription.
+///
+/// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<T: AnyObject, E>(producer: SignalProducer<T?, E>) -> RACSignal {
+    return toRACSignal(producer.mapError { $0 as NSError })
+}
+
+/// Creates a RACSignal that will start() the producer once for each
+/// subscription.
+///
+/// Any `Interrupted` events will be silently discarded.
+public func toRACSignal<T: AnyObject, E: NSError>(producer: SignalProducer<T?, E>) -> RACSignal {
+    // This special casing of `E: NSError` is a workaround for rdar://22708537
+    // which causes an NSError's UserInfo dictionary to get discarded
+    // during a cast from ErrorType to NSError in a generic function
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start { event in
 			switch event {
 			case let .Next(value):
 				subscriber.sendNext(value)
 			case let .Error(error):
-				
-				// This is a workaround for rdar://22708537 which causes an NSError's
-				// UserInfo dictionary to get discarded during a cast from
-				// ErrorType to NSError in a generic function
-				let nsError: NSError
-				if error.dynamicType == NSError.self {
-					nsError = unsafeBitCast(error, NSError.self)
-				} else {
-					nsError = error as NSError
-				}
-				
-				subscriber.sendError(nsError)
+				subscriber.sendError(error)
 			case .Completed:
 				subscriber.sendCompleted()
 			default:
@@ -132,36 +140,42 @@ public func toRACSignal<T: AnyObject, E>(signal: Signal<T, E>) -> RACSignal {
 /// Creates a RACSignal that will observe the given signal.
 ///
 /// Any `Interrupted` event will be silently discarded.
+public func toRACSignal<T: AnyObject, E: NSError>(signal: Signal<T, E>) -> RACSignal {
+	return toRACSignal(signal.optionalize())
+}
+
+/// Creates a RACSignal that will observe the given signal.
+///
+/// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<T: AnyObject, E>(signal: Signal<T?, E>) -> RACSignal {
-	return RACSignal.createSignal { subscriber in
-		let selfDisposable = signal.observe { event in
-			switch event {
-			case let .Next(value):
-				subscriber.sendNext(value)
-			case let .Error(error):
-				
-				// This is a workaround for rdar://22708537 which causes an NSError's
-				// UserInfo dictionary to get discarded during a cast from
-				// ErrorType to NSError in a generic function
-				let nsError: NSError
-				if error.dynamicType == NSError.self {
-					nsError = unsafeBitCast(error, NSError.self)
-				} else {
-					nsError = error as NSError
-				}
-				
-				subscriber.sendError(nsError)
-			case .Completed:
-				subscriber.sendCompleted()
-			default:
-				break
-			}
-		}
-		
-		return RACDisposable {
-			selfDisposable?.dispose()
-		}
-	}
+    return toRACSignal(signal.mapError { $0 as NSError })
+}
+
+/// Creates a RACSignal that will observe the given signal.
+///
+/// Any `Interrupted` event will be silently discarded.
+public func toRACSignal<T: AnyObject, E: NSError>(signal: Signal<T?, E>) -> RACSignal {
+    // This special casing of `E: NSError` is a workaround for rdar://22708537
+    // which causes an NSError's UserInfo dictionary to get discarded
+    // during a cast from ErrorType to NSError in a generic function
+    return RACSignal.createSignal { subscriber in
+        let selfDisposable = signal.observe { event in
+            switch event {
+            case let .Next(value):
+                subscriber.sendNext(value)
+            case let .Error(error):
+                subscriber.sendError(error)
+            case .Completed:
+                subscriber.sendCompleted()
+            default:
+                break
+            }
+        }
+
+        return RACDisposable {
+            selfDisposable?.dispose()
+        }
+    }
 }
 
 extension RACCommand {

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -13,6 +13,7 @@ import ReactiveCocoa
 import XCTest
 
 class ObjectiveCBridgingSpec: QuickSpec {
+	
 	override func spec() {
 		describe("RACSignal.toSignalProducer") {
 			it("should subscribe once per start()") {
@@ -44,6 +45,9 @@ class ObjectiveCBridgingSpec: QuickSpec {
 		}
 
 		describe("toRACSignal") {
+			let key = "TestKey"
+			let userInfo: [String: String] = [key: "TestValue"]
+			let testNSError = TestNSError(domain: "TestDomain", code: 1, userInfo: userInfo)
 			describe("on a Signal") {
 				it("should forward events") {
 					let (signal, sink) = Signal<NSNumber, NoError>.pipe()
@@ -85,6 +89,23 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					sendError(sink, expectedError)
 					expect(error).to(equal(expectedError as NSError))
 				}
+				
+				it("should maintain userInfo on NSError") {
+					let (signal, sink) = Signal<AnyObject, TestNSError>.pipe()
+					let racSignal = toRACSignal(signal)
+					
+					var error: NSError?
+					
+					racSignal.subscribeError {
+						error = $0
+						return
+					}
+					
+					sendError(sink, testNSError)
+					
+					let userInfoValue = error?.userInfo[key] as? String
+					expect(userInfoValue).to(equal(userInfo[key]))
+				}
 			}
 
 			describe("on a SignalProducer") {
@@ -107,6 +128,15 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 					let event = racSignal.first() as? RACEvent
 					expect(event?.error).to(equal(TestError.Error1 as NSError))
+				}
+				
+				it("should maintain userInfo on NSError") {
+					let producer = SignalProducer<AnyObject, TestNSError>(error: testNSError)
+					let racSignal = toRACSignal(producer).materialize()
+					
+					let event = racSignal.first() as? RACEvent
+					let userInfoValue = event?.error.userInfo[key] as? String
+					expect(userInfoValue).to(equal(userInfo[key]))
 				}
 			}
 		}

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -13,7 +13,6 @@ import ReactiveCocoa
 import XCTest
 
 class ObjectiveCBridgingSpec: QuickSpec {
-	
 	override func spec() {
 		describe("RACSignal.toSignalProducer") {
 			it("should subscribe once per start()") {
@@ -47,7 +46,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 		describe("toRACSignal") {
 			let key = "TestKey"
 			let userInfo: [String: String] = [key: "TestValue"]
-			let testNSError = TestNSError(domain: "TestDomain", code: 1, userInfo: userInfo)
+			let testNSError = NSError(domain: "TestDomain", code: 1, userInfo: userInfo)
 			describe("on a Signal") {
 				it("should forward events") {
 					let (signal, sink) = Signal<NSNumber, NoError>.pipe()
@@ -91,7 +90,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				}
 				
 				it("should maintain userInfo on NSError") {
-					let (signal, sink) = Signal<AnyObject, TestNSError>.pipe()
+					let (signal, sink) = Signal<AnyObject, NSError>.pipe()
 					let racSignal = toRACSignal(signal)
 					
 					var error: NSError?
@@ -131,7 +130,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				}
 				
 				it("should maintain userInfo on NSError") {
-					let producer = SignalProducer<AnyObject, TestNSError>(error: testNSError)
+					let producer = SignalProducer<AnyObject, NSError>(error: testNSError)
 					let racSignal = toRACSignal(producer).materialize()
 					
 					let event = racSignal.first() as? RACEvent

--- a/ReactiveCocoaTests/Swift/TestError.swift
+++ b/ReactiveCocoaTests/Swift/TestError.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-import Foundation
-
 enum TestError: Int {
 	case Default = 0
 	case Error1 = 1

--- a/ReactiveCocoaTests/Swift/TestError.swift
+++ b/ReactiveCocoaTests/Swift/TestError.swift
@@ -16,6 +16,3 @@ enum TestError: Int {
 
 extension TestError: ErrorType {
 }
-
-class TestNSError: NSError {
-}

--- a/ReactiveCocoaTests/Swift/TestError.swift
+++ b/ReactiveCocoaTests/Swift/TestError.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
+import Foundation
+
 enum TestError: Int {
 	case Default = 0
 	case Error1 = 1
@@ -13,4 +15,7 @@ enum TestError: Int {
 }
 
 extension TestError: ErrorType {
+}
+
+class TestNSError: NSError {
 }


### PR DESCRIPTION
This is a workaround for [rdar://22708537](http://www.openradar.me/radar?id=6068957668704256) Casting an NSError that's in a generic function with type parameter `<E: ErrorType>` to an NSError strips the error's UserInfo dictionary.

One downside to this workaround is that subclasses of NSError will still be broken. The only workaround that I could think of that would handle that is:

```
    var nsError = error as NSError
    var mirror: Mirror? = Mirror(reflecting: error)
    while mirror != nil {
        if mirror!.subjectType == NSError.self {
            nsError = unsafeBitCast(error, NSError.self)
            break
        }
        mirror = mirror!.superclassMirror()
    }
    subscriber.sendError(nsError)
```

I wasn't sure if there was a significant runtime cost to creating the Mirror struct, or if there was a better way to handle that, so I just left this handling NSError and not subclasses. Let me know if you'd like me to implement the code above instead though.