### PR TITLE
added support for more Type flexible takeUntil and sampleOn

### DIFF
--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -175,6 +175,12 @@ public func sendError<Value, Err: ErrorType>(sink: Event<Value, Err>.Sink, _ err
 	sink(.Error(error))
 }
 
+/// Puts an `Error` event into the given sink.
+public func sendError<Value>(sink: Event<Value, NoError>.Sink, _ error: NoError) {
+	assertionFailure("Don't send an Error to a Signal of type NoError NoError!")
+	sink(.Error(error))
+}
+
 /// Puts a `Completed` event into the given sink.
 public func sendCompleted<Value, Err: ErrorType>(sink: Event<Value, Err>.Sink) {
 	sink(.Completed)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -829,7 +829,7 @@ extension SignalType {
 	/// multiple times) by `sampler`, then complete once both input signals have
 	/// completed, or interrupt if either input signal is interrupted.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
-	public func sampleOn(sampler: Signal<(), NoError>) -> Signal<Value, Error> {
+	public func sampleOn<S: SignalType where S.Error == NoError>(sampler: S) -> Signal<Value, Error> {
 		return Signal { observer in
 			let state = Atomic(SampleState<Value>())
 			let disposable = CompositeDisposable()
@@ -886,7 +886,7 @@ extension SignalType {
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned signal will complete.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
-	public func takeUntil(trigger: Signal<(), NoError>) -> Signal<Value, Error> {
+	public func takeUntil<S : SignalType where S.Error == NoError>(trigger: S) -> Signal<Value, Error> {
 		return Signal { observer in
 			let disposable = CompositeDisposable()
 			disposable += self.observe(observer)

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -373,7 +373,7 @@ extension SignalProducerType {
 	/// producers, just as if the operator had been applied to each Signal
 	/// yielded from start().
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func lift<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
+	public func lift<PType : SignalProducerType, V, G>(transform: Signal<Value, Error> -> Signal<PType.Value, PType.Error> -> Signal<V, G>) -> PType -> SignalProducer<V, G> {
 		return { otherProducer in
 			return SignalProducer { observer, outerDisposable in
 				self.startWithSignal { signal, disposable in
@@ -477,14 +477,14 @@ extension SignalProducerType {
 	/// multiple times) by `sampler`, then complete once both input producers have
 	/// completed, or interrupt if either input producer is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
+	public func sampleOn<PType: SignalProducerType where PType.Error == NoError>(sampler: PType) -> SignalProducer<Value, Error> {
 		return lift(Signal.sampleOn)(sampler)
 	}
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned producer will complete.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func takeUntil(trigger: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
+	public func takeUntil<PType: SignalProducerType where PType.Error == NoError>(trigger: PType) -> SignalProducer<Value, Error> {
 		return lift(Signal.takeUntil)(trigger)
 	}
 


### PR DESCRIPTION
The Event type can be anything now.  So if you are using a Signal that isn' t (), than it still works fine.
ErrorType must still be NoError.

Added an assertionFailure of you you to call SendError() on a Signal.Sink of NoError
