### PR TITLE
Publish optionalize() for signal/producer

### DIFF
--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -71,13 +71,6 @@ extension RACSignal {
 	}
 }
 
-private extension SignalType {
-	/// Turns each value into an Optional.
-	private func optionalize() -> Signal<T?, E> {
-		return signal.map(Optional.init)
-	}
-}
-
 /// Creates a RACSignal that will start() the producer once for each
 /// subscription.
 ///

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -575,6 +575,12 @@ extension SignalType where T: OptionalType {
 }
 
 extension SignalType {
+	/// Turns each value into an Optional.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func optionalize() -> Signal<T?, E> {
+		return signal.map(Optional.init)
+	}
+	
 	/// Returns a signal that will yield the first `count` values from `self`
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func take(count: Int) -> Signal<T, E> {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -596,6 +596,12 @@ extension SignalProducerType {
 	public func timeoutWithError(error: E, afterInterval interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> SignalProducer<T, E> {
 		return lift { $0.timeoutWithError(error, afterInterval: interval, onScheduler: scheduler) }
 	}
+	
+	/// Turns each value into an Optional.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func optionalize() -> SignalProducer<T?, E> {
+		return lift { $0.optionalize() }
+	}
 }
 
 extension SignalProducerType where T: OptionalType {


### PR DESCRIPTION
I PR, because I don't know the reason that `optionalize()` must be private. And I think that it is better to provide type conversion. Well, but I solve it if I use `map()` :sweat_smile: 