### PR TITLE
Moved flatMap intro SignalProducerType extension.

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -262,7 +262,7 @@ public enum FlattenStrategy: Equatable {
 	case Latest
 }
 
-extension Signal where T: SignalProducerType, E == T.E {
+extension SignalType where T: SignalProducerType, E == T.E {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -286,7 +286,7 @@ extension Signal where T: SignalProducerType, E == T.E {
 	}
 }
 
-extension Signal {
+extension SignalType {
 	/// Maps each event from `signal` to a new producer, then flattens the
 	/// resulting producers (into a signal of values), according to the
 	/// semantics of the given strategy.
@@ -299,7 +299,7 @@ extension Signal {
 	}
 }
 
-extension Signal where T: SignalProducerType, E == T.E {
+extension SignalType where T: SignalProducerType, E == T.E {
 	/// Returns a signal which sends all the values from producer signal emitted from
 	/// `signal`, waiting until each inner producer completes before beginning to
 	/// send the values from the next inner producer.
@@ -416,7 +416,7 @@ private final class ConcatState<T, E: ErrorType> {
 	}
 }
 
-extension Signal where T: SignalProducerType, E == T.E {
+extension SignalType where T: SignalProducerType, E == T.E {
 	/// Merges a `signal` of SignalProducers down into a single signal, biased toward the producer
 	/// added earlier. Returns a Signal that will forward events from the inner producers as they arrive.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -598,7 +598,7 @@ extension SignalProducerType {
 	}
 }
 
-extension SignalProducer where T: OptionalType {
+extension SignalProducerType where T: OptionalType {
 	/// Unwraps non-`nil` values and forwards them on the returned signal, `nil`
 	/// values are dropped.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
@@ -973,13 +973,11 @@ extension SignalProducerType {
 			}
 		}
 	}
-}
 
-extension SignalProducer {
 	/// `concat`s `next` onto `self`.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func concat(next: SignalProducer) -> SignalProducer {
-		return SignalProducer<SignalProducer, E>(values: [self, next]).flatten(.Concat)
+	public func concat(next: SignalProducer<T, E>) -> SignalProducer<T, E> {
+		return SignalProducer<SignalProducer<T, E>, E>(values: [self.producer, next]).flatten(.Concat)
 	}
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -913,7 +913,35 @@ public func zip<S: SequenceType, T, Error where S.Generator.Element == SignalPro
 	return .empty
 }
 
+extension SignalProducer where T: SignalProducerType, E == T.E {
+	/// Flattens the inner producers sent upon `producer` (into a single producer of
+	/// values), according to the semantics of the given strategy.
+	///
+	/// If `producer` or an active inner producer emits an error, the returned
+	/// producer will forward that error immediately.
+	///
+	/// `Interrupted` events on inner producers will be treated like `Completed`
+	/// events on inner producers.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func flatten(strategy: FlattenStrategy) -> SignalProducer<T.T, E> {
+		return lift { (signal: Signal<T, E>) -> Signal<T.T, E> in
+			return signal.flatten(strategy)
+		}
+	}
+}
+
 extension SignalProducerType {
+	/// Maps each event from `producer` to a new producer, then flattens the
+	/// resulting producers (into a single producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// If `producer` or any of the created producers emit an error, the returned
+	/// producer will forward that error immediately.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func flatMap<U>(strategy: FlattenStrategy, transform: T -> SignalProducer<U, E>) -> SignalProducer<U, E> {
+		return map(transform).flatten(strategy)
+	}
+
 	/// Catches any error that may occur on the input producer, mapping to a new producer
 	/// that starts in its place.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
@@ -1081,35 +1109,5 @@ extension SignalProducerType {
 	@warn_unused_result(message="Did you forget to check the result?")
 	public func wait() -> Result<(), E> {
 		return then(SignalProducer<(), E>(value: ())).last() ?? .Success(())
-	}
-}
-
-extension SignalProducer where T: SignalProducerType, E == T.E {
-	/// Flattens the inner producers sent upon `producer` (into a single producer of
-	/// values), according to the semantics of the given strategy.
-	///
-	/// If `producer` or an active inner producer emits an error, the returned
-	/// producer will forward that error immediately.
-	///
-	/// `Interrupted` events on inner producers will be treated like `Completed`
-	/// events on inner producers.
-	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func flatten(strategy: FlattenStrategy) -> SignalProducer<T.T, E> {
-		return lift { (signal: Signal<T, E>) -> Signal<T.T, E> in
-			return signal.flatten(strategy)
-		}
-	}
-}
-
-extension SignalProducer {
-	/// Maps each event from `producer` to a new producer, then flattens the
-	/// resulting producers (into a single producer of values), according to the
-	/// semantics of the given strategy.
-	///
-	/// If `producer` or any of the created producers emit an error, the returned
-	/// producer will forward that error immediately.
-	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func flatMap<U>(strategy: FlattenStrategy, transform: T -> SignalProducer<U, E>) -> SignalProducer<U, E> {
-		return map(transform).flatten(strategy)
 	}
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -913,7 +913,8 @@ public func zip<S: SequenceType, T, Error where S.Generator.Element == SignalPro
 	return .empty
 }
 
-extension SignalProducer where T: SignalProducerType, E == T.E {
+
+extension SignalProducerType where T: SignalProducerType, E == T.E {
 	/// Flattens the inner producers sent upon `producer` (into a single producer of
 	/// values), according to the semantics of the given strategy.
 	///
@@ -929,6 +930,7 @@ extension SignalProducer where T: SignalProducerType, E == T.E {
 		}
 	}
 }
+
 
 extension SignalProducerType {
 	/// Maps each event from `producer` to a new producer, then flattens the


### PR DESCRIPTION
According to @neilpa message in #2377 there was language and compiler limitations that didn't allowed this before. On a Xcode 7.0 (7A220) it complies well and all unit-tests are passing. Does it mean it can me merged in, or there is a special case that still may crash such implementation?