### PR TITLE
Fix `filter` operation

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -228,8 +228,10 @@ extension SignalType {
 	public func filter(predicate: T -> Bool) -> Signal<T, E> {
 		return Signal { observer in
 			return self.observe { event in
-				if case let .Next(value) = event where predicate(value) {
-					sendNext(observer, value)
+				if case let .Next(value) = event {
+					if predicate(value) {
+						sendNext(observer, value)
+					}
 				} else {
 					observer(event)
 				}


### PR DESCRIPTION
A bug snuck in with #2354 causing `filter` to forward events when the predicate was false. This brings back some nesting to fix that.