### PR TITLE
Change `lift` signature for better code

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -435,7 +435,7 @@ extension SignalProducerType {
 	/// will also be interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func combineLatestWith<U>(otherProducer: SignalProducer<U, E>) -> SignalProducer<(T, U), E> {
-		return lift { sg -> Signal<T, E> -> Signal<(T, U), E> in { $0.combineLatestWith(sg) } }(otherProducer)
+		return lift { signal -> Signal<T, E> -> Signal<(T, U), E> in { $0.combineLatestWith(signal) } }(otherProducer)
 	}
 
 	/// Delays `Next` and `Completed` events by the given interval, forwarding
@@ -478,14 +478,14 @@ extension SignalProducerType {
 	/// completed, or interrupt if either input producer is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<T, E> {
-		return lift { (sg) -> Signal<T, E> -> Signal<T, E> in { $0.sampleOn(sg) } }(sampler)
+		return lift { signal -> Signal<T, E> -> Signal<T, E> in { $0.sampleOn(signal) } }(sampler)
 	}
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned producer will complete.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func takeUntil(trigger: SignalProducer<(), NoError>) -> SignalProducer<T, E> {
-		return lift { (sg) -> Signal<T, E> -> Signal<T, E> in { $0.takeUntil(sg) } }(trigger)
+		return lift { signal -> Signal<T, E> -> Signal<T, E> in { $0.takeUntil(signal) } }(trigger)
 	}
 
 	/// Forwards events from `self` with history: values of the returned producer
@@ -536,7 +536,7 @@ extension SignalProducerType {
 	/// already.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func takeUntilReplacement(replacement: SignalProducer<T, E>) -> SignalProducer<T, E> {
-		return lift { (sg) -> Signal<T, E> -> Signal<T, E> in { $0.takeUntilReplacement(sg) } }(replacement)
+		return lift { signal -> Signal<T, E> -> Signal<T, E> in { $0.takeUntilReplacement(signal) } }(replacement)
 	}
 
 	/// Waits until `self` completes and then forwards the final `count` values
@@ -557,7 +557,7 @@ extension SignalProducerType {
 	/// are the Nth elements of the two input producers.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func zipWith<U>(otherProducer: SignalProducer<U, E>) -> SignalProducer<(T, U), E> {
-		return lift { sg -> Signal<T, E> -> Signal<(T, U), E> in { $0.zipWith(sg) } }(otherProducer)
+		return lift { signal -> Signal<T, E> -> Signal<(T, U), E> in { $0.zipWith(signal) } }(otherProducer)
 	}
 
 	/// Applies `operation` to values from `self` with `Success`ful results

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -373,7 +373,7 @@ extension SignalProducerType {
 	/// producers, just as if the operator had been applied to each Signal
 	/// yielded from start().
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func lift<U, F, V, G>(transform: Signal<U, F> -> Signal<T, E> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
+	public func lift<U, F, V, G>(transform: Signal<T, E> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
 		return { otherProducer in
 			return SignalProducer { observer, outerDisposable in
 				self.startWithSignal { signal, disposable in
@@ -382,7 +382,7 @@ extension SignalProducerType {
 					otherProducer.startWithSignal { otherSignal, otherDisposable in
 						outerDisposable.addDisposable(otherDisposable)
 
-						transform(otherSignal)(signal).observe(observer)
+						transform(signal)(otherSignal).observe(observer)
 					}
 				}
 			}
@@ -435,7 +435,7 @@ extension SignalProducerType {
 	/// will also be interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func combineLatestWith<U>(otherProducer: SignalProducer<U, E>) -> SignalProducer<(T, U), E> {
-		return lift { signal -> Signal<T, E> -> Signal<(T, U), E> in { $0.combineLatestWith(signal) } }(otherProducer)
+		return lift(Signal.combineLatestWith)(otherProducer)
 	}
 
 	/// Delays `Next` and `Completed` events by the given interval, forwarding
@@ -478,14 +478,14 @@ extension SignalProducerType {
 	/// completed, or interrupt if either input producer is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<T, E> {
-		return lift { signal -> Signal<T, E> -> Signal<T, E> in { $0.sampleOn(signal) } }(sampler)
+		return lift(Signal.sampleOn)(sampler)
 	}
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned producer will complete.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func takeUntil(trigger: SignalProducer<(), NoError>) -> SignalProducer<T, E> {
-		return lift { signal -> Signal<T, E> -> Signal<T, E> in { $0.takeUntil(signal) } }(trigger)
+		return lift(Signal.takeUntil)(trigger)
 	}
 
 	/// Forwards events from `self` with history: values of the returned producer
@@ -536,7 +536,7 @@ extension SignalProducerType {
 	/// already.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func takeUntilReplacement(replacement: SignalProducer<T, E>) -> SignalProducer<T, E> {
-		return lift { signal -> Signal<T, E> -> Signal<T, E> in { $0.takeUntilReplacement(signal) } }(replacement)
+		return lift(Signal.takeUntilReplacement)(replacement)
 	}
 
 	/// Waits until `self` completes and then forwards the final `count` values
@@ -557,7 +557,7 @@ extension SignalProducerType {
 	/// are the Nth elements of the two input producers.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func zipWith<U>(otherProducer: SignalProducer<U, E>) -> SignalProducer<(T, U), E> {
-		return lift { signal -> Signal<T, E> -> Signal<(T, U), E> in { $0.zipWith(signal) } }(otherProducer)
+		return lift(Signal.zipWith)(otherProducer)
 	}
 
 	/// Applies `operation` to values from `self` with `Success`ful results


### PR DESCRIPTION
As mentioned in #2370, I propose that we change the method signature of `lift` from
```swift
func lift<U, F, V, G>(transform: Signal<U, F> -> Signal<T, E> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G>
```
to
```swift
func lift<U, F, V, G>(transform: Signal<T, E> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G>
```
Swapping the positions of `Signal<U, F>` and `Signal<T, E>` not only makes the code more intuitive (because `Signal<T, E>` is the type of `self`, it is more reasonable to make it the first argument), but also allows code simplifications such as the following:

From: 
```swift
func combineLatestWith<U>(otherProducer: SignalProducer<U, E>) -> SignalProducer<(T, U), E> {
	return lift { signal -> Signal<T, E> -> Signal<(T, U), E> in { $0.combineLatestWith(signal) } }(otherProducer)
}
```
To:
```swift
func combineLatestWith<U>(otherProducer: SignalProducer<U, E>) -> SignalProducer<(T, U), E> {
	return lift(Signal.combineLatestWith)(otherProducer)
}
```
The simplified code is possible because [Swift instance methods are curried functions](http://oleb.net/blog/2014/07/swift-instance-methods-curried-functions/).