### PR TITLE
Kill "sink", reify "Observer", kill send* free functions

### DIFF
--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -131,15 +131,15 @@ The `map` operator is used to transform the values in a event stream, creating
 a new stream with the results.
 
 ```Swift
-let (signal, sink) = Signal<String, NoError>.pipe()
+let (signal, observer) = Signal<String, NoError>.pipe()
 
 signal
     .map { string in string.uppercaseString }
     .observe(next: println)
 
-sendNext(sink, "a")     // Prints A
-sendNext(sink, "b")     // Prints B
-sendNext(sink, "c")     // Prints C
+observer.sendNext("a")     // Prints A
+observer.sendNext("b")     // Prints B
+observer.sendNext("c")     // Prints C
 ```
 
 [Interactive visualisation of the `map` operator.](http://neilpa.me/rac-marbles/#map)
@@ -150,16 +150,16 @@ The `filter` operator is used to only include values in an event stream that
 satisfy a predicate.
 
 ```Swift
-let (signal, sink) = Signal<Int, NoError>.pipe()
+let (signal, observer) = Signal<Int, NoError>.pipe()
 
 signal
     .filter { number in number % 2 == 0 }
     .observe(next: println)
 
-sendNext(sink, 1)     // Not printed
-sendNext(sink, 2)     // Prints 2
-sendNext(sink, 3)     // Not printed
-sendNext(sink, 4)     // prints 4
+observer.sendNext(1)     // Not printed
+observer.sendNext(2)     // Prints 2
+observer.sendNext(3)     // Not printed
+observer.sendNext(4)     // prints 4
 ```
 
 [Interactive visualisation of the `filter` operator.](http://neilpa.me/rac-marbles/#filter)
@@ -171,16 +171,16 @@ combined value. Note that the final value is only sent after the input stream
 completes.
 
 ```Swift
-let (signal, sink) = Signal<Int, NoError>.pipe()
+let (signal, observer) = Signal<Int, NoError>.pipe()
 
 signal
     .reduce(1) { $0 * $1 }
     .observe(next: println)
 
-sendNext(sink, 1)     // nothing printed
-sendNext(sink, 2)     // nothing printed
-sendNext(sink, 3)     // nothing printed
-sendCompleted(sink)   // prints 6
+observer.sendNext(1)     // nothing printed
+observer.sendNext(2)     // nothing printed
+observer.sendNext(3)     // nothing printed
+observer.sendCompleted()   // prints 6
 ```
 
 The `collect` operator is used to aggregate a event stream’s values into
@@ -188,13 +188,13 @@ a single array value. Note that the final value is only sent after the input
 stream completes.
 
 ```Swift
-let (signal, sink) = Signal<Int, NoError>.pipe()
+let (signal, observer) = Signal<Int, NoError>.pipe()
 signal.collect().observe(next: println)
 
-sendNext(sink, 1)     // nothing printed
-sendNext(sink, 2)     // nothing printed
-sendNext(sink, 3)     // nothing printed
-sendCompleted(sink)   // prints [1, 2, 3]
+observer.sendNext(1)     // nothing printed
+observer.sendNext(2)     // nothing printed
+observer.sendNext(3)     // nothing printed
+observer.sendCompleted()   // prints [1, 2, 3]
 ```
 
 [Interactive visualisation of the `reduce` operator.](http://neilpa.me/rac-marbles/#reduce)
@@ -214,20 +214,20 @@ least one value. After that, new values on any of the inputs will result in
 a new value on the output.
 
 ```Swift
-let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
-let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
+let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
 
 combineLatest(numbersSignal, lettersSignal)
     .observe(next: println, completed: { println("Completed") })
 
-sendNext(numbersSink, 0)    // nothing printed
-sendNext(numbersSink, 1)    // nothing printed
-sendNext(lettersSink, "A")  // prints (1, A)
-sendNext(numbersSink, 2)    // prints (2, A)
-sendCompleted(numbersSink)  // nothing printed
-sendNext(lettersSink, "B")  // prints (2, B)
-sendNext(lettersSink, "C")  // prints (2, C)
-sendCompleted(lettersSink)  // prints "Completed"
+numbersObserver.sendNext(0)      // nothing printed
+numbersObserver.sendNext(1)      // nothing printed
+lettersObserver.sendNext("A")    // prints (1, A)
+numbersObserver.sendNext(2)      // prints (2, A)
+numbersObserver.sendCompleted()  // nothing printed
+lettersObserver.sendNext("B")    // prints (2, B)
+lettersObserver.sendNext("C")    // prints (2, C)
+lettersObserver.sendCompleted()  // prints "Completed"
 ```
 
 The `combineLatestWith` operator works in the same way, but as an operator.
@@ -243,19 +243,19 @@ That means the Nth value of the output stream cannot be sent until each input
 has sent at least N values.
 
 ```Swift
-let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
-let (lettersSignal, lettersSink) = Signal<String, NoError>.pipe()
+let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, NoError>.pipe()
 
 zip(numbersSignal, lettersSignal)
     .observe(next: println, completed: { println("Completed") })
 
-sendNext(numbersSink, 0)    // nothing printed
-sendNext(numbersSink, 1)    // nothing printed
-sendNext(lettersSink, "A")  // prints (0, A)
-sendNext(numbersSink, 2)    // nothing printed
-sendCompleted(numbersSink)  // nothing printed
-sendNext(lettersSink, "B")  // prints (1, B)
-sendNext(lettersSink, "C")  // prints (2, C) & "Completed"
+numbersObserver.sendNext(0)      // nothing printed
+numbersObserver.sendNext(1)      // nothing printed
+lettersObserver.sendNext("A")    // prints (0, A)
+numbersObserver.sendNext(2)      // nothing printed
+numbersObserver.sendCompleted()  // nothing printed
+lettersObserver.sendNext("B")    // prints (1, B)
+lettersObserver.sendNext("C")    // prints (2, C) & "Completed"
 
 ```
 
@@ -295,22 +295,22 @@ Note, how the values interleave and which values are even included in the result
 The `.Merge` strategy immediately forwards every value of the inner `SignalProducer`s to the outer `SignalProducer`. Any error sent on the outer producer or any inner producer is immediately sent on the flattened producer and terminates it.
 
 ```Swift
-let (producerA, lettersSink) = SignalProducer<String, NoError>.buffer(5)
-let (producerB, numbersSink) = SignalProducer<String, NoError>.buffer(5)
-let (signal, sink) = SignalProducer<SignalProducer<String, NoError>, NoError>.buffer(5)
+let (producerA, lettersObserver) = SignalProducer<String, NoError>.buffer(5)
+let (producerB, numbersObserver) = SignalProducer<String, NoError>.buffer(5)
+let (signal, observer) = SignalProducer<SignalProducer<String, NoError>, NoError>.buffer(5)
 
 signal.flatten(.Merge).start(next: println)
 
-sendNext(sink, producerA)
-sendNext(sink, producerB)
-sendCompleted(sink)
+observer.sendNext(producerA)
+observer.sendNext(producerB)
+observer.sendCompleted()
 
-sendNext(lettersSink, "a")    // prints "a"
-sendNext(numbersSink, "1")    // prints "1"
-sendNext(lettersSink, "b")    // prints "b"
-sendNext(numbersSink, "2")    // prints "2"
-sendNext(lettersSink, "c")    // prints "c"
-sendNext(numbersSink, "3")    // prints "3"
+lettersObserver.sendNext("a")    // prints "a"
+numbersObserver.sendNext("1")    // prints "1"
+lettersObserver.sendNext("b")    // prints "b"
+numbersObserver.sendNext("2")    // prints "2"
+lettersObserver.sendNext("c")    // prints "c"
+numbersObserver.sendNext("3")    // prints "3"
 ```
 
 [Interactive visualisation of the `flatten(.Merge)` operator.](http://neilpa.me/rac-marbles/#merge)
@@ -320,24 +320,24 @@ sendNext(numbersSink, "3")    // prints "3"
 The `.Concat` strategy is used to serialize work of the inner `SignalProducer`s. The outer producer is started immediately. Each subsequent producer is not started until the preceeding one has completed. Errors are immediately forwarded to the flattened producer.
 
 ```Swift
-let (producerA, lettersSink) = SignalProducer<String, NoError>.buffer(5)
-let (producerB, numbersSink) = SignalProducer<String, NoError>.buffer(5)
-let (signal, sink) = SignalProducer<SignalProducer<String, NoError>, NoError>.buffer(5)
+let (producerA, lettersObserver) = SignalProducer<String, NoError>.buffer(5)
+let (producerB, numbersObserver) = SignalProducer<String, NoError>.buffer(5)
+let (signal, observer) = SignalProducer<SignalProducer<String, NoError>, NoError>.buffer(5)
 
 signal.flatten(.Concat).start(next: println)
 
-sendNext(sink, producerA)
-sendNext(sink, producerB)
-sendCompleted(sink)
+observer.sendNext(producerA)
+observer.sendNext(producerB)
+observer.sendCompleted()
 
-sendNext(numbersSink, "1")    // nothing printed
-sendNext(lettersSink, "a")    // prints "a"
-sendNext(lettersSink, "b")    // prints "b"
-sendNext(numbersSink, "2")    // nothing printed
-sendNext(lettersSink, "c")    // prints "c"
-sendCompleted(lettersSink)    // prints "1", "2"
-sendNext(numbersSink, "3")    // prints "3"
-sendCompleted(numbersSink)
+numbersObserver.sendNext("1")    // nothing printed
+lettersObserver.sendNext("a")    // prints "a"
+lettersObserver.sendNext("b")    // prints "b"
+numbersObserver.sendNext("2")    // nothing printed
+lettersObserver.sendNext("c")    // prints "c"
+lettersObserver.sendCompleted()    // prints "1", "2"
+numbersObserver.sendNext("3")    // prints "3"
+numbersObserver.sendCompleted()
 ```
 
 [Interactive visualisation of the `flatten(.Concat)` operator.](http://neilpa.me/rac-marbles/#concat)
@@ -347,25 +347,25 @@ sendCompleted(numbersSink)
 The `.Latest` strategy forwards only values from the latest input `SignalProducer`.
 
 ```Swift
-let (producerA, sinkA) = SignalProducer<String, NoError>.buffer(5)
-let (producerB, sinkB) = SignalProducer<String, NoError>.buffer(5)
-let (producerC, sinkC) = SignalProducer<String, NoError>.buffer(5)
-let (signal, sink) = SignalProducer<SignalProducer<String, NoError>, NoError>.buffer(5)
+let (producerA, observerA) = SignalProducer<String, NoError>.buffer(5)
+let (producerB, observerB) = SignalProducer<String, NoError>.buffer(5)
+let (producerC, observerC) = SignalProducer<String, NoError>.buffer(5)
+let (signal, observer) = SignalProducer<SignalProducer<String, NoError>, NoError>.buffer(5)
 
 signal.flatten(.Latest).start(next: println)
 
-sendNext(sink, producerA)   // nothing printed
-sendNext(sinkC, "X")        // nothing printed
-sendNext(sinkA, "a")        // prints "a"
-sendNext(sinkB, "1")        // nothing printed
-sendNext(sink, producerB)   // prints "1"
-sendNext(sinkA, "b")        // nothing printed
-sendNext(sinkB, "2")        // prints "2"
-sendNext(sinkC, "Y")        // nothing printed
-sendNext(sinkA, "c")        // nothing printed
-sendNext(sink, producerC)   // prints "X", "Y"
-sendNext(sinkB, "3")        // nothing printed
-sendNext(sinkC, "Z")        // prints "Z"
+observer.sendNext(producerA)   // nothing printed
+observerC.sendNext("X")        // nothing printed
+observerA.sendNext("a")        // prints "a"
+observerB.sendNext("1")        // nothing printed
+observer.sendNext(producerB)   // prints "1"
+observerA.sendNext("b")        // nothing printed
+observerB.sendNext("2")        // prints "2"
+observerC.sendNext("Y")        // nothing printed
+observerA.sendNext("c")        // nothing printed
+observer.sendNext(producerC)   // prints "X", "Y"
+observerB.sendNext("3")        // nothing printed
+observerC.sendNext("Z")        // prints "Z"
 ```
 
 ## Handling errors
@@ -377,7 +377,7 @@ These operators are used to handle errors that might occur on an event stream.
 The `catch` operator catches any error that may occur on the input `SignalProducer`, then starts a new `SignalProducer` in its place.
 
 ```Swift
-let (producer, sink) = SignalProducer<String, NSError>.buffer(5)
+let (producer, observer) = SignalProducer<String, NSError>.buffer(5)
 let error = NSError(domain: "domain", code: 0, userInfo: nil)
 
 producer
@@ -385,9 +385,9 @@ producer
     .start(next: println)
 
 
-sendNext(sink, "First")     // prints "First"
-sendNext(sink, "Second")    // prints "Second"
-sendError(sink, error)      // prints "Default"
+observer.sendNext("First")     // prints "First"
+observer.sendNext("Second")    // prints "Second"
+observer.sendError(error)      // prints "Default"
 ```
 
 ### Retrying
@@ -398,12 +398,12 @@ The `retry` operator will restart the original `SignalProducer` on error up to `
 var tries = 0
 let limit = 2
 let error = NSError(domain: "domain", code: 0, userInfo: nil)
-let producer = SignalProducer<String, NSError> { (sink, _) in
+let producer = SignalProducer<String, NSError> { (observer, _) in
     if tries++ < limit {
-        sendError(sink, error)
+        observer.sendError(error)
     } else {
-        sendNext(sink, "Success")
-        sendCompleted(sink)
+        observer.sendNext("Success")
+        observer.sendCompleted()
     }
 }
 
@@ -435,7 +435,7 @@ enum CustomError: String, ErrorType {
     }
 }
 
-let (signal, sink) = Signal<String, NSError>.pipe()
+let (signal, observer) = Signal<String, NSError>.pipe()
 
 signal
     .mapError { (error: NSError) -> CustomError in
@@ -450,7 +450,7 @@ signal
     }
     .observe(error: println)
 
-sendError(sink, NSError(domain: "com.example.foo", code: 42, userInfo: nil))    // prints "Foo Error"
+observer.sendError(NSError(domain: "com.example.foo", code: 42, userInfo: nil))    // prints "Foo Error"
 ```
 
 ### Promote
@@ -458,8 +458,8 @@ sendError(sink, NSError(domain: "com.example.foo", code: 42, userInfo: nil))    
 The `promoteErrors` operator promotes an event stream that does not generate errors into one that can. 
 
 ```Swift
-let (numbersSignal, numbersSink) = Signal<Int, NoError>.pipe()
-let (lettersSignal, lettersSink) = Signal<String, NSError>.pipe()
+let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
+let (lettersSignal, lettersObserver) = Signal<String, NSError>.pipe()
 
 numbersSignal
     .promoteErrors(NSError)

--- a/Documentation/DesignGuidelines.md
+++ b/Documentation/DesignGuidelines.md
@@ -471,7 +471,7 @@ a `switch` statement to determine the event type.
 For example:
 
 ```swift
-producer.start(SinkOf { event in
+producer.start { event in
     switch event {
     case let .Next(value):
         println("Next event: \(value)")
@@ -485,7 +485,7 @@ producer.start(SinkOf { event in
     case .Interrupted:
         println("Interrupted event")
     }
-})
+}
 ```
 
 Since the compiler will generate a warning if the `switch` is missing any case,

--- a/Documentation/FrameworkOverview.md
+++ b/Documentation/FrameworkOverview.md
@@ -115,8 +115,7 @@ dropped to make room for it.
 
 An **observer** is anything that is waiting or capable of waiting for [events](#events)
 from a [signal](#signals). Within RAC, an observer is represented as
-a [`SinkType`](http://swiftdoc.org/protocol/SinkType/) that accepts
-[`Event`][Event] values.
+an [`Observer`][Observer] that accepts [`Event`][Event] values.
 
 Observers can be implicitly created by using the callback-based versions of the
 `Signal.observe` or `SignalProducer.start` methods.
@@ -208,4 +207,4 @@ do not allow tasks to be reordered or depend on one another.
 [Scheduler]: ../ReactiveCocoa/Swift/Scheduler.swift
 [Property]: ../ReactiveCocoa/Swift/Property.swift
 [Event]: ../ReactiveCocoa/Swift/Event.swift
-[SinkOf]: http://swiftdoc.org/type/SinkOf/
+[Observer]: ../ReactiveCocoa/Swift/Observer.swift

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -719,6 +719,10 @@
 		D8170FC21B100EBC004192AD /* FoundationExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8170FC01B100EBC004192AD /* FoundationExtensionsSpec.swift */; };
 		D871D69F1B3B29A40070F16C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
 		D8E84A671B3B32FB00C3E831 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
+		EBCC7DBC1BBF010C00A2AE92 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */; settings = {ASSET_TAGS = (); }; };
+		EBCC7DBD1BBF01E100A2AE92 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */; settings = {ASSET_TAGS = (); }; };
+		EBCC7DBE1BBF01E200A2AE92 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */; settings = {ASSET_TAGS = (); }; };
+		EBCC7DBF1BBF01E200A2AE92 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -776,7 +780,7 @@
 		CD183E811AED1E0E00848F5D /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Box.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDC42E2E1AE7AB8B00965373 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D00004081A46864E000E7D41 /* TupleExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TupleExtensions.swift; sourceTree = "<group>"; };
-		D021671C1A6CD50500987861 /* ActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionSpec.swift; sourceTree = "<group>"; };
+		D021671C1A6CD50500987861 /* ActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ActionSpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D037642A19EDA41200A782A9 /* NSArray+RACSequenceAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+RACSequenceAdditions.h"; sourceTree = "<group>"; };
 		D037642B19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+RACSequenceAdditions.m"; sourceTree = "<group>"; };
 		D037642C19EDA41200A782A9 /* NSControl+RACCommandSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSControl+RACCommandSupport.h"; sourceTree = "<group>"; };
@@ -1056,10 +1060,10 @@
 		D08C54B11A69A2AC00AD8286 /* Signal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Signal.swift; sourceTree = "<group>"; };
 		D08C54B21A69A2AC00AD8286 /* SignalProducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalProducer.swift; sourceTree = "<group>"; };
 		D08C54B51A69A3DB00AD8286 /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
-		D0A226071A72E0E900D33B74 /* SignalSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalSpec.swift; sourceTree = "<group>"; };
-		D0A2260A1A72E6C500D33B74 /* SignalProducerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProducerSpec.swift; sourceTree = "<group>"; };
-		D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PropertySpec.swift; sourceTree = "<group>"; };
-		D0A226101A72F30B00D33B74 /* ObjectiveCBridgingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCBridgingSpec.swift; sourceTree = "<group>"; };
+		D0A226071A72E0E900D33B74 /* SignalSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SignalSpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D0A2260A1A72E6C500D33B74 /* SignalProducerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SignalProducerSpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PropertySpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D0A226101A72F30B00D33B74 /* ObjectiveCBridgingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ObjectiveCBridgingSpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D0C312BB19EF2A5800984962 /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		D0C312BC19EF2A5800984962 /* Bag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bag.swift; sourceTree = "<group>"; };
 		D0C312BE19EF2A5800984962 /* Disposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Disposable.swift; sourceTree = "<group>"; };
@@ -1079,9 +1083,10 @@
 		D0C3131D19EF2D9700984962 /* RACTestUIButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACTestUIButton.m; sourceTree = "<group>"; };
 		D43F279E1A9F7E8A00C1AD76 /* RACDynamicPropertySuperclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RACDynamicPropertySuperclass.h; sourceTree = "<group>"; };
 		D43F279F1A9F7E8A00C1AD76 /* RACDynamicPropertySuperclass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACDynamicPropertySuperclass.m; sourceTree = "<group>"; };
-		D8024DB11B2E1BB0005E6B9A /* SignalProducerLiftingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProducerLiftingSpec.swift; sourceTree = "<group>"; };
+		D8024DB11B2E1BB0005E6B9A /* SignalProducerLiftingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SignalProducerLiftingSpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8170FC01B100EBC004192AD /* FoundationExtensionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationExtensionsSpec.swift; sourceTree = "<group>"; };
 		D871D69E1B3B29A40070F16C /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
+		EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Observer.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1615,6 +1620,7 @@
 				D0C312BF19EF2A5800984962 /* Errors.swift */,
 				D08C54B51A69A3DB00AD8286 /* Event.swift */,
 				D0C312C419EF2A5800984962 /* ObjectiveCBridging.swift */,
+				EBCC7DBB1BBF010C00A2AE92 /* Observer.swift */,
 				D871D69E1B3B29A40070F16C /* Optional.swift */,
 				D0C312C819EF2A5800984962 /* Scheduler.swift */,
 				D03B4A3919F4C25F009E02AC /* Signals */,
@@ -2149,6 +2155,7 @@
 				57A4D1DC1BA13D7A00F7D4B1 /* RACCompoundDisposable.m in Sources */,
 				57A4D1DD1BA13D7A00F7D4B1 /* RACDelegateProxy.m in Sources */,
 				57A4D1DE1BA13D7A00F7D4B1 /* RACDisposable.m in Sources */,
+				EBCC7DBF1BBF01E200A2AE92 /* Observer.swift in Sources */,
 				57A4D1DF1BA13D7A00F7D4B1 /* RACDynamicSequence.m in Sources */,
 				57A4D1E01BA13D7A00F7D4B1 /* RACDynamicSignal.m in Sources */,
 				57A4D1E11BA13D7A00F7D4B1 /* RACEagerSequence.m in Sources */,
@@ -2241,6 +2248,7 @@
 				A9B3157E1B3940750001CB9C /* RACCompoundDisposable.m in Sources */,
 				A9B3157F1B3940750001CB9C /* RACDelegateProxy.m in Sources */,
 				A9B315801B3940750001CB9C /* RACDisposable.m in Sources */,
+				EBCC7DBE1BBF01E200A2AE92 /* Observer.swift in Sources */,
 				A9B315811B3940750001CB9C /* RACDynamicSequence.m in Sources */,
 				A9B315821B3940750001CB9C /* RACDynamicSignal.m in Sources */,
 				A9B315831B3940750001CB9C /* RACEagerSequence.m in Sources */,
@@ -2314,6 +2322,7 @@
 				D037653E19EDA41200A782A9 /* NSString+RACSupport.m in Sources */,
 				D037653619EDA41200A782A9 /* NSString+RACKeyPathUtilities.m in Sources */,
 				D03764FA19EDA41200A782A9 /* NSDictionary+RACSequenceAdditions.m in Sources */,
+				EBCC7DBC1BBF010C00A2AE92 /* Observer.swift in Sources */,
 				D037656819EDA41200A782A9 /* RACCompoundDisposableProvider.d in Sources */,
 				D03B4A3D19F4C39A009E02AC /* FoundationExtensions.swift in Sources */,
 				D037653A19EDA41200A782A9 /* NSString+RACSequenceAdditions.m in Sources */,
@@ -2473,6 +2482,7 @@
 				D03765ED19EDA41200A782A9 /* RACSubject.m in Sources */,
 				D037664F19EDA41200A782A9 /* UIStepper+RACSignalSupport.m in Sources */,
 				D03765D119EDA41200A782A9 /* RACSerialDisposable.m in Sources */,
+				EBCC7DBD1BBF01E100A2AE92 /* Observer.swift in Sources */,
 				D037663F19EDA41200A782A9 /* UIImagePickerController+RACSignalSupport.m in Sources */,
 				D037653F19EDA41200A782A9 /* NSString+RACSupport.m in Sources */,
 				D037653719EDA41200A782A9 /* NSString+RACKeyPathUtilities.m in Sources */,

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -84,7 +84,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 	}
 
 	deinit {
-		sendCompleted(eventsObserver)
+		eventsObserver.sendCompleted()
 	}
 
 	/// Creates a SignalProducer that, when started, will execute the action
@@ -106,7 +106,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 			}
 
 			if !startedExecuting {
-				sendError(observer, .NotEnabled)
+				observer.sendError(.NotEnabled)
 				return
 			}
 
@@ -114,8 +114,8 @@ public final class Action<Input, Output, Error: ErrorType> {
 				disposable.addDisposable(signalDisposable)
 
 				signal.observe { event in
-					observer(event.mapError { .ProducerError($0) })
-					sendNext(self.eventsObserver, event)
+					observer.action(event.mapError { .ProducerError($0) })
+					self.eventsObserver.sendNext(event)
 				}
 			}
 

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -226,7 +226,7 @@ public final class SerialDisposable: Disposable {
 ///     disposable += producer
 ///         .filter { ... }
 ///         .map    { ... }
-///         .start(sink)
+///         .start(observer)
 ///
 public func +=(lhs: CompositeDisposable, rhs: Disposable?) -> CompositeDisposable.DisposableHandle {
 	return lhs.addDisposable(rhs)

--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -25,7 +25,6 @@ public enum Event<Value, Err: ErrorType> {
 	/// will be received.
 	case Interrupted
 
-	public typealias Sink = Event -> ()
 
 	/// Whether this event indicates signal termination (i.e., that no further
 	/// events will be received).
@@ -90,26 +89,6 @@ public enum Event<Value, Err: ErrorType> {
 			return nil
 		}
 	}
-
-	/// Creates a sink that can receive events of this type, then invoke the
-	/// given handlers based on the kind of event received.
-	public static func sink(error error: (Err -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (Value -> ())? = nil) -> Sink {
-		return { event in
-			switch event {
-			case let .Next(value):
-				next?(value)
-
-			case let .Error(err):
-				error?(err)
-
-			case .Completed:
-				completed?()
-
-			case .Interrupted:
-				interrupted?()
-			}
-		}
-	}
 }
 
 public func == <Value: Equatable, Err: Equatable> (lhs: Event<Value, Err>, rhs: Event<Value, Err>) -> Bool {
@@ -163,24 +142,4 @@ extension Event: EventType {
 	public var event: Event<Value, Err> {
 		return self
 	}
-}
-
-/// Puts a `Next` event into the given sink.
-public func sendNext<Value, Err: ErrorType>(sink: Event<Value, Err>.Sink, _ value: Value) {
-	sink(.Next(value))
-}
-
-/// Puts an `Error` event into the given sink.
-public func sendError<Value, Err: ErrorType>(sink: Event<Value, Err>.Sink, _ error: Err) {
-	sink(.Error(error))
-}
-
-/// Puts a `Completed` event into the given sink.
-public func sendCompleted<Value, Err: ErrorType>(sink: Event<Value, Err>.Sink) {
-	sink(.Completed)
-}
-
-/// Puts a `Interrupted` event into the given sink.
-public func sendInterrupted<Value, Err: ErrorType>(sink: Event<Value, Err>.Sink) {
-	sink(.Interrupted)
 }

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -15,7 +15,7 @@ extension NSNotificationCenter {
 	public func rac_notifications(name: String? = nil, object: AnyObject? = nil) -> SignalProducer<NSNotification, NoError> {
 		return SignalProducer { observer, disposable in
 			let notificationObserver = self.addObserverForName(name, object: object, queue: nil) { notification in
-				sendNext(observer, notification)
+				observer.sendNext(notification)
 			}
 
 			disposable.addDisposable {
@@ -34,10 +34,10 @@ extension NSURLSession {
 		return SignalProducer { observer, disposable in
 			let task = self.dataTaskWithRequest(request) { data, response, error in
 				if let data = data, response = response {
-					sendNext(observer, (data, response))
-					sendCompleted(observer)
+					observer.sendNext((data, response))
+					observer.sendCompleted()
 				} else {
-					sendError(observer, error ?? defaultSessionError)
+					observer.sendError(error ?? defaultSessionError)
 				}
 			}
 

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -55,15 +55,15 @@ extension RACSignal {
 	public func toSignalProducer(file: String = __FILE__, line: Int = __LINE__) -> SignalProducer<AnyObject?, NSError> {
 		return SignalProducer { observer, disposable in
 			let next = { obj in
-				sendNext(observer, obj)
+				observer.sendNext(obj)
 			}
 
 			let error = { nsError in
-				sendError(observer, nsError ?? defaultNSError("Nil RACSignal error", file: file, line: line))
+				observer.sendError(nsError ?? defaultNSError("Nil RACSignal error", file: file, line: line))
 			}
 
 			let completed = {
-				sendCompleted(observer)
+				observer.sendCompleted()
 			}
 
 			disposable += self.subscribeNext(next, error: error, completed: completed)

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -6,7 +6,8 @@
 //  Copyright © 2015 GitHub. All rights reserved.
 //
 
-/// TODO(andy): Document me.
+/// An Observer is a simple wrapper around a function which can receive Events
+/// (typically from a Signal).
 public struct Observer<Value, Err: ErrorType> {
 	public typealias Action = Event<Value, Err> -> ()
 

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -1,0 +1,56 @@
+//
+//  Observer.swift
+//  ReactiveCocoa
+//
+//  Created by Andy Matuschak on 10/2/15.
+//  Copyright © 2015 GitHub. All rights reserved.
+//
+
+/// TODO(andy): Document me.
+public struct Observer<Value, Err: ErrorType> {
+	public typealias Action = Event<Value, Err> -> ()
+
+	public let action: Action
+
+	public init(_ action: Action) {
+		self.action = action
+	}
+
+	public init(error: (Err -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (Value -> ())? = nil) {
+		self.init { event in
+			switch event {
+			case let .Next(value):
+				next?(value)
+
+			case let .Error(err):
+				error?(err)
+
+			case .Completed:
+				completed?()
+
+			case .Interrupted:
+				interrupted?()
+			}
+		}
+	}
+
+	/// Puts a `Next` event into the given observer.
+	public func sendNext(value: Value) {
+		action(.Next(value))
+	}
+
+	/// Puts an `Error` event into the given observer.
+	public func sendError(error: Err) {
+		action(.Error(error))
+	}
+
+	/// Puts a `Completed` event into the given observer.
+	public func sendCompleted() {
+		action(.Completed)
+	}
+
+	/// Puts a `Interrupted` event into the given observer.
+	public func sendInterrupted() {
+		action(.Interrupted)
+	}
+}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -96,7 +96,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		set {
 			lock.lock()
 			_value = newValue
-			sendNext(observer, newValue)
+			observer.sendNext(newValue)
 			lock.unlock()
 		}
 	}
@@ -113,11 +113,11 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		(producer, observer) = SignalProducer<Value, NoError>.buffer(1)
 
 		_value = initialValue
-		sendNext(observer, initialValue)
+		observer.sendNext(initialValue)
 	}
 
 	deinit {
-		sendCompleted(observer)
+		observer.sendCompleted()
 	}
 }
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -707,9 +707,9 @@ extension SignalType {
 				observer.sendNext((signalState.latestValue!, otherState.latestValue!))
 			}
 			
-			let onError = { observer.sendError($0) }
-			let onBothCompleted = { observer.sendCompleted() }
-			let onInterrupted = { observer.sendInterrupted() }
+			let onError = observer.sendError($0)
+			let onBothCompleted = observer.sendCompleted()
+			let onInterrupted = observer.sendInterrupted()
 
 			let disposable = CompositeDisposable()
 			disposable += observeWithStates(self.signal, signalState, otherState, lock, onBothNext, onError, onBothCompleted, onInterrupted)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -707,9 +707,9 @@ extension SignalType {
 				observer.sendNext((signalState.latestValue!, otherState.latestValue!))
 			}
 			
-			let onError = observer.sendError($0)
-			let onBothCompleted = observer.sendCompleted()
-			let onInterrupted = observer.sendInterrupted()
+			let onError = { observer.sendError($0) }
+			let onBothCompleted = observer.sendCompleted
+			let onInterrupted = observer.sendInterrupted
 
 			let disposable = CompositeDisposable()
 			disposable += observeWithStates(self.signal, signalState, otherState, lock, onBothNext, onError, onBothCompleted, onInterrupted)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -15,7 +15,7 @@ import Result
 /// Signals do not need to be retained. A Signal will be automatically kept
 /// alive until the event stream has terminated.
 public final class Signal<Value, Error: ErrorType> {
-	public typealias Observer = Event<Value, Error>.Sink
+	public typealias Observer = ReactiveCocoa.Observer<Value, Error>
 
 	private let atomicObservers: Atomic<Bag<Observer>?> = Atomic(Bag())
 
@@ -36,7 +36,7 @@ public final class Signal<Value, Error: ErrorType> {
 		/// When set to `true`, the Signal should interrupt as soon as possible.
 		let interrupted = Atomic(false)
 
-		let sink: Observer = { event in
+		let observer = Observer { event in
 			if case .Interrupted = event {
 				// Normally we disallow recursive events, but
 				// Interrupted is kind of a special snowflake, since it
@@ -58,8 +58,8 @@ public final class Signal<Value, Error: ErrorType> {
 				if let observers = (event.isTerminating ? self.atomicObservers.swap(nil) : self.atomicObservers.value) {
 					sendLock.lock()
 
-					for sink in observers {
-						sink(event)
+					for observer in observers {
+						observer.action(event)
 					}
 
 					let shouldInterrupt = !event.isTerminating && interrupted.value
@@ -78,7 +78,7 @@ public final class Signal<Value, Error: ErrorType> {
 			}
 		}
 
-		generatorDisposable.innerDisposable = generator(sink)
+		generatorDisposable.innerDisposable = generator(observer)
 	}
 
 	/// A Signal that never sends any events to its observers.
@@ -87,34 +87,34 @@ public final class Signal<Value, Error: ErrorType> {
 	}
 
 	/// Creates a Signal that will be controlled by sending events to the given
-	/// observer (sink).
+	/// observer.
 	///
 	/// The Signal will remain alive until a terminating event is sent to the
 	/// observer.
 	public class func pipe() -> (Signal, Observer) {
-		var sink: Observer!
-		let signal = self.init { innerSink in
-			sink = innerSink
+		var observer: Observer!
+		let signal = self.init { innerObserver in
+			observer = innerObserver
 			return nil
 		}
 
-		return (signal, sink)
+		return (signal, observer)
 	}
 
 	/// Interrupts all observers and terminates the stream.
 	private func interrupt() {
 		if let observers = self.atomicObservers.swap(nil) {
-			for sink in observers {
-				sink(.Interrupted)
+			for observer in observers {
+				observer.sendInterrupted()
 			}
 		}
 	}
 
-	/// Observes the Signal by sending any future events to the given sink. If
-	/// the Signal has already terminated, the sink will immediately receive an
+	/// Observes the Signal by sending any future events to the given observer. If
+	/// the Signal has already terminated, the observer will immediately receive an
 	/// `Interrupted` event.
 	///
-	/// Returns a Disposable which can be used to disconnect the sink. Disposing
+	/// Returns a Disposable which can be used to disconnect the observer. Disposing
 	/// of the Disposable will have no effect on the Signal itself.
 	public func observe(observer: Observer) -> Disposable? {
 		var token: RemovalToken?
@@ -135,9 +135,14 @@ public final class Signal<Value, Error: ErrorType> {
 				}
 			}
 		} else {
-			observer(.Interrupted)
+			observer.sendInterrupted()
 			return nil
 		}
+	}
+
+	/// Convenience to avoid lots of extra parentheses everywhere people call observe(). TODO(andy): Document me.
+	public func observe(action: Observer.Action) -> Disposable? {
+		return observe(Observer(action))
 	}
 }
 
@@ -151,7 +156,7 @@ public protocol SignalType {
 	/// Extracts a signal from the receiver.
 	var signal: Signal<Value, Error> { get }
 
-	/// Observes the Signal by sending any future events to the given sink.
+	/// Observes the Signal by sending any future events to the given observer.
 	func observe(observer: Signal<Value, Error>.Observer) -> Disposable?
 }
 
@@ -162,6 +167,11 @@ extension Signal: SignalType {
 }
 
 extension SignalType {
+	/// Convenience to avoid extra parentheses everywehre. TODO(andy): Document.
+	public func observe(action: Signal<Value, Error>.Observer.Action) -> Disposable? {
+		return observe(Observer(action))
+	}
+
 	/// Observes the Signal by invoking the given callback when `next` events are
 	/// received.
 	///
@@ -169,7 +179,7 @@ extension SignalType {
 	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
 	public func observeNext(next: Value -> ()) -> Disposable? {
-		return observe(Event.sink(next: next))
+		return observe(Observer(next: next))
 	}
 
 	/// Observes the Signal by invoking the given callback when a `completed` event is
@@ -179,7 +189,7 @@ extension SignalType {
 	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
 	public func observeCompleted(completed: () -> ()) -> Disposable? {
-		return observe(Event.sink(completed: completed))
+		return observe(Observer(completed: completed))
 	}
 	
 	/// Observes the Signal by invoking the given callback when an `error` event is
@@ -189,7 +199,7 @@ extension SignalType {
 	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
 	public func observeError(error: Error -> ()) -> Disposable? {
-		return observe(Event.sink(error: error))
+		return observe(Observer(error: error))
 	}
 	
 	/// Observes the Signal by invoking the given callback when an `interrupted` event is
@@ -200,7 +210,7 @@ extension SignalType {
 	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
 	public func observeInterrupted(interrupted: () -> ()) -> Disposable? {
-		return observe(Event.sink(interrupted: interrupted))
+		return observe(Observer(interrupted: interrupted))
 	}
 
 	/// Maps each value in the signal to a new value.
@@ -208,7 +218,7 @@ extension SignalType {
 	public func map<U>(transform: Value -> U) -> Signal<U, Error> {
 		return Signal { observer in
 			return self.observe { event in
-				observer(event.map(transform))
+				observer.action(event.map(transform))
 			}
 		}
 	}
@@ -218,7 +228,7 @@ extension SignalType {
 	public func mapError<F>(transform: Error -> F) -> Signal<Value, F> {
 		return Signal { observer in
 			return self.observe { event in
-				observer(event.mapError(transform))
+				observer.action(event.mapError(transform))
 			}
 		}
 	}
@@ -227,13 +237,13 @@ extension SignalType {
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func filter(predicate: Value -> Bool) -> Signal<Value, Error> {
 		return Signal { observer in
-			return self.observe { event in
+			return self.observe { (event: Event<Value, Error>) -> () in
 				if case let .Next(value) = event {
 					if predicate(value) {
-						sendNext(observer, value)
+						observer.sendNext(value)
 					}
 				} else {
-					observer(event)
+					observer.action(event)
 				}
 			}
 		}
@@ -321,17 +331,17 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 					state.enqueueSignalProducer(value.producer)
 
 				case let .Error(error):
-					sendError(observer, error)
+					observer.sendError(error)
 
 				case .Completed:
 					// Add one last producer to the queue, whose sole job is to
 					// "turn out the lights" by completing `observer`.
 					state.enqueueSignalProducer(SignalProducer.empty.on(completed: {
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}))
 
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 				}
 			}
 
@@ -409,7 +419,7 @@ private final class ConcatState<Value, Error: ErrorType> {
 					}
 
 				default:
-					self.observer(event)
+					self.observer.action(event)
 				}
 			}
 		}
@@ -426,7 +436,7 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 			let decrementInFlight: () -> () = {
 				let orig = inFlight.modify { $0 - 1 }
 				if orig == 1 {
-					sendCompleted(relayObserver)
+					relayObserver.sendCompleted()
 				}
 			}
 
@@ -449,19 +459,19 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 								decrementInFlight()
 
 							default:
-								relayObserver(event)
+								relayObserver.action(event)
 							}
 						}
 					}
 
 				case let .Error(error):
-					sendError(relayObserver, error)
+					relayObserver.sendError(error)
 
 				case .Completed:
 					decrementInFlight()
 
 				case .Interrupted:
-					sendInterrupted(relayObserver)
+					relayObserver.sendInterrupted()
 				}
 			}
 
@@ -479,7 +489,7 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 	/// signal have both completed.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	private func switchToLatest() -> Signal<Value.Value, Error> {
-		return Signal<Value.Value, Error> { [signal = self.signal] sink in
+		return Signal<Value.Value, Error> { [signal = self.signal] observer in
 			let disposable = CompositeDisposable()
 			let latestInnerDisposable = SerialDisposable()
 			disposable.addDisposable(latestInnerDisposable)
@@ -519,7 +529,7 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 								}
 
 								if !original.replacingInnerSignal && original.outerSignalComplete {
-									sendCompleted(sink)
+									observer.sendCompleted()
 								}
 
 							case .Completed:
@@ -529,16 +539,16 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 								}
 
 								if original.outerSignalComplete {
-									sendCompleted(sink)
+									observer.sendCompleted()
 								}
 
 							default:
-								sink(event)
+								observer.action(event)
 							}
 						}
 					}
 				case let .Error(error):
-					sendError(sink, error)
+					observer.sendError(error)
 				case .Completed:
 					let original = state.modify { (var state) in
 						state.outerSignalComplete = true
@@ -546,10 +556,10 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 					}
 
 					if original.innerSignalComplete {
-						sendCompleted(sink)
+						observer.sendCompleted()
 					}
 				case .Interrupted:
-					sendInterrupted(sink)
+					observer.sendInterrupted()
 				}
 			}
 
@@ -582,7 +592,7 @@ extension SignalType {
 
 		return Signal { observer in
 			if count == 0 {
-				sendCompleted(observer)
+				observer.sendCompleted()
 				return nil
 			}
 
@@ -592,15 +602,15 @@ extension SignalType {
 				if case let .Next(value) = event {
 					if taken < count {
 						taken++
-						sendNext(observer, value)
+						observer.sendNext(value)
 					}
 
 					if taken == count {
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}
 
 				} else {
-					observer(event)
+					observer.action(event)
 				}
 			}
 		}
@@ -633,7 +643,7 @@ extension SignalType {
 		return Signal { observer in
 			return self.observe { event in
 				scheduler.schedule {
-					observer(event)
+					observer.action(event)
 				}
 			}
 		}
@@ -694,12 +704,12 @@ extension SignalType {
 			let otherState = CombineLatestState<U>()
 			
 			let onBothNext = { () -> () in
-				sendNext(observer, (signalState.latestValue!, otherState.latestValue!))
+				observer.sendNext((signalState.latestValue!, otherState.latestValue!))
 			}
 			
-			let onError = { sendError(observer, $0) }
-			let onBothCompleted = { sendCompleted(observer) }
-			let onInterrupted = { sendInterrupted(observer) }
+			let onError = { observer.sendError($0) }
+			let onBothCompleted = { observer.sendCompleted() }
+			let onInterrupted = { observer.sendInterrupted() }
 
 			let disposable = CompositeDisposable()
 			disposable += observeWithStates(self.signal, signalState, otherState, lock, onBothNext, onError, onBothCompleted, onInterrupted)
@@ -722,13 +732,13 @@ extension SignalType {
 				switch event {
 				case .Error, .Interrupted:
 					scheduler.schedule {
-						observer(event)
+						observer.action(event)
 					}
 
 				default:
 					let date = scheduler.currentDate.dateByAddingTimeInterval(interval)
 					scheduler.scheduleAfter(date) {
-						observer(event)
+						observer.action(event)
 					}
 				}
 			}
@@ -752,7 +762,7 @@ extension SignalType {
 				if case .Next = event where skipped < count {
 					skipped++
 				} else {
-					observer(event)
+					observer.action(event)
 				}
 			}
 		}
@@ -770,14 +780,14 @@ extension SignalType {
 	public func materialize() -> Signal<Event<Value, Error>, NoError> {
 		return Signal { observer in
 			return self.observe { event in
-				sendNext(observer, event)
+				observer.sendNext(event)
 
 				switch event {
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 
 				case .Completed, .Error:
-					sendCompleted(observer)
+					observer.sendCompleted()
 
 				case .Next:
 					break
@@ -796,16 +806,16 @@ extension SignalType where Value: EventType, Error == NoError {
 			return self.observe { event in
 				switch event {
 				case let .Next(innerEvent):
-					observer(innerEvent.event)
+					observer.action(innerEvent.event)
 
 				case .Error:
 					fatalError("NoError is impossible to construct")
 
 				case .Completed:
-					sendCompleted(observer)
+					observer.sendCompleted()
 
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 				}
 			}
 		}
@@ -842,7 +852,7 @@ extension SignalType {
 						return st
 					}
 				case let .Error(error):
-					sendError(observer, error)
+					observer.sendError(error)
 				case .Completed:
 					let oldState = state.modify { (var st) in
 						st.signalCompleted = true
@@ -850,10 +860,10 @@ extension SignalType {
 					}
 					
 					if oldState.samplerCompleted {
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 				}
 			}
 			
@@ -861,7 +871,7 @@ extension SignalType {
 				switch event {
 				case .Next:
 					if let value = state.value.latestValue {
-						sendNext(observer, value)
+						observer.sendNext(value)
 					}
 				case .Completed:
 					let oldState = state.modify { (var st) in
@@ -870,10 +880,10 @@ extension SignalType {
 					}
 					
 					if oldState.signalCompleted {
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 				default:
 					break
 				}
@@ -894,7 +904,7 @@ extension SignalType {
 			disposable += trigger.observe { event in
 				switch event {
 				case .Next, .Completed:
-					sendCompleted(observer)
+					observer.sendCompleted()
 
 				case .Error, .Interrupted:
 					break
@@ -926,7 +936,7 @@ extension SignalType {
 		let outputSignal = scannedSignalWithInitialValue.takeLast(1)
 
 		// Now that we've got takeLast() listening to the piped signal, send that initial value.
-		sendNext(outputSignalObserver, initial)
+		outputSignalObserver.sendNext(initial)
 
 		// Pipe the scanned input signal into the output signal.
 		scan(initial, combine).observe(outputSignalObserver)
@@ -945,7 +955,7 @@ extension SignalType {
 			var accumulator = initial
 
 			return self.observe { event in
-				observer(event.map { value in
+				observer.action(event.map { value in
 					accumulator = combine(accumulator, value)
 					return accumulator
 				})
@@ -997,7 +1007,7 @@ extension SignalType {
 					}
 
 				default:
-					observer(event)
+					observer.action(event)
 				}
 			}
 		}
@@ -1021,14 +1031,14 @@ extension SignalType {
 					break
 
 				case .Next, .Error, .Interrupted:
-					observer(event)
+					observer.action(event)
 				}
 			}
 
 			disposable += signalDisposable
 			disposable += replacement.observe { event in
 				signalDisposable?.dispose()
-				observer(event)
+				observer.action(event)
 			}
 
 			return disposable
@@ -1054,15 +1064,15 @@ extension SignalType {
 					
 					buffer.append(value)
 				case let .Error(error):
-					sendError(observer, error)
+					observer.sendError(error)
 				case .Completed:
 					for bufferedValue in buffer {
-						sendNext(observer, bufferedValue)
+						observer.sendNext(bufferedValue)
 					}
 					
-					sendCompleted(observer)
+					observer.sendCompleted()
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 				}
 			}
 		}
@@ -1075,9 +1085,9 @@ extension SignalType {
 		return Signal { observer in
 			return self.observe { event in
 				if case let .Next(value) = event where !predicate(value) {
-					sendCompleted(observer)
+					observer.sendCompleted()
 				} else {
-					observer(event)
+					observer.action(event)
 				}
 			}
 		}
@@ -1118,16 +1128,16 @@ extension SignalType {
 				while !originalStates.0.values.isEmpty && !originalStates.1.values.isEmpty {
 					let left = originalStates.0.values.removeAtIndex(0)
 					let right = originalStates.1.values.removeAtIndex(0)
-					sendNext(observer, (left, right))
+					observer.sendNext((left, right))
 				}
 				
 				if originalStates.0.isFinished || originalStates.1.isFinished {
-					sendCompleted(observer)
+					observer.sendCompleted()
 				}
 			}
 			
-			let onError = { sendError(observer, $0) }
-			let onInterrupted = { sendInterrupted(observer) }
+			let onError = { observer.sendError($0) }
+			let onInterrupted = { observer.sendInterrupted() }
 
 			disposable += self.observe { event in
 				switch event {
@@ -1199,16 +1209,16 @@ extension SignalType {
 				switch event {
 				case let .Next(value):
 					operation(value).analysis(ifSuccess: { value in
-						sendNext(observer, value)
+						observer.sendNext(value)
 						}, ifFailure: { error in
-							sendError(observer, error)
+							observer.sendError(error)
 					})
 				case let .Error(error):
-					sendError(observer, error)
+					observer.sendError(error)
 				case .Completed:
-					sendCompleted(observer)
+					observer.sendCompleted()
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 				}
 			}
 		}
@@ -1256,13 +1266,13 @@ extension SignalType {
 						}
 						
 						if let pendingValue = previousState.pendingValue {
-							sendNext(observer, pendingValue)
+							observer.sendNext(pendingValue)
 						}
 					}
 
 				} else {
 					schedulerDisposable.innerDisposable = scheduler.schedule {
-						observer(event)
+						observer.action(event)
 					}
 				}
 			}
@@ -1480,7 +1490,7 @@ extension SignalType {
 			let date = scheduler.currentDate.dateByAddingTimeInterval(interval)
 
 			disposable += scheduler.scheduleAfter(date) {
-				sendError(observer, error)
+				observer.sendError(error)
 			}
 
 			disposable += self.observe(observer)
@@ -1501,13 +1511,13 @@ extension SignalType where Error == NoError {
 			return self.observe { event in
 				switch event {
 				case let .Next(value):
-					sendNext(observer, value)
+					observer.sendNext(value)
 				case .Error:
 					fatalError("NoError is impossible to construct")
 				case .Completed:
-					sendCompleted(observer)
+					observer.sendCompleted()
 				case .Interrupted:
-					sendInterrupted(observer)
+					observer.sendInterrupted()
 				}
 			}
 		}

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -162,7 +162,8 @@ extension Signal: SignalType {
 }
 
 extension SignalType {
-	/// Convenience to avoid extra parentheses everywehre. TODO(andy): Document.
+	/// Convenience override for observe(_:) to allow trailing-closure style
+	/// invocations.
 	public func observe(action: Signal<Value, Error>.Observer.Action) -> Disposable? {
 		return observe(Observer(action))
 	}

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -139,11 +139,6 @@ public final class Signal<Value, Error: ErrorType> {
 			return nil
 		}
 	}
-
-	/// Convenience to avoid lots of extra parentheses everywhere people call observe(). TODO(andy): Document me.
-	public func observe(action: Observer.Action) -> Disposable? {
-		return observe(Observer(action))
-	}
 }
 
 public protocol SignalType {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -703,7 +703,7 @@ extension SignalType {
 				observer.sendNext((signalState.latestValue!, otherState.latestValue!))
 			}
 			
-			let onError = { observer.sendError($0) }
+			let onError = observer.sendError
 			let onBothCompleted = observer.sendCompleted
 			let onInterrupted = observer.sendInterrupted
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -310,7 +310,8 @@ extension SignalProducerType {
 		return disposable
 	}
 
-	/// Convenience to avoid extra parentheses everywhere people call start. TODO(andy): Document me.
+	/// Convenience override for start(_:) to allow trailing-closure style
+	/// invocations.
 	public func start(observerAction: Observer<Value, Error>.Action) -> Disposable {
 		return start(Observer(observerAction))
 	}

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -36,15 +36,15 @@ class ActionSpec: QuickSpec {
 						executionCount++
 
 						if number % 2 == 0 {
-							sendNext(observer, "\(number)")
-							sendNext(observer, "\(number)\(number)")
+							observer.sendNext("\(number)")
+							observer.sendNext("\(number)\(number)")
 
 							scheduler.schedule {
-								sendCompleted(observer)
+								observer.sendCompleted()
 							}
 						} else {
 							scheduler.schedule {
-								sendError(observer, testError)
+								observer.sendError(testError)
 							}
 						}
 					}
@@ -169,7 +169,7 @@ class ActionSpec: QuickSpec {
 					.rac_valuesForKeyPath("enabled", observer: nil)
 					.toSignalProducer()
 					.map { $0! as! Bool }
-					.start(Event.sink(next: { values.append($0) }))
+					.start(Observer(next: { values.append($0) }))
 
 				expect(values).to(equal([ true ]))
 
@@ -185,7 +185,7 @@ class ActionSpec: QuickSpec {
 					.rac_valuesForKeyPath("executing", observer: nil)
 					.toSignalProducer()
 					.map { $0! as! Bool }
-					.start(Event.sink(next: { values.append($0) }))
+					.start(Observer(next: { values.append($0) }))
 
 				expect(values).to(equal([ false ]))
 

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -49,7 +49,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			let testNSError = NSError(domain: "TestDomain", code: 1, userInfo: userInfo)
 			describe("on a Signal") {
 				it("should forward events") {
-					let (signal, sink) = Signal<NSNumber, NoError>.pipe()
+					let (signal, observer) = Signal<NSNumber, NoError>.pipe()
 					let racSignal = toRACSignal(signal)
 
 					var lastValue: NSNumber?
@@ -64,17 +64,17 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					expect(lastValue).to(beNil())
 
 					for number in [1, 2, 3] {
-						sink.sendNext(number)
+						observer.sendNext(number)
 						expect(lastValue).to(equal(number))
 					}
 
 					expect(didComplete).to(beFalse())
-					sink.sendCompleted()
+					observer.sendCompleted()
 					expect(didComplete).to(beTrue())
 				}
 
 				it("should convert errors to NSError") {
-					let (signal, sink) = Signal<AnyObject, TestError>.pipe()
+					let (signal, observer) = Signal<AnyObject, TestError>.pipe()
 					let racSignal = toRACSignal(signal)
 
 					let expectedError = TestError.Error2
@@ -85,12 +85,12 @@ class ObjectiveCBridgingSpec: QuickSpec {
 						return
 					}
 
-					sink.sendError(expectedError)
+					observer.sendError(expectedError)
 					expect(error).to(equal(expectedError as NSError))
 				}
 				
 				it("should maintain userInfo on NSError") {
-					let (signal, sink) = Signal<AnyObject, NSError>.pipe()
+					let (signal, observer) = Signal<AnyObject, NSError>.pipe()
 					let racSignal = toRACSignal(signal)
 					
 					var error: NSError?
@@ -100,7 +100,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 						return
 					}
 					
-					sink.sendError(testNSError)
+					observer.sendError(testNSError)
 					
 					let userInfoValue = error?.userInfo[key] as? String
 					expect(userInfoValue).to(equal(userInfo[key]))

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -64,12 +64,12 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					expect(lastValue).to(beNil())
 
 					for number in [1, 2, 3] {
-						sendNext(sink, number)
+						sink.sendNext(number)
 						expect(lastValue).to(equal(number))
 					}
 
 					expect(didComplete).to(beFalse())
-					sendCompleted(sink)
+					sink.sendCompleted()
 					expect(didComplete).to(beTrue())
 				}
 
@@ -85,7 +85,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 						return
 					}
 
-					sendError(sink, expectedError)
+					sink.sendError(expectedError)
 					expect(error).to(equal(expectedError as NSError))
 				}
 				
@@ -100,7 +100,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 						return
 					}
 					
-					sendError(sink, testNSError)
+					sink.sendError(testNSError)
 					
 					let userInfoValue = error?.userInfo[key] as? String
 					expect(userInfoValue).to(equal(userInfo[key]))

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -80,7 +80,7 @@ class PropertySpec: QuickSpec {
 			}
 
 			it("should not deadlock on recursive value access") {
-				let (producer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (producer, observer) = SignalProducer<Int, NoError>.buffer()
 				let property = MutableProperty(0)
 				var value: Int?
 
@@ -89,7 +89,7 @@ class PropertySpec: QuickSpec {
 					value = property.value
 				}
 
-				sink.sendNext(10)
+				observer.sendNext(10)
 				expect(value).to(equal(10))
 			}
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -89,7 +89,7 @@ class PropertySpec: QuickSpec {
 					value = property.value
 				}
 
-				sendNext(sink, 10)
+				sink.sendNext(10)
 				expect(value).to(equal(10))
 			}
 
@@ -161,7 +161,7 @@ class PropertySpec: QuickSpec {
 					
 					expect(property.value).to(equal(initialPropertyValue))
 					
-					sendNext(observer, subsequentPropertyValue)
+					observer.sendNext(subsequentPropertyValue)
 					
 					expect(property.value).to(equal(subsequentPropertyValue))
 				}
@@ -264,7 +264,7 @@ class PropertySpec: QuickSpec {
 					// Verify that the binding hasn't changed the property value:
 					expect(mutableProperty.value).to(equal(initialPropertyValue))
 
-					sendNext(observer, subsequentPropertyValue)
+					observer.sendNext(subsequentPropertyValue)
 					expect(mutableProperty.value).to(equal(subsequentPropertyValue))
 				}
 
@@ -276,7 +276,7 @@ class PropertySpec: QuickSpec {
 					let bindingDisposable = mutableProperty <~ signal
 					bindingDisposable.dispose()
 
-					sendNext(observer, subsequentPropertyValue)
+					observer.sendNext(subsequentPropertyValue)
 					expect(mutableProperty.value).to(equal(initialPropertyValue))
 				}
 				
@@ -288,7 +288,7 @@ class PropertySpec: QuickSpec {
 					let bindingDisposable = mutableProperty <~ signal
 					
 					expect(bindingDisposable.disposed).to(beFalsy())
-					sendCompleted(observer)
+					observer.sendCompleted()
 					expect(bindingDisposable.disposed).to(beTruthy())
 				}
 				
@@ -333,7 +333,7 @@ class PropertySpec: QuickSpec {
 					let mutableProperty = MutableProperty(initialPropertyValue)
 					mutableProperty <~ signalProducer
 
-					sendCompleted(observer)
+					observer.sendCompleted()
 					// TODO: Assert binding was torn down?
 				}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -15,7 +15,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 	override func spec() {
 		describe("map") {
 			it("should transform the values of the signal") {
-				let (producer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (producer, observer) = SignalProducer<Int, NoError>.buffer()
 				let mappedProducer = producer.map { String($0 + 1) }
 
 				var lastValue: String?
@@ -27,17 +27,17 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(0)
+				observer.sendNext(0)
 				expect(lastValue).to(equal("1"))
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal("2"))
 			}
 		}
 		
 		describe("mapError") {
 			it("should transform the errors of the signal") {
-				let (producer, sink) = SignalProducer<Int, TestError>.buffer()
+				let (producer, observer) = SignalProducer<Int, TestError>.buffer()
 				let producerError = NSError(domain: "com.reactivecocoa.errordomain", code: 100, userInfo: nil)
 				var error: NSError?
 
@@ -47,14 +47,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(error).to(beNil())
 
-				sink.sendError(TestError.Default)
+				observer.sendError(TestError.Default)
 				expect(error).to(equal(producerError))
 			}
 		}
 
 		describe("filter") {
 			it("should omit values from the producer") {
-				let (producer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (producer, observer) = SignalProducer<Int, NoError>.buffer()
 				let mappedProducer = producer.filter { $0 % 2 == 0 }
 
 				var lastValue: Int?
@@ -63,20 +63,20 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(0)
+				observer.sendNext(0)
 				expect(lastValue).to(equal(0))
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(0))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
 
 		describe("ignoreNil") {
 			it("should forward only non-nil values") {
-				let (producer, sink) = SignalProducer<Int?, NoError>.buffer()
+				let (producer, observer) = SignalProducer<Int?, NoError>.buffer()
 				let mappedProducer = producer.ignoreNil()
 
 				var lastValue: Int?
@@ -84,23 +84,23 @@ class SignalProducerLiftingSpec: QuickSpec {
 				mappedProducer.startWithNext { lastValue = $0 }
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(nil)
+				observer.sendNext(nil)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(nil)
+				observer.sendNext(nil)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
 
 		describe("scan") {
 			it("should incrementally accumulate a value") {
-				let (baseProducer, sink) = SignalProducer<String, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<String, NoError>.buffer()
 				let producer = baseProducer.scan("", +)
 
 				var lastValue: String?
@@ -109,17 +109,17 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext("a")
+				observer.sendNext("a")
 				expect(lastValue).to(equal("a"))
 
-				sink.sendNext("bb")
+				observer.sendNext("bb")
 				expect(lastValue).to(equal("abb"))
 			}
 		}
 
 		describe("reduce") {
 			it("should accumulate one value") {
-				let (baseProducer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
 				let producer = baseProducer.reduce(1, +)
 
 				var lastValue: Int?
@@ -138,21 +138,21 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(beNil())
 
 				expect(completed).to(beFalse())
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(completed).to(beTrue())
 
 				expect(lastValue).to(equal(4))
 			}
 
 			it("should send the initial value if none are received") {
-				let (baseProducer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
 				let producer = baseProducer.reduce(1, +)
 
 				var lastValue: Int?
@@ -172,7 +172,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sink.sendCompleted()
+				observer.sendCompleted()
 
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beTrue())
@@ -181,7 +181,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("skip") {
 			it("should skip initial values") {
-				let (baseProducer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
 				let producer = baseProducer.skip(1)
 
 				var lastValue: Int?
@@ -189,15 +189,15 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 
 			it("should not skip any values when 0") {
-				let (baseProducer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
 				let producer = baseProducer.skip(0)
 
 				var lastValue: Int?
@@ -205,17 +205,17 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
 
 		describe("skipRepeats") {
 			it("should skip duplicate Equatable values") {
-				let (baseProducer, sink) = SignalProducer<Bool, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Bool, NoError>.buffer()
 				let producer = baseProducer.skipRepeats()
 
 				var values: [Bool] = []
@@ -223,21 +223,21 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sink.sendNext(true)
+				observer.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sink.sendNext(true)
+				observer.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sink.sendNext(false)
+				observer.sendNext(false)
 				expect(values).to(equal([ true, false ]))
 
-				sink.sendNext(true)
+				observer.sendNext(true)
 				expect(values).to(equal([ true, false, true ]))
 			}
 
 			it("should skip values according to a predicate") {
-				let (baseProducer, sink) = SignalProducer<String, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<String, NoError>.buffer()
 				let producer = baseProducer.skipRepeats { $0.characters.count == $1.characters.count }
 
 				var values: [String] = []
@@ -245,31 +245,31 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sink.sendNext("a")
+				observer.sendNext("a")
 				expect(values).to(equal([ "a" ]))
 
-				sink.sendNext("b")
+				observer.sendNext("b")
 				expect(values).to(equal([ "a" ]))
 
-				sink.sendNext("cc")
+				observer.sendNext("cc")
 				expect(values).to(equal([ "a", "cc" ]))
 
-				sink.sendNext("d")
+				observer.sendNext("d")
 				expect(values).to(equal([ "a", "cc", "d" ]))
 			}
 		}
 
 		describe("skipWhile") {
 			var producer: SignalProducer<Int, NoError>!
-			var sink: Signal<Int, NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
 
 			var lastValue: Int?
 
 			beforeEach {
-				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
 
 				producer = baseProducer.skipWhile { $0 < 2 }
-				sink = observer
+				observer = incomingObserver
 				lastValue = nil
 
 				producer.startWithNext { lastValue = $0 }
@@ -278,30 +278,30 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should skip while the predicate is true") {
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				sink.sendNext(0)
+				observer.sendNext(0)
 				expect(lastValue).to(equal(0))
 			}
 
 			it("should not skip any values when the predicate starts false") {
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(3)
+				observer.sendNext(3)
 				expect(lastValue).to(equal(3))
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 			}
 		}
 
 		describe("take") {
 			it("should take initial values") {
-				let (baseProducer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
 				let producer = baseProducer.take(2)
 
 				var lastValue: Int?
@@ -320,11 +320,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beFalse())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 				expect(completed).to(beTrue())
 			}
@@ -335,11 +335,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				let producer: SignalProducer<Int, NoError> = SignalProducer { observer, _ in
 					// workaround `Class declaration cannot close over value 'observer' defined in outer scope`
-					let sink = observer
+					let observer = observer
 
 					testScheduler.schedule {
 						for number in numbers {
-							sink.sendNext(number)
+							observer.sendNext(number)
 						}
 					}
 				}
@@ -361,11 +361,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				let producer: SignalProducer<Int, NoError> = SignalProducer { observer, _ in
 					// workaround `Class declaration cannot close over value 'observer' defined in outer scope`
-					let sink = observer
+					let observer = observer
 
 					testScheduler.schedule {
 						for number in numbers {
-							sink.sendNext(number)
+							observer.sendNext(number)
 						}
 					}
 				}
@@ -395,7 +395,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("collect") {
 			it("should collect all values") {
-				let (original, sink) = SignalProducer<Int, NoError>.buffer()
+				let (original, observer) = SignalProducer<Int, NoError>.buffer()
 				let producer = original.collect()
 				let expectedResult = [ 1, 2, 3 ]
 
@@ -407,16 +407,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				for number in expectedResult {
-					sink.sendNext(number)
+					observer.sendNext(number)
 				}
 
 				expect(result).to(beNil())
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(result).to(equal(expectedResult))
 			}
 
 			it("should complete with an empty array if there are no values") {
-				let (original, sink) = SignalProducer<Int, NoError>.buffer()
+				let (original, observer) = SignalProducer<Int, NoError>.buffer()
 				let producer = original.collect()
 
 				var result: [Int]?
@@ -424,12 +424,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				producer.startWithNext { result = $0 }
 
 				expect(result).to(beNil())
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(result).to(equal([]))
 			}
 
 			it("should forward errors") {
-				let (original, sink) = SignalProducer<Int, TestError>.buffer()
+				let (original, observer) = SignalProducer<Int, TestError>.buffer()
 				let producer = original.collect()
 
 				var error: TestError?
@@ -437,26 +437,26 @@ class SignalProducerLiftingSpec: QuickSpec {
 				producer.startWithError { error = $0 }
 
 				expect(error).to(beNil())
-				sink.sendError(.Default)
+				observer.sendError(.Default)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
 
 		describe("takeUntil") {
 			var producer: SignalProducer<Int, NoError>!
-			var sink: Signal<Int, NoError>.Observer!
-			var triggerSink: Signal<(), NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
+			var triggerObserver: Signal<(), NoError>.Observer!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
 
 			beforeEach {
-				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
-				let (triggerSignal, triggerObserver) = SignalProducer<(), NoError>.buffer()
+				let (baseProducer, baseIncomingObserver) = SignalProducer<Int, NoError>.buffer()
+				let (triggerSignal, incomingTriggerObserver) = SignalProducer<(), NoError>.buffer()
 
 				producer = baseProducer.takeUntil(triggerSignal)
-				sink = observer
-				triggerSink = triggerObserver
+				observer = baseIncomingObserver
+				triggerObserver = incomingTriggerObserver
 
 				lastValue = nil
 				completed = false
@@ -476,14 +476,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should take values until the trigger fires") {
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
 				expect(completed).to(beFalse())
-				triggerSink.sendNext(())
+				triggerObserver.sendNext(())
 				expect(completed).to(beTrue())
 			}
 
@@ -491,7 +491,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				triggerSink.sendNext(())
+				triggerObserver.sendNext(())
 
 				expect(completed).to(beTrue())
 				expect(lastValue).to(beNil())
@@ -500,19 +500,19 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("takeUntilReplacement") {
 			var producer: SignalProducer<Int, NoError>!
-			var sink: Signal<Int, NoError>.Observer!
-			var replacementSink: Signal<Int, NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
+			var replacementObserver: Signal<Int, NoError>.Observer!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
 
 			beforeEach {
-				let (baseProducer, observer) = SignalProducer<Int, NoError>.buffer()
-				let (replacementSignal, replacementObserver) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
+				let (replacementSignal, incomingReplacementObserver) = SignalProducer<Int, NoError>.buffer()
 
 				producer = baseProducer.takeUntilReplacement(replacementSignal)
-				sink = observer
-				replacementSink = replacementObserver
+				observer = incomingObserver
+				replacementObserver = incomingReplacementObserver
 
 				lastValue = nil
 				completed = false
@@ -533,27 +533,27 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				replacementSink.sendNext(3)
+				replacementObserver.sendNext(3)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				sink.sendNext(4)
+				observer.sendNext(4)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				replacementSink.sendNext(5)
+				replacementObserver.sendNext(5)
 				expect(lastValue).to(equal(5))
 
 				expect(completed).to(beFalse())
-				replacementSink.sendCompleted()
+				replacementObserver.sendCompleted()
 				expect(completed).to(beTrue())
 			}
 		}
@@ -563,9 +563,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 			var observer: Signal<Int, NoError>.Observer!
 
 			beforeEach {
-				let (baseProducer, sink) = SignalProducer<Int, NoError>.buffer()
+				let (baseProducer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
 				producer = baseProducer.takeWhile { $0 <= 4 }
-				observer = sink
+				observer = incomingObserver
 			}
 
 			it("should take while the predicate is true") {
@@ -680,10 +680,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let testScheduler = TestScheduler()
 				let producer: SignalProducer<Int, TestError> = SignalProducer { observer, _ in
 					// workaround `Class declaration cannot close over value 'observer' defined in outer scope`
-					let sink = observer
+					let observer = observer
 
 					testScheduler.schedule {
-						sink.sendError(TestError.Default)
+						observer.sendError(TestError.Default)
 					}
 				}
 				
@@ -786,11 +786,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 			var samplerObserver: Signal<(), NoError>.Observer!
 			
 			beforeEach {
-				let (producer, sink) = SignalProducer<Int, NoError>.buffer()
-				let (sampler, samplesSink) = SignalProducer<(), NoError>.buffer()
+				let (producer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
+				let (sampler, incomingSamplerObserver) = SignalProducer<(), NoError>.buffer()
 				sampledProducer = producer.sampleOn(sampler)
-				observer = sink
-				samplerObserver = samplesSink
+				observer = incomingObserver
+				samplerObserver = incomingSamplerObserver
 			}
 			
 			it("should forward the latest value when the sampler fires") {
@@ -839,11 +839,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 			var otherObserver: Signal<Double, NoError>.Observer!
 			
 			beforeEach {
-				let (producer, sink) = SignalProducer<Int, NoError>.buffer()
-				let (otherSignal, otherSink) = SignalProducer<Double, NoError>.buffer()
+				let (producer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
+				let (otherSignal, incomingOtherObserver) = SignalProducer<Double, NoError>.buffer()
 				combinedProducer = producer.combineLatestWith(otherSignal)
-				observer = sink
-				otherObserver = otherSink
+				observer = incomingObserver
+				otherObserver = incomingOtherObserver
 			}
 			
 			it("should forward the latest values from both inputs") {
@@ -876,16 +876,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 		}
 
 		describe("zipWith") {
-			var leftSink: Signal<Int, NoError>.Observer!
-			var rightSink: Signal<String, NoError>.Observer!
+			var leftObserver: Signal<Int, NoError>.Observer!
+			var rightObserver: Signal<String, NoError>.Observer!
 			var zipped: SignalProducer<(Int, String), NoError>!
 
 			beforeEach {
-				let (leftProducer, leftObserver) = SignalProducer<Int, NoError>.buffer()
-				let (rightProducer, rightObserver) = SignalProducer<String, NoError>.buffer()
+				let (leftProducer, incomingLeftObserver) = SignalProducer<Int, NoError>.buffer()
+				let (rightProducer, incomingRightObserver) = SignalProducer<String, NoError>.buffer()
 
-				leftSink = leftObserver
-				rightSink = rightObserver
+				leftObserver = incomingLeftObserver
+				rightObserver = incomingRightObserver
 				zipped = leftProducer.zipWith(rightProducer)
 			}
 
@@ -893,24 +893,24 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [String] = []
 				zipped.startWithNext { (left, right) in result.append("\(left)\(right)") }
 
-				leftSink.sendNext(1)
-				leftSink.sendNext(2)
+				leftObserver.sendNext(1)
+				leftObserver.sendNext(2)
 				expect(result).to(equal([]))
 
-				rightSink.sendNext("foo")
+				rightObserver.sendNext("foo")
 				expect(result).to(equal([ "1foo" ]))
 
-				leftSink.sendNext(3)
-				rightSink.sendNext("bar")
+				leftObserver.sendNext(3)
+				rightObserver.sendNext("bar")
 				expect(result).to(equal([ "1foo", "2bar" ]))
 
-				rightSink.sendNext("buzz")
+				rightObserver.sendNext("buzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				rightSink.sendNext("fuzz")
+				rightObserver.sendNext("fuzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				leftSink.sendNext(4)
+				leftObserver.sendNext(4)
 				expect(result).to(equal([ "1foo", "2bar", "3buzz", "4fuzz" ]))
 			}
 
@@ -931,12 +931,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(completed).to(beFalsy())
 
-				leftSink.sendNext(0)
-				leftSink.sendCompleted()
+				leftObserver.sendNext(0)
+				leftObserver.sendCompleted()
 				expect(completed).to(beFalsy())
 				expect(result).to(equal([]))
 
-				rightSink.sendNext("foo")
+				rightObserver.sendNext("foo")
 				expect(completed).to(beTruthy())
 				expect(result).to(equal([ "0foo" ]))
 			}
@@ -976,12 +976,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("dematerialize") {
 			typealias IntEvent = Event<Int, TestError>
-			var sink: Signal<IntEvent, NoError>.Observer!
+			var observer: Signal<IntEvent, NoError>.Observer!
 			var dematerialized: SignalProducer<Int, TestError>!
 			
 			beforeEach {
-				let (producer, observer) = SignalProducer<IntEvent, NoError>.buffer()
-				sink = observer
+				let (producer, incomingObserver) = SignalProducer<IntEvent, NoError>.buffer()
+				observer = incomingObserver
 				dematerialized = producer.dematerialize()
 			}
 			
@@ -991,10 +991,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				expect(result).to(beEmpty())
 				
-				sink.sendNext(.Next(2))
+				observer.sendNext(.Next(2))
 				expect(result).to(equal([ 2 ]))
 				
-				sink.sendNext(.Next(4))
+				observer.sendNext(.Next(4))
 				expect(result).to(equal([ 2, 4 ]))
 			}
 
@@ -1004,7 +1004,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				expect(errored).to(beFalsy())
 				
-				sink.sendNext(.Error(TestError.Default))
+				observer.sendNext(.Error(TestError.Default))
 				expect(errored).to(beTruthy())
 			}
 
@@ -1013,18 +1013,18 @@ class SignalProducerLiftingSpec: QuickSpec {
 				dematerialized.startWithCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
-				sink.sendNext(IntEvent.Completed)
+				observer.sendNext(IntEvent.Completed)
 				expect(completed).to(beTruthy())
 			}
 		}
 
 		describe("takeLast") {
-			var sink: Signal<Int, TestError>.Observer!
+			var observer: Signal<Int, TestError>.Observer!
 			var lastThree: SignalProducer<Int, TestError>!
 				
 			beforeEach {
-				let (producer, observer) = SignalProducer<Int, TestError>.buffer()
-				sink = observer
+				let (producer, incomingObserver) = SignalProducer<Int, TestError>.buffer()
+				observer = incomingObserver
 				lastThree = producer.takeLast(3)
 			}
 			
@@ -1032,13 +1032,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree.startWithNext { result.append($0) }
 				
-				sink.sendNext(1)
-				sink.sendNext(2)
-				sink.sendNext(3)
-				sink.sendNext(4)
+				observer.sendNext(1)
+				observer.sendNext(2)
+				observer.sendNext(3)
+				observer.sendNext(4)
 				expect(result).to(beEmpty())
 				
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(result).to(equal([ 2, 3, 4 ]))
 			}
 
@@ -1046,9 +1046,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree.startWithNext { result.append($0) }
 				
-				sink.sendNext(1)
-				sink.sendNext(2)
-				sink.sendCompleted()
+				observer.sendNext(1)
+				observer.sendNext(2)
+				observer.sendCompleted()
 				expect(result).to(equal([ 1, 2 ]))
 			}
 			
@@ -1066,12 +1066,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 				
-				sink.sendNext(1)
-				sink.sendNext(2)
-				sink.sendNext(3)
+				observer.sendNext(1)
+				observer.sendNext(2)
+				observer.sendNext(3)
 				expect(errored).to(beFalsy())
 				
-				sink.sendError(TestError.Default)
+				observer.sendError(TestError.Default)
 				expect(errored).to(beTruthy())
 				expect(result).to(beEmpty())
 			}
@@ -1080,13 +1080,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 		describe("timeoutWithError") {
 			var testScheduler: TestScheduler!
 			var producer: SignalProducer<Int, TestError>!
-			var sink: Signal<Int, TestError>.Observer!
+			var observer: Signal<Int, TestError>.Observer!
 
 			beforeEach {
 				testScheduler = TestScheduler()
-				let (baseProducer, observer) = SignalProducer<Int, TestError>.buffer()
+				let (baseProducer, incomingObserver) = SignalProducer<Int, TestError>.buffer()
 				producer = baseProducer.timeoutWithError(TestError.Default, afterInterval: 2, onScheduler: testScheduler)
-				sink = observer
+				observer = incomingObserver
 			}
 
 			it("should complete if within the interval") {
@@ -1104,7 +1104,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(1) {
-					sink.sendCompleted()
+					observer.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1130,7 +1130,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(3) {
-					sink.sendCompleted()
+					observer.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1144,7 +1144,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("attempt") {
 			it("should forward original values upon success") {
-				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attempt { _ in
 					return .Success()
 				}
@@ -1155,13 +1155,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				for value in 1...5 {
-					sink.sendNext(value)
+					observer.sendNext(value)
 					expect(current).to(equal(value))
 				}
 			}
 			
 			it("should error if an attempt fails") {
-				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attempt { _ in
 					return .Failure(.Default)
 				}
@@ -1171,14 +1171,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 					error = err
 				}
 				
-				sink.sendNext(42)
+				observer.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
 		
 		describe("attemptMap") {
 			it("should forward mapped values upon success") {
-				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attemptMap { num -> Result<Bool, TestError> in
 					return .Success(num % 2 == 0)
 				}
@@ -1188,15 +1188,15 @@ class SignalProducerLiftingSpec: QuickSpec {
 					even = value
 				}
 				
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(even).to(equal(false))
 				
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(even).to(equal(true))
 			}
 			
 			it("should error if a mapping fails") {
-				let (baseProducer, sink) = SignalProducer<Int, TestError>.buffer()
+				let (baseProducer, observer) = SignalProducer<Int, TestError>.buffer()
 				let producer = baseProducer.attemptMap { _ -> Result<Bool, TestError> in
 					return .Failure(.Default)
 				}
@@ -1206,32 +1206,32 @@ class SignalProducerLiftingSpec: QuickSpec {
 					error = err
 				}
 				
-				sink.sendNext(42)
+				observer.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
 		
 		describe("combinePrevious") {
-			var sink: Signal<Int, NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
 			let initialValue: Int = 0
 			var latestValues: (Int, Int)?
 			
 			beforeEach {
 				latestValues = nil
 				
-				let (signal, baseSink) = SignalProducer<Int, NoError>.buffer()
-				sink = baseSink
+				let (signal, baseObserver) = SignalProducer<Int, NoError>.buffer()
+				observer = baseObserver
 				signal.combinePrevious(initialValue).startWithNext { latestValues = $0 }
 			}
 			
 			it("should forward the latest value with previous value") {
 				expect(latestValues).to(beNil())
 				
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(latestValues?.0).to(equal(initialValue))
 				expect(latestValues?.1).to(equal(1))
 				
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(latestValues?.0).to(equal(1))
 				expect(latestValues?.1).to(equal(2))
 			}

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -27,10 +27,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 0)
+				sink.sendNext(0)
 				expect(lastValue).to(equal("1"))
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal("2"))
 			}
 		}
@@ -47,7 +47,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(error).to(beNil())
 
-				sendError(sink, TestError.Default)
+				sink.sendError(TestError.Default)
 				expect(error).to(equal(producerError))
 			}
 		}
@@ -63,13 +63,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 0)
+				sink.sendNext(0)
 				expect(lastValue).to(equal(0))
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(0))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
@@ -84,16 +84,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 				mappedProducer.startWithNext { lastValue = $0 }
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, nil)
+				sink.sendNext(nil)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, nil)
+				sink.sendNext(nil)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
@@ -109,10 +109,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, "a")
+				sink.sendNext("a")
 				expect(lastValue).to(equal("a"))
 
-				sendNext(sink, "bb")
+				sink.sendNext("bb")
 				expect(lastValue).to(equal("abb"))
 			}
 		}
@@ -138,14 +138,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(beNil())
 
 				expect(completed).to(beFalse())
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(completed).to(beTrue())
 
 				expect(lastValue).to(equal(4))
@@ -172,7 +172,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beTrue())
@@ -189,10 +189,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 
@@ -205,10 +205,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
@@ -223,16 +223,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sendNext(sink, true)
+				sink.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sendNext(sink, true)
+				sink.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sendNext(sink, false)
+				sink.sendNext(false)
 				expect(values).to(equal([ true, false ]))
 
-				sendNext(sink, true)
+				sink.sendNext(true)
 				expect(values).to(equal([ true, false, true ]))
 			}
 
@@ -245,16 +245,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sendNext(sink, "a")
+				sink.sendNext("a")
 				expect(values).to(equal([ "a" ]))
 
-				sendNext(sink, "b")
+				sink.sendNext("b")
 				expect(values).to(equal([ "a" ]))
 
-				sendNext(sink, "cc")
+				sink.sendNext("cc")
 				expect(values).to(equal([ "a", "cc" ]))
 
-				sendNext(sink, "d")
+				sink.sendNext("d")
 				expect(values).to(equal([ "a", "cc", "d" ]))
 			}
 		}
@@ -278,23 +278,23 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should skip while the predicate is true") {
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				sendNext(sink, 0)
+				sink.sendNext(0)
 				expect(lastValue).to(equal(0))
 			}
 
 			it("should not skip any values when the predicate starts false") {
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 3)
+				sink.sendNext(3)
 				expect(lastValue).to(equal(3))
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 			}
 		}
@@ -320,11 +320,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 				expect(completed).to(beTrue())
 			}
@@ -339,7 +339,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 					testScheduler.schedule {
 						for number in numbers {
-							sendNext(sink, number)
+							sink.sendNext(number)
 						}
 					}
 				}
@@ -365,7 +365,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 					testScheduler.schedule {
 						for number in numbers {
-							sendNext(sink, number)
+							sink.sendNext(number)
 						}
 					}
 				}
@@ -407,11 +407,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				for number in expectedResult {
-					sendNext(sink, number)
+					sink.sendNext(number)
 				}
 
 				expect(result).to(beNil())
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(result).to(equal(expectedResult))
 			}
 
@@ -424,7 +424,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				producer.startWithNext { result = $0 }
 
 				expect(result).to(beNil())
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(result).to(equal([]))
 			}
 
@@ -437,7 +437,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				producer.startWithError { error = $0 }
 
 				expect(error).to(beNil())
-				sendError(sink, .Default)
+				sink.sendError(.Default)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -476,14 +476,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should take values until the trigger fires") {
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 
 				expect(completed).to(beFalse())
-				sendNext(triggerSink, ())
+				triggerSink.sendNext(())
 				expect(completed).to(beTrue())
 			}
 
@@ -491,7 +491,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendNext(triggerSink, ())
+				triggerSink.sendNext(())
 
 				expect(completed).to(beTrue())
 				expect(lastValue).to(beNil())
@@ -533,27 +533,27 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				sendNext(replacementSink, 3)
+				replacementSink.sendNext(3)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 4)
+				sink.sendNext(4)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				sendNext(replacementSink, 5)
+				replacementSink.sendNext(5)
 				expect(lastValue).to(equal(5))
 
 				expect(completed).to(beFalse())
-				sendCompleted(replacementSink)
+				replacementSink.sendCompleted()
 				expect(completed).to(beTrue())
 			}
 		}
@@ -584,12 +584,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				for value in -1...4 {
-					sendNext(observer, value)
+					observer.sendNext(value)
 					expect(latestValue).to(equal(value))
 					expect(completed).to(beFalse())
 				}
 
-				sendNext(observer, 5)
+				observer.sendNext(5)
 				expect(latestValue).to(equal(4))
 				expect(completed).to(beTrue())
 			}
@@ -609,7 +609,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 
-				sendNext(observer, 5)
+				observer.sendNext(5)
 				expect(latestValue).to(beNil())
 				expect(completed).to(beTrue())
 			}
@@ -626,8 +626,8 @@ class SignalProducerLiftingSpec: QuickSpec {
 					.observeOn(testScheduler)
 					.startWithNext { result.append($0) }
 				
-				sendNext(observer, 1)
-				sendNext(observer, 2)
+				observer.sendNext(1)
+				observer.sendNext(2)
 				expect(result).to(beEmpty())
 				
 				testScheduler.run()
@@ -640,11 +640,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				let testScheduler = TestScheduler()
 				let producer: SignalProducer<Int, NoError> = SignalProducer { observer, _ in
 					testScheduler.schedule {
-						sendNext(observer, 1)
+						observer.sendNext(1)
 					}
 					testScheduler.scheduleAfter(5, action: {
-						sendNext(observer, 2)
-						sendCompleted(observer)
+						observer.sendNext(2)
+						observer.sendCompleted()
 					})
 				}
 				
@@ -683,7 +683,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					let sink = observer
 
 					testScheduler.schedule {
-						sendError(sink, TestError.Default)
+						sink.sendError(TestError.Default)
 					}
 				}
 				
@@ -720,14 +720,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sendNext(observer, 0)
+				observer.sendNext(0)
 				expect(values).to(equal([]))
 
 				scheduler.advance()
 				expect(values).to(equal([ 0 ]))
 
-				sendNext(observer, 1)
-				sendNext(observer, 2)
+				observer.sendNext(1)
+				observer.sendNext(2)
 				expect(values).to(equal([ 0 ]))
 
 				scheduler.advanceByInterval(1.5)
@@ -736,14 +736,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 				scheduler.advanceByInterval(3)
 				expect(values).to(equal([ 0, 2 ]))
 
-				sendNext(observer, 3)
+				observer.sendNext(3)
 				expect(values).to(equal([ 0, 2 ]))
 
 				scheduler.advance()
 				expect(values).to(equal([ 0, 2, 3 ]))
 
-				sendNext(observer, 4)
-				sendNext(observer, 5)
+				observer.sendNext(4)
+				observer.sendNext(5)
 				scheduler.advance()
 				expect(values).to(equal([ 0, 2, 3 ]))
 
@@ -766,12 +766,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 
-				sendNext(observer, 0)
+				observer.sendNext(0)
 				scheduler.advance()
 				expect(values).to(equal([ 0 ]))
 
-				sendNext(observer, 1)
-				sendCompleted(observer)
+				observer.sendNext(1)
+				observer.sendCompleted()
 				expect(completed).to(beFalsy())
 
 				scheduler.run()
@@ -797,9 +797,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				sampledProducer.startWithNext { result.append($0) }
 				
-				sendNext(observer, 1)
-				sendNext(observer, 2)
-				sendNext(samplerObserver, ())
+				observer.sendNext(1)
+				observer.sendNext(2)
+				samplerObserver.sendNext(())
 				expect(result).to(equal([ 2 ]))
 			}
 			
@@ -807,7 +807,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				sampledProducer.startWithNext { result.append($0) }
 				
-				sendNext(samplerObserver, ())
+				samplerObserver.sendNext(())
 				expect(result).to(beEmpty())
 			}
 			
@@ -815,9 +815,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				sampledProducer.startWithNext { result.append($0) }
 				
-				sendNext(observer, 1)
-				sendNext(samplerObserver, ())
-				sendNext(samplerObserver, ())
+				observer.sendNext(1)
+				samplerObserver.sendNext(())
+				samplerObserver.sendNext(())
 				expect(result).to(equal([ 1, 1 ]))
 			}
 
@@ -825,10 +825,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var completed = false
 				sampledProducer.startWithCompleted { completed = true }
 				
-				sendCompleted(observer)
+				observer.sendCompleted()
 				expect(completed).to(beFalsy())
 				
-				sendCompleted(samplerObserver)
+				samplerObserver.sendCompleted()
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -850,15 +850,15 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var latest: (Int, Double)?
 				combinedProducer.startWithNext { latest = $0 }
 				
-				sendNext(observer, 1)
+				observer.sendNext(1)
 				expect(latest).to(beNil())
 				
 				// is there a better way to test tuples?
-				sendNext(otherObserver, 1.5)
+				otherObserver.sendNext(1.5)
 				expect(latest?.0).to(equal(1))
 				expect(latest?.1).to(equal(1.5))
 				
-				sendNext(observer, 2)
+				observer.sendNext(2)
 				expect(latest?.0).to(equal(2))
 				expect(latest?.1).to(equal(1.5))
 			}
@@ -867,10 +867,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var completed = false
 				combinedProducer.startWithCompleted { completed = true }
 				
-				sendCompleted(observer)
+				observer.sendCompleted()
 				expect(completed).to(beFalsy())
 				
-				sendCompleted(otherObserver)
+				otherObserver.sendCompleted()
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -893,24 +893,24 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [String] = []
 				zipped.startWithNext { (left, right) in result.append("\(left)\(right)") }
 
-				sendNext(leftSink, 1)
-				sendNext(leftSink, 2)
+				leftSink.sendNext(1)
+				leftSink.sendNext(2)
 				expect(result).to(equal([]))
 
-				sendNext(rightSink, "foo")
+				rightSink.sendNext("foo")
 				expect(result).to(equal([ "1foo" ]))
 
-				sendNext(leftSink, 3)
-				sendNext(rightSink, "bar")
+				leftSink.sendNext(3)
+				rightSink.sendNext("bar")
 				expect(result).to(equal([ "1foo", "2bar" ]))
 
-				sendNext(rightSink, "buzz")
+				rightSink.sendNext("buzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				sendNext(rightSink, "fuzz")
+				rightSink.sendNext("fuzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				sendNext(leftSink, 4)
+				leftSink.sendNext(4)
 				expect(result).to(equal([ "1foo", "2bar", "3buzz", "4fuzz" ]))
 			}
 
@@ -931,12 +931,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(completed).to(beFalsy())
 
-				sendNext(leftSink, 0)
-				sendCompleted(leftSink)
+				leftSink.sendNext(0)
+				leftSink.sendCompleted()
 				expect(completed).to(beFalsy())
 				expect(result).to(equal([]))
 
-				sendNext(rightSink, "foo")
+				rightSink.sendNext("foo")
 				expect(completed).to(beTruthy())
 				expect(result).to(equal([ "0foo" ]))
 			}
@@ -950,7 +950,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					.materialize()
 					.startWithNext { latestEvent = $0 }
 				
-				sendNext(observer, 2)
+				observer.sendNext(2)
 				
 				expect(latestEvent).toNot(beNil())
 				if let latestEvent = latestEvent {
@@ -962,7 +962,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 				
-				sendError(observer, TestError.Default)
+				observer.sendError(TestError.Default)
 				if let latestEvent = latestEvent {
 					switch latestEvent {
 					case .Error(_):
@@ -991,10 +991,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				expect(result).to(beEmpty())
 				
-				sendNext(sink, .Next(2))
+				sink.sendNext(.Next(2))
 				expect(result).to(equal([ 2 ]))
 				
-				sendNext(sink, .Next(4))
+				sink.sendNext(.Next(4))
 				expect(result).to(equal([ 2, 4 ]))
 			}
 
@@ -1004,7 +1004,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				expect(errored).to(beFalsy())
 				
-				sendNext(sink, .Error(TestError.Default))
+				sink.sendNext(.Error(TestError.Default))
 				expect(errored).to(beTruthy())
 			}
 
@@ -1013,7 +1013,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				dematerialized.startWithCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
-				sendNext(sink, IntEvent.Completed)
+				sink.sendNext(IntEvent.Completed)
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -1032,13 +1032,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree.startWithNext { result.append($0) }
 				
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendNext(sink, 3)
-				sendNext(sink, 4)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendNext(3)
+				sink.sendNext(4)
 				expect(result).to(beEmpty())
 				
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(result).to(equal([ 2, 3, 4 ]))
 			}
 
@@ -1046,9 +1046,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree.startWithNext { result.append($0) }
 				
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendCompleted(sink)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendCompleted()
 				expect(result).to(equal([ 1, 2 ]))
 			}
 			
@@ -1066,12 +1066,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 				
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendNext(sink, 3)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendNext(3)
 				expect(errored).to(beFalsy())
 				
-				sendError(sink, TestError.Default)
+				sink.sendError(TestError.Default)
 				expect(errored).to(beTruthy())
 				expect(result).to(beEmpty())
 			}
@@ -1104,7 +1104,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(1) {
-					sendCompleted(sink)
+					sink.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1130,7 +1130,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(3) {
-					sendCompleted(sink)
+					sink.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1155,7 +1155,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				for value in 1...5 {
-					sendNext(sink, value)
+					sink.sendNext(value)
 					expect(current).to(equal(value))
 				}
 			}
@@ -1171,7 +1171,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					error = err
 				}
 				
-				sendNext(sink, 42)
+				sink.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -1188,10 +1188,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 					even = value
 				}
 				
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(even).to(equal(false))
 				
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(even).to(equal(true))
 			}
 			
@@ -1206,7 +1206,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					error = err
 				}
 				
-				sendNext(sink, 42)
+				sink.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -1227,11 +1227,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 			it("should forward the latest value with previous value") {
 				expect(latestValues).to(beNil())
 				
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(latestValues?.0).to(equal(initialValue))
 				expect(latestValues?.1).to(equal(1))
 				
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(latestValues?.0).to(equal(1))
 				expect(latestValues?.1).to(equal(2))
 			}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -39,7 +39,7 @@ class SignalProducerSpec: QuickSpec {
 					innerDisposable.addDisposable {
 						// This is necessary to keep the observer long enough to
 						// even test the memory management.
-						sendNext(observer, 0)
+						observer.sendNext(0)
 					}
 				}
 
@@ -68,7 +68,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.start()
 				expect(addedDisposable.disposed).to(beFalsy())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
@@ -84,7 +84,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.start()
 				expect(addedDisposable.disposed).to(beFalsy())
 
-				sendError(sink, .Default)
+				sink.sendError(.Default)
 				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
@@ -100,7 +100,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.start()
 				expect(addedDisposable.disposed).to(beFalsy())
 
-				sendInterrupted(sink)
+				sink.sendInterrupted()
 				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
@@ -185,9 +185,9 @@ class SignalProducerSpec: QuickSpec {
 			it("should replay buffered events when started, then forward events as added") {
 				let (producer, sink) = SignalProducer<Int, NSError>.buffer()
 
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendNext(sink, 3)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendNext(3)
 
 				var values: [Int] = []
 				var completed = false
@@ -205,13 +205,13 @@ class SignalProducerSpec: QuickSpec {
 				expect(values).to(equal([1, 2, 3]))
 				expect(completed).to(beFalsy())
 
-				sendNext(sink, 4)
-				sendNext(sink, 5)
+				sink.sendNext(4)
+				sink.sendNext(5)
 
 				expect(values).to(equal([1, 2, 3, 4, 5]))
 				expect(completed).to(beFalsy())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 
 				expect(values).to(equal([1, 2, 3, 4, 5]))
 				expect(completed).to(beTruthy())
@@ -220,8 +220,8 @@ class SignalProducerSpec: QuickSpec {
 			it("should drop earliest events to maintain the capacity") {
 				let (producer, sink) = SignalProducer<Int, TestError>.buffer(1)
 
-				sendNext(sink, 1)
-				sendNext(sink, 2)
+				sink.sendNext(1)
+				sink.sendNext(2)
 
 				var values: [Int] = []
 				var error: TestError?
@@ -239,13 +239,13 @@ class SignalProducerSpec: QuickSpec {
 				expect(values).to(equal([2]))
 				expect(error).to(beNil())
 
-				sendNext(sink, 3)
-				sendNext(sink, 4)
+				sink.sendNext(3)
+				sink.sendNext(4)
 
 				expect(values).to(equal([2, 3, 4]))
 				expect(error).to(beNil())
 
-				sendError(sink, .Default)
+				sink.sendError(.Default)
 
 				expect(values).to(equal([2, 3, 4]))
 				expect(error).to(equal(TestError.Default))
@@ -255,7 +255,7 @@ class SignalProducerSpec: QuickSpec {
 				let (producer, sink) = SignalProducer<Int, TestError>.buffer(0)
 				var completed = false
 				
-				sendCompleted(sink)
+				sink.sendCompleted()
 				
 				producer.startWithCompleted {
 					completed = true
@@ -269,8 +269,8 @@ class SignalProducerSpec: QuickSpec {
 				var value: Int?
 				var completed = false
 				
-				sendNext(sink, 123)
-				sendCompleted(sink)
+				sink.sendNext(123)
+				sink.sendCompleted()
 				
 				producer.start { event in
 					switch event {
@@ -290,9 +290,9 @@ class SignalProducerSpec: QuickSpec {
 			it("should not deadlock when started while sending") {
 				let (producer, sink) = SignalProducer<Int, NoError>.buffer()
 
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendNext(sink, 3)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendNext(3)
 
 				var values: [Int] = []
 				producer.startWithCompleted {
@@ -303,7 +303,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 				}
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(values).to(equal([ 1, 2, 3 ]))
 			}
 
@@ -326,15 +326,15 @@ class SignalProducerSpec: QuickSpec {
 					lastBufferedValues = bufferedValues
 				}
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(values).to(equal([ 1 ]))
 				expect(lastBufferedValues).to(equal(values))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(values).to(equal([ 1, 2 ]))
 				expect(lastBufferedValues).to(equal(values))
 
-				sendNext(sink, 3)
+				sink.sendNext(3)
 				expect(values).to(equal([ 1, 2, 3 ]))
 				expect(lastBufferedValues).to(equal(values))
 			}
@@ -344,7 +344,7 @@ class SignalProducerSpec: QuickSpec {
 			it("receives next values") {
 				var values = [Int]()
 				let (producer, sink) = SignalProducer<Int, NoError>.buffer(1)
-				sendNext(sink, 1)
+				sink.sendNext(1)
 
 				producer.startWithNext { next in
 					values.append(next)
@@ -519,7 +519,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.startWithSignal { _ in }
 				expect(addedDisposable.disposed).to(beFalsy())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
@@ -535,7 +535,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.startWithSignal { _ in }
 				expect(addedDisposable.disposed).to(beFalsy())
 
-				sendError(sink, .Default)
+				sink.sendError(.Default)
 				expect(addedDisposable.disposed).to(beTruthy())
 			}
 		}
@@ -601,11 +601,11 @@ class SignalProducerSpec: QuickSpec {
 						values.append(next)
 					}
 
-					sendNext(sink, 1)
-					sendNext(sink, 2)
-					sendNext(sink, 3)
+					sink.sendNext(1)
+					sink.sendNext(2)
+					sink.sendNext(3)
 
-					sendCompleted(sink)
+					sink.sendCompleted()
 
 					expect(values).to(equal([1, 2, 3]))
 				}
@@ -784,11 +784,11 @@ class SignalProducerSpec: QuickSpec {
 				producer.start()
 				expect(started).to(equal(2))
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(event).to(equal(2))
 				expect(next).to(equal(2))
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(event).to(equal(4))
 				expect(completed).to(equal(2))
 				expect(terminated).to(equal(2))
@@ -834,8 +834,8 @@ class SignalProducerSpec: QuickSpec {
 		describe("flatMapError") {
 			it("should invoke the handler and start new producer for an error") {
 				let (baseProducer, baseSink) = SignalProducer<Int, TestError>.buffer()
-				sendNext(baseSink, 1)
-				sendError(baseSink, .Default)
+				baseSink.sendNext(1)
+				baseSink.sendError(.Default)
 
 				var values: [Int] = []
 				var completed = false
@@ -846,8 +846,8 @@ class SignalProducerSpec: QuickSpec {
 						expect(values).to(equal([1]))
 
 						let (innerProducer, innerSink) = SignalProducer<Int, TestError>.buffer()
-						sendNext(innerSink, 2)
-						sendCompleted(innerSink)
+						innerSink.sendNext(2)
+						innerSink.sendCompleted()
 						return innerProducer
 					}
 					.start { event in
@@ -884,12 +884,12 @@ class SignalProducerSpec: QuickSpec {
 							subsequentStarted = true
 						}
 
-						completePrevious = { sendCompleted(previousSink) }
-						sendSubsequent = { sendNext(outerSink, subsequentProducer) }
-						completeOuter = { sendCompleted(outerSink) }
+						completePrevious = { previousSink.sendCompleted() }
+						sendSubsequent = { outerSink.sendNext(subsequentProducer) }
+						completeOuter = { outerSink.sendCompleted() }
 
 						outerProducer.flatten(.Concat).start()
-						sendNext(outerSink, previousProducer)
+						outerSink.sendNext(previousProducer)
 					}
 
 					it("should immediately start subsequent inner producer if previous inner producer has already completed") {
@@ -938,7 +938,7 @@ class SignalProducerSpec: QuickSpec {
 						error = e
 					}
 
-					sendError(outerSink, TestError.Default)
+					outerSink.sendError(TestError.Default)
 					expect(error).to(equal(TestError.Default))
 				}
 
@@ -952,15 +952,15 @@ class SignalProducerSpec: QuickSpec {
 						let (outerProducer, outerSink) = SignalProducer<SignalProducer<Int, NoError>, NoError>.buffer()
 						let (innerProducer, innerSink) = SignalProducer<Int, NoError>.buffer()
 
-						completeOuter = { sendCompleted(outerSink) }
-						completeInner = { sendCompleted(innerSink) }
+						completeOuter = { outerSink.sendCompleted() }
+						completeInner = { innerSink.sendCompleted() }
 
 						completed = false
 						outerProducer.flatten(.Concat).startWithCompleted {
 							completed = true
 						}
 
-						sendNext(outerSink, innerProducer)
+						outerSink.sendNext(innerProducer)
 					}
 
 					it("should complete when inner producers complete, then outer producer completes") {
@@ -997,17 +997,17 @@ class SignalProducerSpec: QuickSpec {
 						let (producerA, sinkA) = SignalProducer<Int, NoError>.buffer()
 						let (producerB, sinkB) = SignalProducer<Int, NoError>.buffer()
 
-						completeA = { sendCompleted(sinkA) }
-						completeB = { sendCompleted(sinkB) }
+						completeA = { sinkA.sendCompleted() }
+						completeB = { sinkB.sendCompleted() }
 
 						var a = 0
-						sendA = { sendNext(sinkA, a++) }
+						sendA = { sinkA.sendNext(a++) }
 
 						var b = 100
-						sendB = { sendNext(sinkB, b++) }
+						sendB = { sinkB.sendNext(b++) }
 
-						sendNext(outerSink, producerA)
-						sendNext(outerSink, producerB)
+						outerSink.sendNext(producerA)
+						outerSink.sendNext(producerB)
 
 						outerProducer.flatten(.Merge).start { event in
 							switch event {
@@ -1020,7 +1020,7 @@ class SignalProducerSpec: QuickSpec {
 							}
 						}
 
-						sendCompleted(outerSink)
+						outerSink.sendCompleted()
 					}
 
 					it("should forward values from any inner signals") {
@@ -1060,7 +1060,7 @@ class SignalProducerSpec: QuickSpec {
 							error = e
 						}
 
-						sendError(outerSink, TestError.Default)
+						outerSink.sendError(TestError.Default)
 						expect(error).to(equal(TestError.Default))
 					}
 				}
@@ -1089,21 +1089,21 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-					sendNext(firstInnerSink, 1)
-					sendNext(secondInnerSink, 2)
-					sendNext(outerSink, SignalProducer(value: 0))
-					sendNext(outerSink, firstInner)
-					sendNext(outerSink, secondInner)
-					sendCompleted(outerSink)
+					firstInnerSink.sendNext(1)
+					secondInnerSink.sendNext(2)
+					outerSink.sendNext(SignalProducer(value: 0))
+					outerSink.sendNext(firstInner)
+					outerSink.sendNext(secondInner)
+					outerSink.sendCompleted()
 
 					expect(receivedValues).to(equal([ 0, 1, 2 ]))
 					expect(errored).to(beFalsy())
 					expect(completed).to(beFalsy())
 
-					sendNext(firstInnerSink, 3)
-					sendCompleted(firstInnerSink)
-					sendNext(secondInnerSink, 4)
-					sendCompleted(secondInnerSink)
+					firstInnerSink.sendNext(3)
+					firstInnerSink.sendCompleted()
+					secondInnerSink.sendNext(4)
+					secondInnerSink.sendCompleted()
 
 					expect(receivedValues).to(equal([ 0, 1, 2, 4 ]))
 					expect(errored).to(beFalsy())
@@ -1190,24 +1190,24 @@ class SignalProducerSpec: QuickSpec {
 							}
 					}
 
-					sendNext(outerSink, innerProducer)
+					outerSink.sendNext(innerProducer)
 				}
 
 				describe("Concat") {
 					it("should drop interrupted from an inner producer") {
 						execute(.Concat)
 
-						sendInterrupted(innerSink)
+						innerSink.sendInterrupted()
 						expect(interrupted).to(beFalsy())
 						expect(completed).to(beFalsy())
 
-						sendCompleted(outerSink)
+						outerSink.sendCompleted()
 						expect(completed).to(beTruthy())
 					}
 
 					it("should forward interrupted from the outer producer") {
 						execute(.Concat)
-						sendInterrupted(outerSink)
+						outerSink.sendInterrupted()
 						expect(interrupted).to(beTruthy())
 					}
 				}
@@ -1216,17 +1216,17 @@ class SignalProducerSpec: QuickSpec {
 					it("should drop interrupted from an inner producer") {
 						execute(.Latest)
 
-						sendInterrupted(innerSink)
+						innerSink.sendInterrupted()
 						expect(interrupted).to(beFalsy())
 						expect(completed).to(beFalsy())
 
-						sendCompleted(outerSink)
+						outerSink.sendCompleted()
 						expect(completed).to(beTruthy())
 					}
 
 					it("should forward interrupted from the outer producer") {
 						execute(.Latest)
-						sendInterrupted(outerSink)
+						outerSink.sendInterrupted()
 						expect(interrupted).to(beTruthy())
 					}
 				}
@@ -1235,17 +1235,17 @@ class SignalProducerSpec: QuickSpec {
 					it("should drop interrupted from an inner producer") {
 						execute(.Merge)
 
-						sendInterrupted(innerSink)
+						innerSink.sendInterrupted()
 						expect(interrupted).to(beFalsy())
 						expect(completed).to(beFalsy())
 
-						sendCompleted(outerSink)
+						outerSink.sendCompleted()
 						expect(completed).to(beTruthy())
 					}
 
 					it("should forward interrupted from the outer producer") {
 						execute(.Merge)
-						sendInterrupted(outerSink)
+						outerSink.sendInterrupted()
 						expect(interrupted).to(beTruthy())
 					}
 				}
@@ -1379,7 +1379,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.start()
 				expect(subsequentStarted).to(beFalsy())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(subsequentStarted).to(beTruthy())
 			}
 
@@ -1410,10 +1410,10 @@ class SignalProducerSpec: QuickSpec {
 					completed = true
 				}
 
-				sendCompleted(originalSink)
+				originalSink.sendCompleted()
 				expect(completed).to(beFalsy())
 
-				sendCompleted(subsequentSink)
+				subsequentSink.sendCompleted()
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -1430,7 +1430,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 				expect(result).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
 				expect(result?.value).to(equal(1))
 			}
@@ -1463,10 +1463,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 				expect(result).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(result).to(beNil())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
 				expect(result?.value).to(equal(1))
 			}
@@ -1499,11 +1499,11 @@ class SignalProducerSpec: QuickSpec {
 				}
 				expect(result).to(beNil())
 
-				sendNext(sink, 1)
-				sendNext(sink, 2)
+				sink.sendNext(1)
+				sink.sendNext(2)
 				expect(result).to(beNil())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
 				expect(result?.value).to(equal(2))
 			}
@@ -1536,7 +1536,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 				expect(result).to(beNil())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
 				expect(result?.value).toNot(beNil())
 			}

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -39,7 +39,7 @@ class SignalSpec: QuickSpec {
 			it("should deallocate after erroring") {
 				weak var signal: Signal<AnyObject, TestError>? = Signal { observer in
 					testScheduler.schedule {
-						sendError(observer, TestError.Default)
+						observer.sendError(TestError.Default)
 					}
 					return nil
 				}
@@ -60,7 +60,7 @@ class SignalSpec: QuickSpec {
 			it("should deallocate after completing") {
 				weak var signal: Signal<AnyObject, NoError>? = Signal { observer in
 					testScheduler.schedule {
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}
 					return nil
 				}
@@ -81,7 +81,7 @@ class SignalSpec: QuickSpec {
 			it("should deallocate after interrupting") {
 				weak var signal: Signal<AnyObject, NoError>? = Signal { observer in
 					testScheduler.schedule {
-						sendInterrupted(observer)
+						observer.sendInterrupted()
 					}
 
 					return nil
@@ -107,9 +107,9 @@ class SignalSpec: QuickSpec {
 				let signal: Signal<Int, NoError> = Signal { observer in
 					testScheduler.schedule {
 						for number in numbers {
-							sendNext(observer, number)
+							observer.sendNext(number)
 						}
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}
 					return nil
 				}
@@ -142,7 +142,7 @@ class SignalSpec: QuickSpec {
 				
 				let signal: Signal<AnyObject, TestError> = Signal { observer in
 					testScheduler.schedule {
-						sendError(observer, TestError.Default)
+						observer.sendError(TestError.Default)
 					}
 					return disposable
 				}
@@ -165,7 +165,7 @@ class SignalSpec: QuickSpec {
 				
 				let signal: Signal<AnyObject, NoError> = Signal { observer in
 					testScheduler.schedule {
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}
 					return disposable
 				}
@@ -188,7 +188,7 @@ class SignalSpec: QuickSpec {
 
 				let signal: Signal<AnyObject, NoError> = Signal { observer in
 					testScheduler.schedule {
-						sendInterrupted(observer)
+						observer.sendInterrupted()
 					}
 					return disposable
 				}
@@ -225,7 +225,7 @@ class SignalSpec: QuickSpec {
 					let (signal, observer) = Signal<(), TestError>.pipe()
 					weakSignal = signal
 					testScheduler.schedule {
-						sendError(observer, TestError.Default)
+						observer.sendError(TestError.Default)
 					}
 				}
 				test()
@@ -246,7 +246,7 @@ class SignalSpec: QuickSpec {
 					let (signal, observer) = Signal<(), TestError>.pipe()
 					weakSignal = signal
 					testScheduler.schedule {
-						sendCompleted(observer)
+						observer.sendCompleted()
 					}
 				}
 				test()
@@ -266,7 +266,7 @@ class SignalSpec: QuickSpec {
 					weakSignal = signal
 
 					testScheduler.schedule {
-						sendInterrupted(observer)
+						observer.sendInterrupted()
 					}
 				}
 
@@ -297,14 +297,14 @@ class SignalSpec: QuickSpec {
 				expect(fromSignal).to(beEmpty())
 				expect(completed).to(beFalsy())
 				
-				sendNext(observer, 1)
+				observer.sendNext(1)
 				expect(fromSignal).to(equal([ 1 ]))
 				
-				sendNext(observer, 2)
+				observer.sendNext(2)
 				expect(fromSignal).to(equal([ 1, 2 ]))
 				
 				expect(completed).to(beFalsy())
-				sendCompleted(observer)
+				observer.sendCompleted()
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -322,10 +322,10 @@ class SignalSpec: QuickSpec {
 				let signal: Signal<Int, NoError> = Signal { observer in
 					testScheduler.schedule {
 						for number in [ 1, 2 ] {
-							sendNext(observer, number)
+							observer.sendNext(number)
 						}
-						sendCompleted(observer)
-						sendNext(observer, 4)
+						observer.sendCompleted()
+						observer.sendNext(4)
 					}
 					return disposable
 				}
@@ -353,7 +353,7 @@ class SignalSpec: QuickSpec {
 				
 				expect(runCount).to(equal(1))
 				
-				signal.observe(Event<(), NoError>.sink())
+				signal.observe(Observer<(), NoError>())
 				expect(runCount).to(equal(1))
 			}
 
@@ -370,12 +370,12 @@ class SignalSpec: QuickSpec {
 				}
 				test()
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(testStr).to(equal("1"))
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(testStr).to(equal("12"))
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(testStr).to(beNil())
 			}
 
@@ -394,13 +394,13 @@ class SignalSpec: QuickSpec {
 
 				test()
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(testStr).to(equal("1"))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(testStr).to(equal("12"))
 
-				sendInterrupted(sink)
+				sink.sendInterrupted()
 				expect(testStr).to(beNil())
 			}
 		}
@@ -414,7 +414,7 @@ class SignalSpec: QuickSpec {
 					values.append(next)
 				}
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(values).to(equal([1]))
 			}
 		}
@@ -433,10 +433,10 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 0)
+				sink.sendNext(0)
 				expect(lastValue).to(equal("1"))
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal("2"))
 			}
 		}
@@ -454,7 +454,7 @@ class SignalSpec: QuickSpec {
 
 				expect(error).to(beNil())
 
-				sendError(sink, TestError.Default)
+				sink.sendError(TestError.Default)
 				expect(error).to(equal(producerError))
 			}
 		}
@@ -471,13 +471,13 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 0)
+				sink.sendNext(0)
 				expect(lastValue).to(equal(0))
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(0))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
@@ -492,16 +492,16 @@ class SignalSpec: QuickSpec {
 				mappedSignal.observeNext { lastValue = $0 }
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, nil)
+				sink.sendNext(nil)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, nil)
+				sink.sendNext(nil)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
@@ -517,10 +517,10 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, "a")
+				sink.sendNext("a")
 				expect(lastValue).to(equal("a"))
 
-				sendNext(sink, "bb")
+				sink.sendNext("bb")
 				expect(lastValue).to(equal("abb"))
 			}
 		}
@@ -546,14 +546,14 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(beNil())
 
 				expect(completed).to(beFalse())
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(completed).to(beTrue())
 
 				expect(lastValue).to(equal(4))
@@ -580,7 +580,7 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendCompleted(sink)
+				sink.sendCompleted()
 
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beTrue())
@@ -597,10 +597,10 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 
@@ -613,10 +613,10 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
@@ -631,16 +631,16 @@ class SignalSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sendNext(sink, true)
+				sink.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sendNext(sink, true)
+				sink.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sendNext(sink, false)
+				sink.sendNext(false)
 				expect(values).to(equal([ true, false ]))
 
-				sendNext(sink, true)
+				sink.sendNext(true)
 				expect(values).to(equal([ true, false, true ]))
 			}
 
@@ -653,16 +653,16 @@ class SignalSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sendNext(sink, "a")
+				sink.sendNext("a")
 				expect(values).to(equal([ "a" ]))
 
-				sendNext(sink, "b")
+				sink.sendNext("b")
 				expect(values).to(equal([ "a" ]))
 
-				sendNext(sink, "cc")
+				sink.sendNext("cc")
 				expect(values).to(equal([ "a", "cc" ]))
 
-				sendNext(sink, "d")
+				sink.sendNext("d")
 				expect(values).to(equal([ "a", "cc", "d" ]))
 			}
 		}
@@ -686,23 +686,23 @@ class SignalSpec: QuickSpec {
 			it("should skip while the predicate is true") {
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				sendNext(sink, 0)
+				sink.sendNext(0)
 				expect(lastValue).to(equal(0))
 			}
 
 			it("should not skip any values when the predicate starts false") {
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 3)
+				sink.sendNext(3)
 				expect(lastValue).to(equal(3))
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 			}
 		}
@@ -728,11 +728,11 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 				expect(completed).to(beTrue())
 			}
@@ -744,7 +744,7 @@ class SignalSpec: QuickSpec {
 				var signal: Signal<Int, NoError> = Signal { observer in
 					testScheduler.schedule {
 						for number in numbers {
-							sendNext(observer, number)
+							observer.sendNext(number)
 						}
 					}
 					return nil
@@ -767,7 +767,7 @@ class SignalSpec: QuickSpec {
 				let signal: Signal<Int, NoError> = Signal { observer in
 					testScheduler.schedule {
 						for number in numbers {
-							sendNext(observer, number)
+							observer.sendNext(number)
 						}
 					}
 					return nil
@@ -810,11 +810,11 @@ class SignalSpec: QuickSpec {
 				}
 
 				for number in expectedResult {
-					sendNext(sink, number)
+					sink.sendNext(number)
 				}
 
 				expect(result).to(beNil())
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(result).to(equal(expectedResult))
 			}
 
@@ -827,7 +827,7 @@ class SignalSpec: QuickSpec {
 				signal.observeNext { result = $0 }
 
 				expect(result).to(beNil())
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(result).to(equal([]))
 			}
 
@@ -840,7 +840,7 @@ class SignalSpec: QuickSpec {
 				signal.observeError { error = $0 }
 
 				expect(error).to(beNil())
-				sendError(sink, .Default)
+				sink.sendError(.Default)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -879,14 +879,14 @@ class SignalSpec: QuickSpec {
 			it("should take values until the trigger fires") {
 				expect(lastValue).to(beNil())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 
 				expect(completed).to(beFalse())
-				sendNext(triggerSink, ())
+				triggerSink.sendNext(())
 				expect(completed).to(beTrue())
 			}
 
@@ -894,7 +894,7 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendNext(triggerSink, ())
+				triggerSink.sendNext(())
 
 				expect(completed).to(beTrue())
 				expect(lastValue).to(beNil())
@@ -936,27 +936,27 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				sendNext(replacementSink, 3)
+				replacementSink.sendNext(3)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				sendNext(sink, 4)
+				sink.sendNext(4)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				sendNext(replacementSink, 5)
+				replacementSink.sendNext(5)
 				expect(lastValue).to(equal(5))
 
 				expect(completed).to(beFalse())
-				sendCompleted(replacementSink)
+				replacementSink.sendCompleted()
 				expect(completed).to(beTrue())
 			}
 		}
@@ -987,12 +987,12 @@ class SignalSpec: QuickSpec {
 				}
 
 				for value in -1...4 {
-					sendNext(observer, value)
+					observer.sendNext(value)
 					expect(latestValue).to(equal(value))
 					expect(completed).to(beFalse())
 				}
 
-				sendNext(observer, 5)
+				observer.sendNext(5)
 				expect(latestValue).to(equal(4))
 				expect(completed).to(beTrue())
 			}
@@ -1012,7 +1012,7 @@ class SignalSpec: QuickSpec {
 					}
 				}
 
-				sendNext(observer, 5)
+				observer.sendNext(5)
 				expect(latestValue).to(beNil())
 				expect(completed).to(beTrue())
 			}
@@ -1029,8 +1029,8 @@ class SignalSpec: QuickSpec {
 					.observeOn(testScheduler)
 					.observeNext { result.append($0) }
 				
-				sendNext(observer, 1)
-				sendNext(observer, 2)
+				observer.sendNext(1)
+				observer.sendNext(2)
 				expect(result).to(beEmpty())
 				
 				testScheduler.run()
@@ -1043,11 +1043,11 @@ class SignalSpec: QuickSpec {
 				let testScheduler = TestScheduler()
 				let signal: Signal<Int, NoError> = Signal { observer in
 					testScheduler.schedule {
-						sendNext(observer, 1)
+						observer.sendNext(1)
 					}
 					testScheduler.scheduleAfter(5, action: {
-						sendNext(observer, 2)
-						sendCompleted(observer)
+						observer.sendNext(2)
+						observer.sendCompleted()
 					})
 					return nil
 				}
@@ -1084,7 +1084,7 @@ class SignalSpec: QuickSpec {
 				let testScheduler = TestScheduler()
 				let signal: Signal<Int, TestError> = Signal { observer in
 					testScheduler.schedule {
-						sendError(observer, TestError.Default)
+						observer.sendError(TestError.Default)
 					}
 					return nil
 				}
@@ -1123,14 +1123,14 @@ class SignalSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sendNext(observer, 0)
+				observer.sendNext(0)
 				expect(values).to(equal([]))
 
 				scheduler.advance()
 				expect(values).to(equal([ 0 ]))
 
-				sendNext(observer, 1)
-				sendNext(observer, 2)
+				observer.sendNext(1)
+				observer.sendNext(2)
 				expect(values).to(equal([ 0 ]))
 
 				scheduler.advanceByInterval(1.5)
@@ -1139,14 +1139,14 @@ class SignalSpec: QuickSpec {
 				scheduler.advanceByInterval(3)
 				expect(values).to(equal([ 0, 2 ]))
 
-				sendNext(observer, 3)
+				observer.sendNext(3)
 				expect(values).to(equal([ 0, 2 ]))
 
 				scheduler.advance()
 				expect(values).to(equal([ 0, 2, 3 ]))
 
-				sendNext(observer, 4)
-				sendNext(observer, 5)
+				observer.sendNext(4)
+				observer.sendNext(5)
 				scheduler.advance()
 				expect(values).to(equal([ 0, 2, 3 ]))
 
@@ -1169,12 +1169,12 @@ class SignalSpec: QuickSpec {
 					}
 				}
 
-				sendNext(observer, 0)
+				observer.sendNext(0)
 				scheduler.advance()
 				expect(values).to(equal([ 0 ]))
 
-				sendNext(observer, 1)
-				sendCompleted(observer)
+				observer.sendNext(1)
+				observer.sendCompleted()
 				expect(completed).to(beFalsy())
 
 				scheduler.run()
@@ -1200,9 +1200,9 @@ class SignalSpec: QuickSpec {
 				var result: [Int] = []
 				sampledSignal.observeNext { result.append($0) }
 				
-				sendNext(observer, 1)
-				sendNext(observer, 2)
-				sendNext(samplerObserver, ())
+				observer.sendNext(1)
+				observer.sendNext(2)
+				samplerObserver.sendNext(())
 				expect(result).to(equal([ 2 ]))
 			}
 			
@@ -1210,7 +1210,7 @@ class SignalSpec: QuickSpec {
 				var result: [Int] = []
 				sampledSignal.observeNext { result.append($0) }
 				
-				sendNext(samplerObserver, ())
+				samplerObserver.sendNext(())
 				expect(result).to(beEmpty())
 			}
 			
@@ -1218,9 +1218,9 @@ class SignalSpec: QuickSpec {
 				var result: [Int] = []
 				sampledSignal.observeNext { result.append($0) }
 				
-				sendNext(observer, 1)
-				sendNext(samplerObserver, ())
-				sendNext(samplerObserver, ())
+				observer.sendNext(1)
+				samplerObserver.sendNext(())
+				samplerObserver.sendNext(())
 				expect(result).to(equal([ 1, 1 ]))
 			}
 
@@ -1228,10 +1228,10 @@ class SignalSpec: QuickSpec {
 				var completed = false
 				sampledSignal.observeCompleted { completed = true }
 				
-				sendCompleted(observer)
+				observer.sendCompleted()
 				expect(completed).to(beFalsy())
 				
-				sendCompleted(samplerObserver)
+				samplerObserver.sendCompleted()
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -1253,15 +1253,15 @@ class SignalSpec: QuickSpec {
 				var latest: (Int, Double)?
 				combinedSignal.observeNext { latest = $0 }
 				
-				sendNext(observer, 1)
+				observer.sendNext(1)
 				expect(latest).to(beNil())
 				
 				// is there a better way to test tuples?
-				sendNext(otherObserver, 1.5)
+				otherObserver.sendNext(1.5)
 				expect(latest?.0).to(equal(1))
 				expect(latest?.1).to(equal(1.5))
 				
-				sendNext(observer, 2)
+				observer.sendNext(2)
 				expect(latest?.0).to(equal(2))
 				expect(latest?.1).to(equal(1.5))
 			}
@@ -1270,10 +1270,10 @@ class SignalSpec: QuickSpec {
 				var completed = false
 				combinedSignal.observeCompleted { completed = true }
 				
-				sendCompleted(observer)
+				observer.sendCompleted()
 				expect(completed).to(beFalsy())
 				
-				sendCompleted(otherObserver)
+				otherObserver.sendCompleted()
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -1296,24 +1296,24 @@ class SignalSpec: QuickSpec {
 				var result: [String] = []
 				zipped.observeNext { (left, right) in result.append("\(left)\(right)") }
 
-				sendNext(leftSink, 1)
-				sendNext(leftSink, 2)
+				leftSink.sendNext(1)
+				leftSink.sendNext(2)
 				expect(result).to(equal([]))
 
-				sendNext(rightSink, "foo")
+				rightSink.sendNext("foo")
 				expect(result).to(equal([ "1foo" ]))
 
-				sendNext(leftSink, 3)
-				sendNext(rightSink, "bar")
+				leftSink.sendNext(3)
+				rightSink.sendNext("bar")
 				expect(result).to(equal([ "1foo", "2bar" ]))
 
-				sendNext(rightSink, "buzz")
+				rightSink.sendNext("buzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				sendNext(rightSink, "fuzz")
+				rightSink.sendNext("fuzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				sendNext(leftSink, 4)
+				leftSink.sendNext(4)
 				expect(result).to(equal([ "1foo", "2bar", "3buzz", "4fuzz" ]))
 			}
 
@@ -1334,12 +1334,12 @@ class SignalSpec: QuickSpec {
 
 				expect(completed).to(beFalsy())
 
-				sendNext(leftSink, 0)
-				sendCompleted(leftSink)
+				leftSink.sendNext(0)
+				leftSink.sendCompleted()
 				expect(completed).to(beFalsy())
 				expect(result).to(equal([]))
 
-				sendNext(rightSink, "foo")
+				rightSink.sendNext("foo")
 				expect(completed).to(beTruthy())
 				expect(result).to(equal([ "0foo" ]))
 			}
@@ -1353,7 +1353,7 @@ class SignalSpec: QuickSpec {
 					.materialize()
 					.observeNext { latestEvent = $0 }
 				
-				sendNext(observer, 2)
+				observer.sendNext(2)
 				
 				expect(latestEvent).toNot(beNil())
 				if let latestEvent = latestEvent {
@@ -1365,7 +1365,7 @@ class SignalSpec: QuickSpec {
 					}
 				}
 				
-				sendError(observer, TestError.Default)
+				observer.sendError(TestError.Default)
 				if let latestEvent = latestEvent {
 					switch latestEvent {
 					case .Error(_):
@@ -1394,10 +1394,10 @@ class SignalSpec: QuickSpec {
 				
 				expect(result).to(beEmpty())
 				
-				sendNext(sink, .Next(2))
+				sink.sendNext(.Next(2))
 				expect(result).to(equal([ 2 ]))
 				
-				sendNext(sink, .Next(4))
+				sink.sendNext(.Next(4))
 				expect(result).to(equal([ 2, 4 ]))
 			}
 
@@ -1407,7 +1407,7 @@ class SignalSpec: QuickSpec {
 				
 				expect(errored).to(beFalsy())
 				
-				sendNext(sink, .Error(TestError.Default))
+				sink.sendNext(.Error(TestError.Default))
 				expect(errored).to(beTruthy())
 			}
 
@@ -1416,7 +1416,7 @@ class SignalSpec: QuickSpec {
 				dematerialized.observeCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
-				sendNext(sink, IntEvent.Completed)
+				sink.sendNext(IntEvent.Completed)
 				expect(completed).to(beTruthy())
 			}
 		}
@@ -1435,13 +1435,13 @@ class SignalSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree.observeNext { result.append($0) }
 				
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendNext(sink, 3)
-				sendNext(sink, 4)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendNext(3)
+				sink.sendNext(4)
 				expect(result).to(beEmpty())
 				
-				sendCompleted(sink)
+				sink.sendCompleted()
 				expect(result).to(equal([ 2, 3, 4 ]))
 			}
 
@@ -1449,9 +1449,9 @@ class SignalSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree.observeNext { result.append($0) }
 				
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendCompleted(sink)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendCompleted()
 				expect(result).to(equal([ 1, 2 ]))
 			}
 			
@@ -1469,12 +1469,12 @@ class SignalSpec: QuickSpec {
 					}
 				}
 				
-				sendNext(sink, 1)
-				sendNext(sink, 2)
-				sendNext(sink, 3)
+				sink.sendNext(1)
+				sink.sendNext(2)
+				sink.sendNext(3)
 				expect(errored).to(beFalsy())
 				
-				sendError(sink, TestError.Default)
+				sink.sendError(TestError.Default)
 				expect(errored).to(beTruthy())
 				expect(result).to(beEmpty())
 			}
@@ -1507,7 +1507,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(1) {
-					sendCompleted(sink)
+					sink.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1533,7 +1533,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(3) {
-					sendCompleted(sink)
+					sink.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1558,7 +1558,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				for value in 1...5 {
-					sendNext(sink, value)
+					sink.sendNext(value)
 					expect(current).to(equal(value))
 				}
 			}
@@ -1574,7 +1574,7 @@ class SignalSpec: QuickSpec {
 					error = err
 				}
 				
-				sendNext(sink, 42)
+				sink.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -1591,10 +1591,10 @@ class SignalSpec: QuickSpec {
 					even = value
 				}
 				
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(even).to(equal(false))
 				
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(even).to(equal(true))
 			}
 			
@@ -1609,7 +1609,7 @@ class SignalSpec: QuickSpec {
 					error = err
 				}
 				
-				sendNext(sink, 42)
+				sink.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -1630,11 +1630,11 @@ class SignalSpec: QuickSpec {
 			it("should forward the latest value with previous value") {
 				expect(latestValues).to(beNil())
 				
-				sendNext(sink, 1)
+				sink.sendNext(1)
 				expect(latestValues?.0).to(equal(initialValue))
 				expect(latestValues?.1).to(equal(1))
 				
-				sendNext(sink, 2)
+				sink.sendNext(2)
 				expect(latestValues?.0).to(equal(1))
 				expect(latestValues?.1).to(equal(2))
 			}
@@ -1673,36 +1673,36 @@ class SignalSpec: QuickSpec {
 				it("should forward the latest values from all inputs"){
 					expect(combinedValues).to(beNil())
 					
-					sendNext(sinkA, 0)
-					sendNext(sinkB, 1)
-					sendNext(sinkC, 2)
+					sinkA.sendNext(0)
+					sinkB.sendNext(1)
+					sinkC.sendNext(2)
 					expect(combinedValues).to(equal([0, 1, 2]))
 					
-					sendNext(sinkA, 10)
+					sinkA.sendNext(10)
 					expect(combinedValues).to(equal([10, 1, 2]))
 				}
 				
 				it("should not forward the latest values before all inputs"){
 					expect(combinedValues).to(beNil())
 					
-					sendNext(sinkA, 0)
+					sinkA.sendNext(0)
 					expect(combinedValues).to(beNil())
 					
-					sendNext(sinkB, 1)
+					sinkB.sendNext(1)
 					expect(combinedValues).to(beNil())
 					
-					sendNext(sinkC, 2)
+					sinkC.sendNext(2)
 					expect(combinedValues).to(equal([0, 1, 2]))
 				}
 				
 				it("should complete when all inputs have completed"){
 					expect(completed).to(beFalsy())
 					
-					sendCompleted(sinkA)
-					sendCompleted(sinkB)
+					sinkA.sendCompleted()
+					sinkB.sendCompleted()
 					expect(completed).to(beFalsy())
 					
-					sendCompleted(sinkC)
+					sinkC.sendCompleted()
 					expect(completed).to(beTruthy())
 				}
 			}
@@ -1777,38 +1777,38 @@ class SignalSpec: QuickSpec {
 				it("should combine all set"){
 					expect(zippedValues).to(beNil())
 					
-					sendNext(sinkA, 0)
+					sinkA.sendNext(0)
 					expect(zippedValues).to(beNil())
 					
-					sendNext(sinkB, 1)
+					sinkB.sendNext(1)
 					expect(zippedValues).to(beNil())
 					
-					sendNext(sinkC, 2)
+					sinkC.sendNext(2)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sendNext(sinkA, 10)
+					sinkA.sendNext(10)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sendNext(sinkA, 20)
+					sinkA.sendNext(20)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sendNext(sinkB, 11)
+					sinkB.sendNext(11)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sendNext(sinkC, 12)
+					sinkC.sendNext(12)
 					expect(zippedValues).to(equal([10, 11, 12]))
 				}
 				
 				it("should complete when the shorter signal has completed"){
 					expect(completed).to(beFalsy())
 					
-					sendNext(sinkB, 1)
-					sendNext(sinkC, 2)
-					sendCompleted(sinkB)
-					sendCompleted(sinkC)
+					sinkB.sendNext(1)
+					sinkC.sendNext(2)
+					sinkB.sendCompleted()
+					sinkC.sendCompleted()
 					expect(completed).to(beFalsy())
 					
-					sendNext(sinkA, 0)
+					sinkA.sendNext(0)
 					expect(completed).to(beTruthy())
 				}
 			}

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -359,7 +359,7 @@ class SignalSpec: QuickSpec {
 
 			it("should release observer after termination") {
 				weak var testStr: NSMutableString?
-				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let (signal, observer) = Signal<Int, NoError>.pipe()
 
 				let test: () -> () = {
 					let innerStr: NSMutableString = NSMutableString()
@@ -370,18 +370,18 @@ class SignalSpec: QuickSpec {
 				}
 				test()
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(testStr).to(equal("1"))
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(testStr).to(equal("12"))
 
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(testStr).to(beNil())
 			}
 
 			it("should release observer after interruption") {
 				weak var testStr: NSMutableString?
-				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let (signal, observer) = Signal<Int, NoError>.pipe()
 
 				let test: () -> () = {
 					let innerStr: NSMutableString = NSMutableString()
@@ -394,13 +394,13 @@ class SignalSpec: QuickSpec {
 
 				test()
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(testStr).to(equal("1"))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(testStr).to(equal("12"))
 
-				sink.sendInterrupted()
+				observer.sendInterrupted()
 				expect(testStr).to(beNil())
 			}
 		}
@@ -408,20 +408,20 @@ class SignalSpec: QuickSpec {
 		describe("trailing closure") {
 			it("receives next values") {
 				var values = [Int]()
-				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let (signal, observer) = Signal<Int, NoError>.pipe()
 
 				signal.observeNext { next in
 					values.append(next)
 				}
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(values).to(equal([1]))
 			}
 		}
 
 		describe("map") {
 			it("should transform the values of the signal") {
-				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let (signal, observer) = Signal<Int, NoError>.pipe()
 				let mappedSignal = signal.map { String($0 + 1) }
 
 				var lastValue: String?
@@ -433,10 +433,10 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(0)
+				observer.sendNext(0)
 				expect(lastValue).to(equal("1"))
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal("2"))
 			}
 		}
@@ -444,7 +444,7 @@ class SignalSpec: QuickSpec {
 		
 		describe("mapError") {
 			it("should transform the errors of the signal") {
-				let (signal, sink) = Signal<Int, TestError>.pipe()
+				let (signal, observer) = Signal<Int, TestError>.pipe()
 				let producerError = NSError(domain: "com.reactivecocoa.errordomain", code: 100, userInfo: nil)
 				var error: NSError?
 
@@ -454,7 +454,7 @@ class SignalSpec: QuickSpec {
 
 				expect(error).to(beNil())
 
-				sink.sendError(TestError.Default)
+				observer.sendError(TestError.Default)
 				expect(error).to(equal(producerError))
 			}
 		}
@@ -462,7 +462,7 @@ class SignalSpec: QuickSpec {
 
 		describe("filter") {
 			it("should omit values from the signal") {
-				let (signal, sink) = Signal<Int, NoError>.pipe()
+				let (signal, observer) = Signal<Int, NoError>.pipe()
 				let mappedSignal = signal.filter { $0 % 2 == 0 }
 
 				var lastValue: Int?
@@ -471,20 +471,20 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(0)
+				observer.sendNext(0)
 				expect(lastValue).to(equal(0))
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(0))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
 
 		describe("ignoreNil") {
 			it("should forward only non-nil values") {
-				let (signal, sink) = Signal<Int?, NoError>.pipe()
+				let (signal, observer) = Signal<Int?, NoError>.pipe()
 				let mappedSignal = signal.ignoreNil()
 
 				var lastValue: Int?
@@ -492,23 +492,23 @@ class SignalSpec: QuickSpec {
 				mappedSignal.observeNext { lastValue = $0 }
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(nil)
+				observer.sendNext(nil)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(nil)
+				observer.sendNext(nil)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
 
 		describe("scan") {
 			it("should incrementally accumulate a value") {
-				let (baseSignal, sink) = Signal<String, NoError>.pipe()
+				let (baseSignal, observer) = Signal<String, NoError>.pipe()
 				let signal = baseSignal.scan("", +)
 
 				var lastValue: String?
@@ -517,17 +517,17 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext("a")
+				observer.sendNext("a")
 				expect(lastValue).to(equal("a"))
 
-				sink.sendNext("bb")
+				observer.sendNext("bb")
 				expect(lastValue).to(equal("abb"))
 			}
 		}
 
 		describe("reduce") {
 			it("should accumulate one value") {
-				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
 				let signal = baseSignal.reduce(1, +)
 
 				var lastValue: Int?
@@ -546,21 +546,21 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(beNil())
 
 				expect(completed).to(beFalse())
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(completed).to(beTrue())
 
 				expect(lastValue).to(equal(4))
 			}
 
 			it("should send the initial value if none are received") {
-				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
 				let signal = baseSignal.reduce(1, +)
 
 				var lastValue: Int?
@@ -580,7 +580,7 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sink.sendCompleted()
+				observer.sendCompleted()
 
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beTrue())
@@ -589,7 +589,7 @@ class SignalSpec: QuickSpec {
 
 		describe("skip") {
 			it("should skip initial values") {
-				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
 				let signal = baseSignal.skip(1)
 
 				var lastValue: Int?
@@ -597,15 +597,15 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 
 			it("should not skip any values when 0") {
-				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
 				let signal = baseSignal.skip(0)
 
 				var lastValue: Int?
@@ -613,17 +613,17 @@ class SignalSpec: QuickSpec {
 
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 			}
 		}
 
 		describe("skipRepeats") {
 			it("should skip duplicate Equatable values") {
-				let (baseSignal, sink) = Signal<Bool, NoError>.pipe()
+				let (baseSignal, observer) = Signal<Bool, NoError>.pipe()
 				let signal = baseSignal.skipRepeats()
 
 				var values: [Bool] = []
@@ -631,21 +631,21 @@ class SignalSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sink.sendNext(true)
+				observer.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sink.sendNext(true)
+				observer.sendNext(true)
 				expect(values).to(equal([ true ]))
 
-				sink.sendNext(false)
+				observer.sendNext(false)
 				expect(values).to(equal([ true, false ]))
 
-				sink.sendNext(true)
+				observer.sendNext(true)
 				expect(values).to(equal([ true, false, true ]))
 			}
 
 			it("should skip values according to a predicate") {
-				let (baseSignal, sink) = Signal<String, NoError>.pipe()
+				let (baseSignal, observer) = Signal<String, NoError>.pipe()
 				let signal = baseSignal.skipRepeats { $0.characters.count == $1.characters.count }
 
 				var values: [String] = []
@@ -653,31 +653,31 @@ class SignalSpec: QuickSpec {
 
 				expect(values).to(equal([]))
 
-				sink.sendNext("a")
+				observer.sendNext("a")
 				expect(values).to(equal([ "a" ]))
 
-				sink.sendNext("b")
+				observer.sendNext("b")
 				expect(values).to(equal([ "a" ]))
 
-				sink.sendNext("cc")
+				observer.sendNext("cc")
 				expect(values).to(equal([ "a", "cc" ]))
 
-				sink.sendNext("d")
+				observer.sendNext("d")
 				expect(values).to(equal([ "a", "cc", "d" ]))
 			}
 		}
 
 		describe("skipWhile") {
 			var signal: Signal<Int, NoError>!
-			var sink: Signal<Int, NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
 
 			var lastValue: Int?
 
 			beforeEach {
-				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
+				let (baseSignal, incomingObserver) = Signal<Int, NoError>.pipe()
 
 				signal = baseSignal.skipWhile { $0 < 2 }
-				sink = observer
+				observer = incomingObserver
 				lastValue = nil
 
 				signal.observeNext { lastValue = $0 }
@@ -686,30 +686,30 @@ class SignalSpec: QuickSpec {
 			it("should skip while the predicate is true") {
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				sink.sendNext(0)
+				observer.sendNext(0)
 				expect(lastValue).to(equal(0))
 			}
 
 			it("should not skip any values when the predicate starts false") {
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(3)
+				observer.sendNext(3)
 				expect(lastValue).to(equal(3))
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 			}
 		}
 
 		describe("take") {
 			it("should take initial values") {
-				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
 				let signal = baseSignal.take(2)
 
 				var lastValue: Int?
@@ -728,11 +728,11 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 				expect(completed).to(beFalse())
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 				expect(completed).to(beTrue())
 			}
@@ -798,7 +798,7 @@ class SignalSpec: QuickSpec {
 
 		describe("collect") {
 			it("should collect all values") {
-				let (original, sink) = Signal<Int, NoError>.pipe()
+				let (original, observer) = Signal<Int, NoError>.pipe()
 				let signal = original.collect()
 				let expectedResult = [ 1, 2, 3 ]
 
@@ -810,16 +810,16 @@ class SignalSpec: QuickSpec {
 				}
 
 				for number in expectedResult {
-					sink.sendNext(number)
+					observer.sendNext(number)
 				}
 
 				expect(result).to(beNil())
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(result).to(equal(expectedResult))
 			}
 
 			it("should complete with an empty array if there are no values") {
-				let (original, sink) = Signal<Int, NoError>.pipe()
+				let (original, observer) = Signal<Int, NoError>.pipe()
 				let signal = original.collect()
 
 				var result: [Int]?
@@ -827,12 +827,12 @@ class SignalSpec: QuickSpec {
 				signal.observeNext { result = $0 }
 
 				expect(result).to(beNil())
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(result).to(equal([]))
 			}
 
 			it("should forward errors") {
-				let (original, sink) = Signal<Int, TestError>.pipe()
+				let (original, observer) = Signal<Int, TestError>.pipe()
 				let signal = original.collect()
 
 				var error: TestError?
@@ -840,26 +840,26 @@ class SignalSpec: QuickSpec {
 				signal.observeError { error = $0 }
 
 				expect(error).to(beNil())
-				sink.sendError(.Default)
+				observer.sendError(.Default)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
 
 		describe("takeUntil") {
 			var signal: Signal<Int, NoError>!
-			var sink: Signal<Int, NoError>.Observer!
-			var triggerSink: Signal<(), NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
+			var triggerObserver: Signal<(), NoError>.Observer!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
 
 			beforeEach {
-				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
-				let (triggerSignal, triggerObserver) = Signal<(), NoError>.pipe()
+				let (baseSignal, incomingObserver) = Signal<Int, NoError>.pipe()
+				let (triggerSignal, incomingTriggerObserver) = Signal<(), NoError>.pipe()
 
 				signal = baseSignal.takeUntil(triggerSignal)
-				sink = observer
-				triggerSink = triggerObserver
+				observer = incomingObserver
+				triggerObserver = incomingTriggerObserver
 
 				lastValue = nil
 				completed = false
@@ -879,14 +879,14 @@ class SignalSpec: QuickSpec {
 			it("should take values until the trigger fires") {
 				expect(lastValue).to(beNil())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
 				expect(completed).to(beFalse())
-				triggerSink.sendNext(())
+				triggerObserver.sendNext(())
 				expect(completed).to(beTrue())
 			}
 
@@ -894,7 +894,7 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				triggerSink.sendNext(())
+				triggerObserver.sendNext(())
 
 				expect(completed).to(beTrue())
 				expect(lastValue).to(beNil())
@@ -903,19 +903,19 @@ class SignalSpec: QuickSpec {
 
 		describe("takeUntilReplacement") {
 			var signal: Signal<Int, NoError>!
-			var sink: Signal<Int, NoError>.Observer!
-			var replacementSink: Signal<Int, NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
+			var replacementObserver: Signal<Int, NoError>.Observer!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
 
 			beforeEach {
-				let (baseSignal, observer) = Signal<Int, NoError>.pipe()
-				let (replacementSignal, replacementObserver) = Signal<Int, NoError>.pipe()
+				let (baseSignal, incomingObserver) = Signal<Int, NoError>.pipe()
+				let (replacementSignal, incomingReplacementObserver) = Signal<Int, NoError>.pipe()
 
 				signal = baseSignal.takeUntilReplacement(replacementSignal)
-				sink = observer
-				replacementSink = replacementObserver
+				observer = incomingObserver
+				replacementObserver = incomingReplacementObserver
 
 				lastValue = nil
 				completed = false
@@ -936,27 +936,27 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				expect(completed).to(beFalse())
 
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
 
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				replacementSink.sendNext(3)
+				replacementObserver.sendNext(3)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				sink.sendNext(4)
+				observer.sendNext(4)
 
 				expect(lastValue).to(equal(3))
 				expect(completed).to(beFalse())
 
-				replacementSink.sendNext(5)
+				replacementObserver.sendNext(5)
 				expect(lastValue).to(equal(5))
 
 				expect(completed).to(beFalse())
-				replacementSink.sendCompleted()
+				replacementObserver.sendCompleted()
 				expect(completed).to(beTrue())
 			}
 		}
@@ -966,9 +966,9 @@ class SignalSpec: QuickSpec {
 			var observer: Signal<Int, NoError>.Observer!
 
 			beforeEach {
-				let (baseSignal, sink) = Signal<Int, NoError>.pipe()
+				let (baseSignal, incomingObserver) = Signal<Int, NoError>.pipe()
 				signal = baseSignal.takeWhile { $0 <= 4 }
-				observer = sink
+				observer = incomingObserver
 			}
 
 			it("should take while the predicate is true") {
@@ -1189,11 +1189,11 @@ class SignalSpec: QuickSpec {
 			var samplerObserver: Signal<(), NoError>.Observer!
 			
 			beforeEach {
-				let (signal, sink) = Signal<Int, NoError>.pipe()
-				let (sampler, samplesSink) = Signal<(), NoError>.pipe()
+				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
+				let (sampler, incomingSamplerObserver) = Signal<(), NoError>.pipe()
 				sampledSignal = signal.sampleOn(sampler)
-				observer = sink
-				samplerObserver = samplesSink
+				observer = incomingObserver
+				samplerObserver = incomingSamplerObserver
 			}
 			
 			it("should forward the latest value when the sampler fires") {
@@ -1242,11 +1242,11 @@ class SignalSpec: QuickSpec {
 			var otherObserver: Signal<Double, NoError>.Observer!
 			
 			beforeEach {
-				let (signal, sink) = Signal<Int, NoError>.pipe()
-				let (otherSignal, otherSink) = Signal<Double, NoError>.pipe()
+				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
+				let (otherSignal, incomingOtherObserver) = Signal<Double, NoError>.pipe()
 				combinedSignal = signal.combineLatestWith(otherSignal)
-				observer = sink
-				otherObserver = otherSink
+				observer = incomingObserver
+				otherObserver = incomingOtherObserver
 			}
 			
 			it("should forward the latest values from both inputs") {
@@ -1279,16 +1279,16 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("zipWith") {
-			var leftSink: Signal<Int, NoError>.Observer!
-			var rightSink: Signal<String, NoError>.Observer!
+			var leftObserver: Signal<Int, NoError>.Observer!
+			var rightObserver: Signal<String, NoError>.Observer!
 			var zipped: Signal<(Int, String), NoError>!
 
 			beforeEach {
-				let (leftSignal, leftObserver) = Signal<Int, NoError>.pipe()
-				let (rightSignal, rightObserver) = Signal<String, NoError>.pipe()
+				let (leftSignal, incomingLeftObserver) = Signal<Int, NoError>.pipe()
+				let (rightSignal, incomingRightObserver) = Signal<String, NoError>.pipe()
 
-				leftSink = leftObserver
-				rightSink = rightObserver
+				leftObserver = incomingLeftObserver
+				rightObserver = incomingRightObserver
 				zipped = leftSignal.zipWith(rightSignal)
 			}
 
@@ -1296,24 +1296,24 @@ class SignalSpec: QuickSpec {
 				var result: [String] = []
 				zipped.observeNext { (left, right) in result.append("\(left)\(right)") }
 
-				leftSink.sendNext(1)
-				leftSink.sendNext(2)
+				leftObserver.sendNext(1)
+				leftObserver.sendNext(2)
 				expect(result).to(equal([]))
 
-				rightSink.sendNext("foo")
+				rightObserver.sendNext("foo")
 				expect(result).to(equal([ "1foo" ]))
 
-				leftSink.sendNext(3)
-				rightSink.sendNext("bar")
+				leftObserver.sendNext(3)
+				rightObserver.sendNext("bar")
 				expect(result).to(equal([ "1foo", "2bar" ]))
 
-				rightSink.sendNext("buzz")
+				rightObserver.sendNext("buzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				rightSink.sendNext("fuzz")
+				rightObserver.sendNext("fuzz")
 				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
 
-				leftSink.sendNext(4)
+				leftObserver.sendNext(4)
 				expect(result).to(equal([ "1foo", "2bar", "3buzz", "4fuzz" ]))
 			}
 
@@ -1334,12 +1334,12 @@ class SignalSpec: QuickSpec {
 
 				expect(completed).to(beFalsy())
 
-				leftSink.sendNext(0)
-				leftSink.sendCompleted()
+				leftObserver.sendNext(0)
+				leftObserver.sendCompleted()
 				expect(completed).to(beFalsy())
 				expect(result).to(equal([]))
 
-				rightSink.sendNext("foo")
+				rightObserver.sendNext("foo")
 				expect(completed).to(beTruthy())
 				expect(result).to(equal([ "0foo" ]))
 			}
@@ -1379,12 +1379,12 @@ class SignalSpec: QuickSpec {
 
 		describe("dematerialize") {
 			typealias IntEvent = Event<Int, TestError>
-			var sink: Signal<IntEvent, NoError>.Observer!
+			var observer: Signal<IntEvent, NoError>.Observer!
 			var dematerialized: Signal<Int, TestError>!
 			
 			beforeEach {
-				let (signal, observer) = Signal<IntEvent, NoError>.pipe()
-				sink = observer
+				let (signal, incomingObserver) = Signal<IntEvent, NoError>.pipe()
+				observer = incomingObserver
 				dematerialized = signal.dematerialize()
 			}
 			
@@ -1394,10 +1394,10 @@ class SignalSpec: QuickSpec {
 				
 				expect(result).to(beEmpty())
 				
-				sink.sendNext(.Next(2))
+				observer.sendNext(.Next(2))
 				expect(result).to(equal([ 2 ]))
 				
-				sink.sendNext(.Next(4))
+				observer.sendNext(.Next(4))
 				expect(result).to(equal([ 2, 4 ]))
 			}
 
@@ -1407,7 +1407,7 @@ class SignalSpec: QuickSpec {
 				
 				expect(errored).to(beFalsy())
 				
-				sink.sendNext(.Error(TestError.Default))
+				observer.sendNext(.Error(TestError.Default))
 				expect(errored).to(beTruthy())
 			}
 
@@ -1416,32 +1416,32 @@ class SignalSpec: QuickSpec {
 				dematerialized.observeCompleted { completed = true }
 				
 				expect(completed).to(beFalsy())
-				sink.sendNext(IntEvent.Completed)
+				observer.sendNext(IntEvent.Completed)
 				expect(completed).to(beTruthy())
 			}
 		}
 
 		describe("takeLast") {
-			var sink: Signal<Int, TestError>.Observer!
+			var observer: Signal<Int, TestError>.Observer!
 			var lastThree: Signal<Int, TestError>!
 				
 			beforeEach {
-				let (signal, observer) = Signal<Int, TestError>.pipe()
-				sink = observer
+				let (signal, incomingObserver) = Signal<Int, TestError>.pipe()
+				observer = incomingObserver
 				lastThree = signal.takeLast(3)
 			}
-			
+
 			it("should send the last N values upon completion") {
 				var result: [Int] = []
 				lastThree.observeNext { result.append($0) }
 				
-				sink.sendNext(1)
-				sink.sendNext(2)
-				sink.sendNext(3)
-				sink.sendNext(4)
+				observer.sendNext(1)
+				observer.sendNext(2)
+				observer.sendNext(3)
+				observer.sendNext(4)
 				expect(result).to(beEmpty())
 				
-				sink.sendCompleted()
+				observer.sendCompleted()
 				expect(result).to(equal([ 2, 3, 4 ]))
 			}
 
@@ -1449,9 +1449,9 @@ class SignalSpec: QuickSpec {
 				var result: [Int] = []
 				lastThree.observeNext { result.append($0) }
 				
-				sink.sendNext(1)
-				sink.sendNext(2)
-				sink.sendCompleted()
+				observer.sendNext(1)
+				observer.sendNext(2)
+				observer.sendCompleted()
 				expect(result).to(equal([ 1, 2 ]))
 			}
 			
@@ -1469,12 +1469,12 @@ class SignalSpec: QuickSpec {
 					}
 				}
 				
-				sink.sendNext(1)
-				sink.sendNext(2)
-				sink.sendNext(3)
+				observer.sendNext(1)
+				observer.sendNext(2)
+				observer.sendNext(3)
 				expect(errored).to(beFalsy())
 				
-				sink.sendError(TestError.Default)
+				observer.sendError(TestError.Default)
 				expect(errored).to(beTruthy())
 				expect(result).to(beEmpty())
 			}
@@ -1483,13 +1483,13 @@ class SignalSpec: QuickSpec {
 		describe("timeoutWithError") {
 			var testScheduler: TestScheduler!
 			var signal: Signal<Int, TestError>!
-			var sink: Signal<Int, TestError>.Observer!
+			var observer: Signal<Int, TestError>.Observer!
 
 			beforeEach {
 				testScheduler = TestScheduler()
-				let (baseSignal, observer) = Signal<Int, TestError>.pipe()
+				let (baseSignal, incomingObserver) = Signal<Int, TestError>.pipe()
 				signal = baseSignal.timeoutWithError(TestError.Default, afterInterval: 2, onScheduler: testScheduler)
-				sink = observer
+				observer = incomingObserver
 			}
 
 			it("should complete if within the interval") {
@@ -1507,7 +1507,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(1) {
-					sink.sendCompleted()
+					observer.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1533,7 +1533,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				testScheduler.scheduleAfter(3) {
-					sink.sendCompleted()
+					observer.sendCompleted()
 				}
 
 				expect(completed).to(beFalsy())
@@ -1547,7 +1547,7 @@ class SignalSpec: QuickSpec {
 
 		describe("attempt") {
 			it("should forward original values upon success") {
-				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
+				let (baseSignal, observer) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attempt { _ in
 					return .Success()
 				}
@@ -1558,13 +1558,13 @@ class SignalSpec: QuickSpec {
 				}
 				
 				for value in 1...5 {
-					sink.sendNext(value)
+					observer.sendNext(value)
 					expect(current).to(equal(value))
 				}
 			}
 			
 			it("should error if an attempt fails") {
-				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
+				let (baseSignal, observer) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attempt { _ in
 					return .Failure(.Default)
 				}
@@ -1574,14 +1574,14 @@ class SignalSpec: QuickSpec {
 					error = err
 				}
 				
-				sink.sendNext(42)
+				observer.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
 		
 		describe("attemptMap") {
 			it("should forward mapped values upon success") {
-				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
+				let (baseSignal, observer) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attemptMap { num -> Result<Bool, TestError> in
 					return .Success(num % 2 == 0)
 				}
@@ -1591,15 +1591,15 @@ class SignalSpec: QuickSpec {
 					even = value
 				}
 				
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(even).to(equal(false))
 				
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(even).to(equal(true))
 			}
 			
 			it("should error if a mapping fails") {
-				let (baseSignal, sink) = Signal<Int, TestError>.pipe()
+				let (baseSignal, observer) = Signal<Int, TestError>.pipe()
 				let signal = baseSignal.attemptMap { _ -> Result<Bool, TestError> in
 					return .Failure(.Default)
 				}
@@ -1609,32 +1609,32 @@ class SignalSpec: QuickSpec {
 					error = err
 				}
 				
-				sink.sendNext(42)
+				observer.sendNext(42)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
 		
 		describe("combinePrevious") {
-			var sink: Signal<Int, NoError>.Observer!
+			var observer: Signal<Int, NoError>.Observer!
 			let initialValue: Int = 0
 			var latestValues: (Int, Int)?
 			
 			beforeEach {
 				latestValues = nil
 				
-				let (signal, baseSink) = Signal<Int, NoError>.pipe()
-				sink = baseSink
+				let (signal, baseObserver) = Signal<Int, NoError>.pipe()
+				observer = baseObserver
 				signal.combinePrevious(initialValue).observeNext { latestValues = $0 }
 			}
 			
 			it("should forward the latest value with previous value") {
 				expect(latestValues).to(beNil())
 				
-				sink.sendNext(1)
+				observer.sendNext(1)
 				expect(latestValues?.0).to(equal(initialValue))
 				expect(latestValues?.1).to(equal(1))
 				
-				sink.sendNext(2)
+				observer.sendNext(2)
 				expect(latestValues?.0).to(equal(1))
 				expect(latestValues?.1).to(equal(2))
 			}
@@ -1644,9 +1644,9 @@ class SignalSpec: QuickSpec {
 			var signalA: Signal<Int, NoError>!
 			var signalB: Signal<Int, NoError>!
 			var signalC: Signal<Int, NoError>!
-			var sinkA: Signal<Int, NoError>.Observer!
-			var sinkB: Signal<Int, NoError>.Observer!
-			var sinkC: Signal<Int, NoError>.Observer!
+			var observerA: Signal<Int, NoError>.Observer!
+			var observerB: Signal<Int, NoError>.Observer!
+			var observerC: Signal<Int, NoError>.Observer!
 			
 			var combinedValues: [Int]?
 			var completed: Bool!
@@ -1655,17 +1655,17 @@ class SignalSpec: QuickSpec {
 				combinedValues = nil
 				completed = false
 				
-				let (baseSignalA, baseSinkA) = Signal<Int, NoError>.pipe()
-				let (baseSignalB, baseSinkB) = Signal<Int, NoError>.pipe()
-				let (baseSignalC, baseSinkC) = Signal<Int, NoError>.pipe()
+				let (baseSignalA, baseObserverA) = Signal<Int, NoError>.pipe()
+				let (baseSignalB, baseObserverB) = Signal<Int, NoError>.pipe()
+				let (baseSignalC, baseObserverC) = Signal<Int, NoError>.pipe()
 				
 				signalA = baseSignalA
 				signalB = baseSignalB
 				signalC = baseSignalC
 				
-				sinkA = baseSinkA
-				sinkB = baseSinkB
-				sinkC = baseSinkC
+				observerA = baseObserverA
+				observerB = baseObserverB
+				observerC = baseObserverC
 			}
 			
 			let combineLatestExampleName = "combineLatest examples"
@@ -1673,36 +1673,36 @@ class SignalSpec: QuickSpec {
 				it("should forward the latest values from all inputs"){
 					expect(combinedValues).to(beNil())
 					
-					sinkA.sendNext(0)
-					sinkB.sendNext(1)
-					sinkC.sendNext(2)
+					observerA.sendNext(0)
+					observerB.sendNext(1)
+					observerC.sendNext(2)
 					expect(combinedValues).to(equal([0, 1, 2]))
 					
-					sinkA.sendNext(10)
+					observerA.sendNext(10)
 					expect(combinedValues).to(equal([10, 1, 2]))
 				}
 				
 				it("should not forward the latest values before all inputs"){
 					expect(combinedValues).to(beNil())
 					
-					sinkA.sendNext(0)
+					observerA.sendNext(0)
 					expect(combinedValues).to(beNil())
 					
-					sinkB.sendNext(1)
+					observerB.sendNext(1)
 					expect(combinedValues).to(beNil())
 					
-					sinkC.sendNext(2)
+					observerC.sendNext(2)
 					expect(combinedValues).to(equal([0, 1, 2]))
 				}
 				
 				it("should complete when all inputs have completed"){
 					expect(completed).to(beFalsy())
 					
-					sinkA.sendCompleted()
-					sinkB.sendCompleted()
+					observerA.sendCompleted()
+					observerB.sendCompleted()
 					expect(completed).to(beFalsy())
 					
-					sinkC.sendCompleted()
+					observerC.sendCompleted()
 					expect(completed).to(beTruthy())
 				}
 			}
@@ -1748,9 +1748,9 @@ class SignalSpec: QuickSpec {
 			var signalA: Signal<Int, NoError>!
 			var signalB: Signal<Int, NoError>!
 			var signalC: Signal<Int, NoError>!
-			var sinkA: Signal<Int, NoError>.Observer!
-			var sinkB: Signal<Int, NoError>.Observer!
-			var sinkC: Signal<Int, NoError>.Observer!
+			var observerA: Signal<Int, NoError>.Observer!
+			var observerB: Signal<Int, NoError>.Observer!
+			var observerC: Signal<Int, NoError>.Observer!
 
 			var zippedValues: [Int]?
 			var completed: Bool!
@@ -1759,17 +1759,17 @@ class SignalSpec: QuickSpec {
 				zippedValues = nil
 				completed = false
                 
-				let (baseSignalA, baseSinkA) = Signal<Int, NoError>.pipe()
-				let (baseSignalB, baseSinkB) = Signal<Int, NoError>.pipe()
-				let (baseSignalC, baseSinkC) = Signal<Int, NoError>.pipe()
+				let (baseSignalA, baseObserverA) = Signal<Int, NoError>.pipe()
+				let (baseSignalB, baseObserverB) = Signal<Int, NoError>.pipe()
+				let (baseSignalC, baseObserverC) = Signal<Int, NoError>.pipe()
 				
 				signalA = baseSignalA
 				signalB = baseSignalB
 				signalC = baseSignalC
 				
-				sinkA = baseSinkA
-				sinkB = baseSinkB
-				sinkC = baseSinkC
+				observerA = baseObserverA
+				observerB = baseObserverB
+				observerC = baseObserverC
 			}
 			
 			let zipExampleName = "zip examples"
@@ -1777,38 +1777,38 @@ class SignalSpec: QuickSpec {
 				it("should combine all set"){
 					expect(zippedValues).to(beNil())
 					
-					sinkA.sendNext(0)
+					observerA.sendNext(0)
 					expect(zippedValues).to(beNil())
 					
-					sinkB.sendNext(1)
+					observerB.sendNext(1)
 					expect(zippedValues).to(beNil())
 					
-					sinkC.sendNext(2)
+					observerC.sendNext(2)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sinkA.sendNext(10)
+					observerA.sendNext(10)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sinkA.sendNext(20)
+					observerA.sendNext(20)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sinkB.sendNext(11)
+					observerB.sendNext(11)
 					expect(zippedValues).to(equal([0, 1, 2]))
 					
-					sinkC.sendNext(12)
+					observerC.sendNext(12)
 					expect(zippedValues).to(equal([10, 11, 12]))
 				}
 				
 				it("should complete when the shorter signal has completed"){
 					expect(completed).to(beFalsy())
 					
-					sinkB.sendNext(1)
-					sinkC.sendNext(2)
-					sinkB.sendCompleted()
-					sinkC.sendCompleted()
+					observerB.sendNext(1)
+					observerC.sendNext(2)
+					observerB.sendCompleted()
+					observerC.sendCompleted()
 					expect(completed).to(beFalsy())
 					
-					sinkA.sendNext(0)
+					observerA.sendNext(0)
 					expect(completed).to(beTruthy())
 				}
 			}


### PR DESCRIPTION
When we were introducing teammates to RAC 4, there were two related sticking points that seemed like incidental complexity: the conflation of “sink” and “observer”, and the fact that `sendNext` and friends were free functions (didn’t autocomplete, looked weird, etc).

Here, I’ve done the following:
* `Event` no longer knows about sinks or observers.
* `Observer` is now its own thing akin to `SinkOf` but specific to `Event`s. There is no such thing as a sink anymore.
* `Event.sink()` becomes a convenience initializer for `Observer`.
* `send*` become methods on `Observer`
* Added some convenience overloads where raw observer/sink functions were arguments so that they can continue to be used that way for less line noise.

If you folks like this approach, I’ll update docs etc.