### PR TITLE
Reduce dependency on the `signal` property of `SignalType`

### DIFF
--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -99,7 +99,7 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(producer: SignalProduc
 ///
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(producer: SignalProducer<Value?, Error>) -> RACSignal {
-	return toRACSignal(producer.mapError { $0 as NSError })
+    return toRACSignal(producer.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will start() the producer once for each
@@ -107,9 +107,9 @@ public func toRACSignal<Value: AnyObject, Error>(producer: SignalProducer<Value?
 ///
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error: NSError>(producer: SignalProducer<Value?, Error>) -> RACSignal {
-	// This special casing of `Error: NSError` is a workaround for rdar://22708537
-	// which causes an NSError's UserInfo dictionary to get discarded
-	// during a cast from ErrorType to NSError in a generic function
+    // This special casing of `Error: NSError` is a workaround for rdar://22708537
+    // which causes an NSError's UserInfo dictionary to get discarded
+    // during a cast from ErrorType to NSError in a generic function
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start { event in
 			switch event {
@@ -148,34 +148,34 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value, 
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(signal: Signal<Value?, Error>) -> RACSignal {
-	return toRACSignal(signal.mapError { $0 as NSError })
+    return toRACSignal(signal.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will observe the given signal.
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value?, Error>) -> RACSignal {
-	// This special casing of `Error: NSError` is a workaround for rdar://22708537
-	// which causes an NSError's UserInfo dictionary to get discarded
-	// during a cast from ErrorType to NSError in a generic function
-	return RACSignal.createSignal { subscriber in
-		let selfDisposable = signal.observe { event in
-			switch event {
-			case let .Next(value):
-				subscriber.sendNext(value)
-			case let .Error(error):
-				subscriber.sendError(error)
-			case .Completed:
-				subscriber.sendCompleted()
-			case .Interrupted:
-				break
-			}
-		}
+    // This special casing of `Error: NSError` is a workaround for rdar://22708537
+    // which causes an NSError's UserInfo dictionary to get discarded
+    // during a cast from ErrorType to NSError in a generic function
+    return RACSignal.createSignal { subscriber in
+        let selfDisposable = signal.observe { event in
+            switch event {
+            case let .Next(value):
+                subscriber.sendNext(value)
+            case let .Error(error):
+                subscriber.sendError(error)
+            case .Completed:
+                subscriber.sendCompleted()
+            case .Interrupted:
+                break
+            }
+        }
 
-		return RACDisposable {
-			selfDisposable?.dispose()
-		}
-	}
+        return RACDisposable {
+            selfDisposable?.dispose()
+        }
+    }
 }
 
 extension RACCommand {

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -99,7 +99,7 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(producer: SignalProduc
 ///
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(producer: SignalProducer<Value?, Error>) -> RACSignal {
-	return toRACSignal(producer.mapError { $0 as NSError })
+    return toRACSignal(producer.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will start() the producer once for each
@@ -107,9 +107,9 @@ public func toRACSignal<Value: AnyObject, Error>(producer: SignalProducer<Value?
 ///
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<T: AnyObject, E: NSError>(producer: SignalProducer<T?, E>) -> RACSignal {
-	// This special casing of `E: NSError` is a workaround for rdar://22708537
-	// which causes an NSError's UserInfo dictionary to get discarded
-	// during a cast from ErrorType to NSError in a generic function
+    // This special casing of `E: NSError` is a workaround for rdar://22708537
+    // which causes an NSError's UserInfo dictionary to get discarded
+    // during a cast from ErrorType to NSError in a generic function
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start { event in
 			switch event {
@@ -148,34 +148,34 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value, 
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(signal: Signal<Value?, Error>) -> RACSignal {
-	return toRACSignal(signal.mapError { $0 as NSError })
+    return toRACSignal(signal.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will observe the given signal.
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value?, Error>) -> RACSignal {
-	// This special casing of `E: NSError` is a workaround for rdar://22708537
-	// which causes an NSError's UserInfo dictionary to get discarded
-	// during a cast from ErrorType to NSError in a generic function
-	return RACSignal.createSignal { subscriber in
-		let selfDisposable = signal.observe { event in
-			switch event {
-			case let .Next(value):
-				subscriber.sendNext(value)
-			case let .Error(error):
-				subscriber.sendError(error)
-			case .Completed:
-				subscriber.sendCompleted()
+    // This special casing of `E: NSError` is a workaround for rdar://22708537
+    // which causes an NSError's UserInfo dictionary to get discarded
+    // during a cast from ErrorType to NSError in a generic function
+    return RACSignal.createSignal { subscriber in
+        let selfDisposable = signal.observe { event in
+            switch event {
+            case let .Next(value):
+                subscriber.sendNext(value)
+            case let .Error(error):
+                subscriber.sendError(error)
+            case .Completed:
+                subscriber.sendCompleted()
 			case .Interrupted:
-				break
-			}
-		}
+                break
+            }
+        }
 
-		return RACDisposable {
-			selfDisposable?.dispose()
-		}
-	}
+        return RACDisposable {
+            selfDisposable?.dispose()
+        }
+    }
 }
 
 extension RACCommand {

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -99,7 +99,7 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(producer: SignalProduc
 ///
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(producer: SignalProducer<Value?, Error>) -> RACSignal {
-    return toRACSignal(producer.mapError { $0 as NSError })
+	return toRACSignal(producer.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will start() the producer once for each
@@ -107,9 +107,9 @@ public func toRACSignal<Value: AnyObject, Error>(producer: SignalProducer<Value?
 ///
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<T: AnyObject, E: NSError>(producer: SignalProducer<T?, E>) -> RACSignal {
-    // This special casing of `E: NSError` is a workaround for rdar://22708537
-    // which causes an NSError's UserInfo dictionary to get discarded
-    // during a cast from ErrorType to NSError in a generic function
+	// This special casing of `E: NSError` is a workaround for rdar://22708537
+	// which causes an NSError's UserInfo dictionary to get discarded
+	// during a cast from ErrorType to NSError in a generic function
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start { event in
 			switch event {
@@ -148,34 +148,34 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value, 
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(signal: Signal<Value?, Error>) -> RACSignal {
-    return toRACSignal(signal.mapError { $0 as NSError })
+	return toRACSignal(signal.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will observe the given signal.
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value?, Error>) -> RACSignal {
-    // This special casing of `E: NSError` is a workaround for rdar://22708537
-    // which causes an NSError's UserInfo dictionary to get discarded
-    // during a cast from ErrorType to NSError in a generic function
-    return RACSignal.createSignal { subscriber in
-        let selfDisposable = signal.observe { event in
-            switch event {
-            case let .Next(value):
-                subscriber.sendNext(value)
-            case let .Error(error):
-                subscriber.sendError(error)
-            case .Completed:
-                subscriber.sendCompleted()
+	// This special casing of `E: NSError` is a workaround for rdar://22708537
+	// which causes an NSError's UserInfo dictionary to get discarded
+	// during a cast from ErrorType to NSError in a generic function
+	return RACSignal.createSignal { subscriber in
+		let selfDisposable = signal.observe { event in
+			switch event {
+			case let .Next(value):
+				subscriber.sendNext(value)
+			case let .Error(error):
+				subscriber.sendError(error)
+			case .Completed:
+				subscriber.sendCompleted()
 			case .Interrupted:
-                break
-            }
-        }
+				break
+			}
+		}
 
-        return RACDisposable {
-            selfDisposable?.dispose()
-        }
-    }
+		return RACDisposable {
+			selfDisposable?.dispose()
+		}
+	}
 }
 
 extension RACCommand {

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -119,7 +119,7 @@ public func toRACSignal<T: AnyObject, E: NSError>(producer: SignalProducer<T?, E
 				subscriber.sendError(error)
 			case .Completed:
 				subscriber.sendCompleted()
-			default:
+			case .Interrupted:
 				break
 			}
 		}
@@ -167,7 +167,7 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value?,
                 subscriber.sendError(error)
             case .Completed:
                 subscriber.sendCompleted()
-            default:
+			case .Interrupted:
                 break
             }
         }

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -71,7 +71,7 @@ extension RACSignal {
 	}
 }
 
-private extension SignalType {
+extension SignalType {
 	/// Turns each value into an Optional.
 	private func optionalize() -> Signal<Value?, Error> {
 		return signal.map(Optional.init)
@@ -99,17 +99,17 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(producer: SignalProduc
 ///
 /// Any `Interrupted` events will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(producer: SignalProducer<Value?, Error>) -> RACSignal {
-    return toRACSignal(producer.mapError { $0 as NSError })
+	return toRACSignal(producer.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will start() the producer once for each
 /// subscription.
 ///
 /// Any `Interrupted` events will be silently discarded.
-public func toRACSignal<T: AnyObject, E: NSError>(producer: SignalProducer<T?, E>) -> RACSignal {
-    // This special casing of `E: NSError` is a workaround for rdar://22708537
-    // which causes an NSError's UserInfo dictionary to get discarded
-    // during a cast from ErrorType to NSError in a generic function
+public func toRACSignal<Value: AnyObject, Error: NSError>(producer: SignalProducer<Value?, Error>) -> RACSignal {
+	// This special casing of `Error: NSError` is a workaround for rdar://22708537
+	// which causes an NSError's UserInfo dictionary to get discarded
+	// during a cast from ErrorType to NSError in a generic function
 	return RACSignal.createSignal { subscriber in
 		let selfDisposable = producer.start { event in
 			switch event {
@@ -148,34 +148,34 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value, 
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error>(signal: Signal<Value?, Error>) -> RACSignal {
-    return toRACSignal(signal.mapError { $0 as NSError })
+	return toRACSignal(signal.mapError { $0 as NSError })
 }
 
 /// Creates a RACSignal that will observe the given signal.
 ///
 /// Any `Interrupted` event will be silently discarded.
 public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value?, Error>) -> RACSignal {
-    // This special casing of `E: NSError` is a workaround for rdar://22708537
-    // which causes an NSError's UserInfo dictionary to get discarded
-    // during a cast from ErrorType to NSError in a generic function
-    return RACSignal.createSignal { subscriber in
-        let selfDisposable = signal.observe { event in
-            switch event {
-            case let .Next(value):
-                subscriber.sendNext(value)
-            case let .Error(error):
-                subscriber.sendError(error)
-            case .Completed:
-                subscriber.sendCompleted()
+	// This special casing of `Error: NSError` is a workaround for rdar://22708537
+	// which causes an NSError's UserInfo dictionary to get discarded
+	// during a cast from ErrorType to NSError in a generic function
+	return RACSignal.createSignal { subscriber in
+		let selfDisposable = signal.observe { event in
+			switch event {
+			case let .Next(value):
+				subscriber.sendNext(value)
+			case let .Error(error):
+				subscriber.sendError(error)
+			case .Completed:
+				subscriber.sendCompleted()
 			case .Interrupted:
-                break
-            }
-        }
+				break
+			}
+		}
 
-        return RACDisposable {
-            selfDisposable?.dispose()
-        }
-    }
+		return RACDisposable {
+			selfDisposable?.dispose()
+		}
+	}
 }
 
 extension RACCommand {

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2014 GitHub. All rights reserved.
 //
 
+import Foundation
+
 /// Represents a serial queue of work items.
 public protocol SchedulerType {
 	/// Enqueues an action on the scheduler.

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -138,8 +138,8 @@ public final class QueueScheduler: DateSchedulerType {
 	}
 
 	private func wallTimeWithDate(date: NSDate) -> dispatch_time_t {
-		var seconds = 0.0
-		let frac = modf(date.timeIntervalSince1970, &seconds)
+
+		let (seconds, frac) = modf(date.timeIntervalSince1970)
 
 		let nsec: Double = frac * Double(NSEC_PER_SEC)
 		var walltime = timespec(tv_sec: Int(seconds), tv_nsec: Int(nsec))

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -142,7 +142,7 @@ public final class QueueScheduler: DateSchedulerType {
 		let frac = modf(date.timeIntervalSince1970, &seconds)
 
 		let nsec: Double = frac * Double(NSEC_PER_SEC)
-		var walltime = timespec(tv_sec: CLong(seconds), tv_nsec: CLong(nsec))
+		var walltime = timespec(tv_sec: Int(seconds), tv_nsec: Int(nsec))
 
 		return dispatch_walltime(&walltime, 0)
 	}


### PR DESCRIPTION
In many places `signal` can actually be replaced by `self`, which can give rise to looser coupling. 
Other changes are taken from #2386.
All tests are passed.
PS: The indentation changes are actually replacing spaces with tabs.