### PR TITLE
Add explicit type annotations to examples in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ That’s easy enough:
 
 ```swift
 searchResults.startWithNext { results in
-    println("Search results: \(results)")
+    print("Search results: \(results)")
 }
 ```
 
@@ -129,7 +129,7 @@ quickest solution would be to log them, then ignore them:
         return NSURLSession.sharedSession()
             .rac_dataWithRequest(URLRequest)
             .flatMapError { error in
-                println("Network error occurred: \(error)")
+                print("Network error occurred: \(error)")
                 return SignalProducer.empty
             }
     }
@@ -152,7 +152,7 @@ let searchResults = searchStrings
             .rac_dataWithRequest(URLRequest)
             .retry(2)
             .flatMapError { error in
-                println("Network error occurred: \(error)")
+                print("Network error occurred: \(error)")
                 return SignalProducer.empty
             }
     }

--- a/README.md
+++ b/README.md
@@ -145,20 +145,20 @@ Our improved `searchResults` producer might look like this:
 
 ```swift
 let searchResults = searchStrings
-    .flatMap(.Latest) { query in
+    .flatMap(.Latest) { (query: String) -> SignalProducer<(NSData, NSURLResponse), NSError> in
         let URLRequest = self.searchRequestWithEscapedQuery(query)
-
+        
         return NSURLSession.sharedSession()
             .rac_dataWithRequest(URLRequest)
             .retry(2)
             .flatMapError { error in
                 print("Network error occurred: \(error)")
                 return SignalProducer.empty
-            }
+        }
     }
-    .map { data, URLResponse in
+    .map { (data, URLResponse) -> String in
         let string = String(data: data, encoding: NSUTF8StringEncoding)!
-        return parseJSONResultsFromString(string)
+        return self.parseJSONResultsFromString(string)
     }
     .observeOn(UIScheduler())
 ```

--- a/README.md
+++ b/README.md
@@ -123,15 +123,15 @@ To remedy this, we need to decide what to do with errors that occur. The
 quickest solution would be to log them, then ignore them:
 
 ```swift
-    .flatMap(.Latest) { query in
+    .flatMap(.Latest) { (query: String) -> SignalProducer<(NSData, NSURLResponse), NSError> in
         let URLRequest = self.searchRequestWithEscapedQuery(query)
-
+        
         return NSURLSession.sharedSession()
             .rac_dataWithRequest(URLRequest)
             .flatMapError { error in
                 print("Network error occurred: \(error)")
                 return SignalProducer.empty
-            }
+        }
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ quickest solution would be to log them, then ignore them:
             .flatMapError { error in
                 print("Network error occurred: \(error)")
                 return SignalProducer.empty
-	        }
+            }
     }
 ```
 
@@ -154,7 +154,7 @@ let searchResults = searchStrings
             .flatMapError { error in
                 print("Network error occurred: \(error)")
                 return SignalProducer.empty
-	        }
+            }
     }
     .map { (data, URLResponse) -> String in
         let string = String(data: data, encoding: NSUTF8StringEncoding)!

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ With each string, we want to execute a network request. Luckily, RAC offers an
 
 ```swift
 let searchResults = searchStrings
-    .flatMap(.Latest) { query in
+    .flatMap(.Latest) { (query: String) -> SignalProducer<(NSData, NSURLResponse), NSError> in
         let URLRequest = self.searchRequestWithEscapedQuery(query)
         return NSURLSession.sharedSession().rac_dataWithRequest(URLRequest)
     }
-    .map { data, URLResponse in
+    .map { (data, URLResponse) -> String in
         let string = String(data: data, encoding: NSUTF8StringEncoding)!
-        return parseJSONResultsFromString(string)
+        return self.parseJSONResultsFromString(string)
     }
     .observeOn(UIScheduler())
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ quickest solution would be to log them, then ignore them:
 ```swift
     .flatMap(.Latest) { (query: String) -> SignalProducer<(NSData, NSURLResponse), NSError> in
         let URLRequest = self.searchRequestWithEscapedQuery(query)
-        
+
         return NSURLSession.sharedSession()
             .rac_dataWithRequest(URLRequest)
             .flatMapError { error in
@@ -147,7 +147,7 @@ Our improved `searchResults` producer might look like this:
 let searchResults = searchStrings
     .flatMap(.Latest) { (query: String) -> SignalProducer<(NSData, NSURLResponse), NSError> in
         let URLRequest = self.searchRequestWithEscapedQuery(query)
-        
+
         return NSURLSession.sharedSession()
             .rac_dataWithRequest(URLRequest)
             .retry(2)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ quickest solution would be to log them, then ignore them:
             .flatMapError { error in
                 print("Network error occurred: \(error)")
                 return SignalProducer.empty
-        }
+	        }
     }
 ```
 
@@ -154,7 +154,7 @@ let searchResults = searchStrings
             .flatMapError { error in
                 print("Network error occurred: \(error)")
                 return SignalProducer.empty
-        }
+	        }
     }
     .map { (data, URLResponse) -> String in
         let string = String(data: data, encoding: NSUTF8StringEncoding)!


### PR DESCRIPTION
This is in response to #2412 

In order to make the examples compile in the current Xcode Version (7.0), explicit type annotations are needed at some places where Xcode seems to not be able to infer the correct types automatically.

This clutters up the code, but I guess the examples should work when pasted into Xcode. Hopefully these changes can be reverted anytime soon...

Furthermore, `println` is now just `print` and I've added an explicit `self.` to the `self.parseJSONResultsFromString` call under the assumption that `parseJSONResultsFromString` is a method rather than a free function as was assumed in #2412 
