### PR TITLE
flatten and flatMap are now possible for all 4 combinations of Signal+SignalProducer

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -273,16 +273,7 @@ extension SignalType where Value: SignalType, Error == Value.Error {
 	/// events on inner signals.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func flatten(strategy: FlattenStrategy) -> Signal<Value.Value, Error> {
-		switch strategy {
-		case .Merge:
-			return self.map(SignalProducer.init).merge()
-
-		case .Concat:
-			return self.map(SignalProducer.init).concat()
-
-		case .Latest:
-			return self.map(SignalProducer.init).switchToLatest()
-		}
+		return self.map(SignalProducer.init).flatten(strategy)
 	}
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -372,6 +372,9 @@ extension SignalProducerType {
 	/// the given Signal operator to _every_ Signal created from the two
 	/// producers, just as if the operator had been applied to each Signal
 	/// yielded from start().
+	///
+	/// Note: starting the returned producer will start the receiver of the operator,
+	/// which may not be adviseable for some operators.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func lift<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
 		return { otherProducer in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -19,6 +19,17 @@ public struct SignalProducer<Value, Error: ErrorType> {
 
 	private let startHandler: (Signal<Value, Error>.Observer, CompositeDisposable) -> ()
 
+	/// Initializes a SignalProducer that will emit the same events as the given signal.
+	///
+	/// If the Disposable returned from start() is disposed or a terminating
+	/// event is sent to the observer, the given signal will be
+	/// disposed.
+	public init<S: SignalType where S.Value == Value, S.Error == Error>(signal: S) {
+		self.init { observer, disposable in
+			disposable += signal.observe(observer)
+		}
+	}
+
 	/// Initializes a SignalProducer that will invoke the given closure once
 	/// for each invocation of start().
 	///

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1136,7 +1136,7 @@ extension SignalProducerType {
 						sendCompleted(observer)
 					case .Interrupted:
 						sendInterrupted(observer)
-					default:
+					case .Next:
 						break
 					}
 				}


### PR DESCRIPTION
Fixes #2422. This is a follow up to #2439.

## Description:

Before this change, `flatten` and `flatMap` were only defined for `Signal<SignalProducer<T, E>, E>` and `SignalProducer<SignalProducer<T, E>, E>`. However, after a long conversation with @andymatuschak (who helped a lot and with whom I pair programmed to make this change) we realize that there's no reason why these operators should not exist for `Signal<Signal<T, E>, E>` and `Signal<Signal<T, E>, E>`.

## Why:
We came up with some examples for when it would be useful:
- `Signal<SignalProducer<T, E>, E>.flatten`:
  - `.Merge`: You want to flatten the results of some network request that gets created upon tapping on a button.
  - `.Concat`: same as previous example, except you want results to come in order. 
  - `.Latest`: same as previous example, except you want to cancel any request that's already running

- `Signal<Signal<T, E>, E>.flatten`:
  - `.Merge`: You want to flatten the values created by some clock created upon tapping on a button. Both of these things, button taps, and a "clock" are *hot* streams.
  - `.Concat`: Same as the previous example, but you want to wait for previous "clocks" to finish ticking.
  - `.Latest`: Same as previous example, but you only want to observe the _ticks_ from the last "clock".

Due to the absence of these operators (as well as those introduced in #2439), we believe that `SignalProducer` was being favored, which is the opposite of what we wanted to accomplish with `RAC 3/4`: limit side effects by encouraging the usage of *hot* `Signal`s.

## Notes:
- I haven't added any tests for these new operators since we managed to keep them all defined in terms of the canonical implementation: `Signal<SignalProducer<T, E>, E>.flatten`.
- I added an initializer to `SignalProducer` that constructs a producer given a `Signal`, with no side-effects.