### PR TITLE
Fix -flatten: circular reference.

### DIFF
--- a/ReactiveCocoa/Objective-C/RACSignal+Operations.m
+++ b/ReactiveCocoa/Objective-C/RACSignal+Operations.m
@@ -520,10 +520,6 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 		void (^completeIfAllowed)(void) = ^{
 			if (selfCompleted && activeDisposables.count == 0) {
 				[subscriber sendCompleted];
-
-				// A strong reference is held to `subscribeToSignal` until completion,
-				// preventing it from deallocating early.
-				subscribeToSignal = nil;
 			}
 		};
 
@@ -588,6 +584,12 @@ static RACDisposable *subscribeForever (RACSignal *signal, void (^next)(id), voi
 				selfCompleted = YES;
 				completeIfAllowed();
 			}
+		}]];
+
+		[compoundDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+			// A strong reference is held to `subscribeToSignal` until we're
+			// done, preventing it from deallocating early.
+			subscribeToSignal = nil;
 		}]];
 
 		return compoundDisposable;


### PR DESCRIPTION
Previously we only nil’d our reference out on completion. So if we were disposed of instead of terminating naturally, we’d keep this block alive and everything it referenced.

![](https://media.giphy.com/media/7yoAIR7CdWOUE/giphy.gif)

Much like https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2328, I’m not sure how to test this as the objects we leak are deep within `-flatten:`.

I was (finally!) able to reproduce this and measure it in Instruments using these methods:

```objc
- (RACSignal *)doAThing {
	return [[[RACSignal
		return:@1]
		map:^id(id value) {
			return [[RACSignal return:@1] subscribeOn:[RACScheduler mainThreadScheduler]];
		}]
		flatten:1];
}

- (IBAction)start:(id)sender {
	[[[self doAThing]
		take:1]
		subscribeNext:^(id x) {

		} completed:^{

		}];
}
```

The key being that the signal has to be disposed of synchronously with its send (done by the `-take:` in this case), but subscribed to asynchronously (by the `-subscribeOn:`).