### PR TITLE
Improvements on `Bag` and others

### DIFF
--- a/ReactiveCocoa/Swift/Bag.swift
+++ b/ReactiveCocoa/Swift/Bag.swift
@@ -42,14 +42,14 @@ internal struct Bag<T> {
 	///
 	/// If the value has already been removed, nothing happens.
 	mutating func removeValueForToken(token: RemovalToken) {
-		guard let identifier = token.identifier else { return }
-		// Removal is more likely for recent objects than old ones.
-		for i in (elements.startIndex..<elements.endIndex).reverse() {
-			if elements[i].identifier == identifier {
-				swap(&elements[i], &elements[elements.endIndex - 1])
-				elements.removeLast()
-				token.identifier = nil
-				break
+		if let identifier = token.identifier {
+			// Removal is more likely for recent objects than old ones.
+			for i in (0..<elements.endIndex).reverse() {
+				if elements[i].identifier == identifier {
+					elements.removeAtIndex(i)
+					token.identifier = nil
+					break
+				}
 			}
 		}
 	}

--- a/ReactiveCocoa/Swift/Bag.swift
+++ b/ReactiveCocoa/Swift/Bag.swift
@@ -44,7 +44,7 @@ internal struct Bag<T> {
 	mutating func removeValueForToken(token: RemovalToken) {
 		if let identifier = token.identifier {
 			// Removal is more likely for recent objects than old ones.
-			for i in (0..<elements.endIndex).reverse() {
+			for i in elements.indices.reverse() {
 				if elements[i].identifier == identifier {
 					elements.removeAtIndex(i)
 					token.identifier = nil
@@ -58,7 +58,7 @@ internal struct Bag<T> {
 	/// will reset all current identifiers to reclaim a contiguous set of
 	/// available identifiers for the future.
 	private mutating func reindex() {
-		for i in elements.startIndex..<elements.endIndex {
+		for i in elements.indices {
 			currentIdentifier = UInt(i)
 
 			elements[i].identifier = currentIdentifier

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -119,7 +119,7 @@ public func toRACSignal<T: AnyObject, E: NSError>(producer: SignalProducer<T?, E
 				subscriber.sendError(error)
 			case .Completed:
 				subscriber.sendCompleted()
-			default:
+			case .Interrupted:
 				break
 			}
 		}
@@ -167,7 +167,7 @@ public func toRACSignal<T: AnyObject, E: NSError>(signal: Signal<T?, E>) -> RACS
                 subscriber.sendError(error)
             case .Completed:
                 subscriber.sendCompleted()
-            default:
+			case .Interrupted:
                 break
             }
         }

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -86,7 +86,6 @@ public final class UIScheduler: SchedulerType {
 
 /// A scheduler backed by a serial GCD queue.
 public final class QueueScheduler: DateSchedulerType {
-	internal let queue: dispatch_queue_t
 
 	/// A singleton QueueScheduler that always targets the main thread's GCD
 	/// queue.
@@ -95,6 +94,8 @@ public final class QueueScheduler: DateSchedulerType {
 	/// date, and will always schedule asynchronously (even if already running
 	/// on the main thread).
 	public static let mainQueueScheduler = QueueScheduler(queue: dispatch_get_main_queue(), name: "org.reactivecocoa.ReactiveCocoa.QueueScheduler.mainQueueScheduler")
+
+	internal let queue: dispatch_queue_t
 
 	public var currentDate: NSDate {
 		return NSDate()
@@ -111,7 +112,7 @@ public final class QueueScheduler: DateSchedulerType {
 
 	/// Initializes a scheduler that will target the global queue with the given
 	/// priority.
-	public convenience init(priority: CLong = DISPATCH_QUEUE_PRIORITY_DEFAULT, name: String = "org.reactivecocoa.ReactiveCocoa.QueueScheduler") {
+	public convenience init(priority: Int = DISPATCH_QUEUE_PRIORITY_DEFAULT, name: String = "org.reactivecocoa.ReactiveCocoa.QueueScheduler") {
 		self.init(queue: dispatch_get_global_queue(priority, 0), name: name)
 	}
 
@@ -128,11 +129,10 @@ public final class QueueScheduler: DateSchedulerType {
 	}
 
 	private func wallTimeWithDate(date: NSDate) -> dispatch_time_t {
-		var seconds = 0.0
-		let frac = modf(date.timeIntervalSince1970, &seconds)
+		let (seconds, frac) = modf(date.timeIntervalSince1970)
 
-		let nsec: Double = frac * Double(NSEC_PER_SEC)
-		var walltime = timespec(tv_sec: CLong(seconds), tv_nsec: CLong(nsec))
+		let nsec = frac * Double(NSEC_PER_SEC)
+		var walltime = timespec(tv_sec: Int(seconds), tv_nsec: Int(nsec))
 
 		return dispatch_walltime(&walltime, 0)
 	}


### PR DESCRIPTION
#### Bag
- Manual overflow check is replaced by automatic check using `UInt.addWithOverflow()`
- Remove the implementation of `generate()` because this method is default-implemented

#### Others
- `modf()` has an overload that returns a 2-tuple
- `CLong` is replaced by `Int` because the compiler infers `Int` for `DISPATCH_QUEUE_PRIORITY_DEFAULT` and other values