### PR TITLE
Update Result to new beta version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" "76f9a97"
+github "antitypical/Result" "0.6.0-beta.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "v2.0.0-rc.3"
 github "Quick/Quick" "v0.6.0"
-github "antitypical/Result" "76f9a972ed61ff872b731460bc610c8acbfae58c"
+github "antitypical/Result" "0.6.0-beta.2"
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"


### PR DESCRIPTION
I tagged 0.6 beta 2 of Result last night. I don't think RAC is
particularly interested in the `materialize` function, but it includes
the tvOS target and it'll help other libs with Result as a common
dependency to point at a tag instead of a sha.