### PR TITLE
Fixed infinite recursion in RACScheduler.schedule

### DIFF
--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -15,7 +15,8 @@ extension RACScheduler: DateSchedulerType {
 	}
 
 	public func schedule(action: () -> ()) -> Disposable? {
-		return (self.schedule(action) as RACDisposable) as Disposable?
+		let disposable: RACDisposable = self.schedule(action) // Call the Objective-C implementation
+		return disposable as Disposable?
 	}
 
 	public func scheduleAfter(date: NSDate, action: () -> ()) -> Disposable? {

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -15,7 +15,7 @@ extension RACScheduler: DateSchedulerType {
 	}
 
 	public func schedule(action: () -> ()) -> Disposable? {
-		return self.schedule(action)
+		return (self.schedule(action) as RACDisposable) as Disposable?
 	}
 
 	public func scheduleAfter(date: NSDate, action: () -> ()) -> Disposable? {

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -14,6 +14,45 @@ import XCTest
 
 class ObjectiveCBridgingSpec: QuickSpec {
 	override func spec() {
+		describe("RACScheduler") {
+			var originalScheduler: RACTestScheduler!
+			var scheduler: DateSchedulerType!
+
+			beforeEach {
+				originalScheduler = RACTestScheduler()
+				scheduler = originalScheduler as DateSchedulerType
+			}
+
+			it("gives current date") {
+				expect(scheduler.currentDate).to(beCloseTo(NSDate()))
+			}
+
+			it("schedules actions") {
+				var actionRan: Bool = false
+
+				scheduler.schedule {
+					actionRan = true
+				}
+
+				expect(actionRan) == false
+				originalScheduler.step()
+				expect(actionRan) == true
+			}
+
+			it("does not invoke action if disposed") {
+				var actionRan: Bool = false
+
+				let disposable: Disposable? = scheduler.schedule {
+					actionRan = true
+				}
+
+				expect(actionRan) == false
+				disposable!.dispose()
+				originalScheduler.step()
+				expect(actionRan) == false
+			}
+		}
+
 		describe("RACSignal.toSignalProducer") {
 			it("should subscribe once per start()") {
 				var subscriptions = 0


### PR DESCRIPTION
We ran into this infinite recursion in the Khan Academy app, and @andymatuschak traced down the issue to this.
I added (previously lacking!) test coverage for this and fixed the implementation.