### PR TITLE
Added support for using faster OSAtomicCompareAndSwap32

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0995ECFE1BCC7C4B000AE3F1 /* AtomicSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EE19EF2A7700984962 /* AtomicSpec.swift */; settings = {ASSET_TAGS = (); }; };
+		0995ECFF1BCC7C4C000AE3F1 /* AtomicSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EE19EF2A7700984962 /* AtomicSpec.swift */; settings = {ASSET_TAGS = (); }; };
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
 		579504331BB8A34200A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
@@ -2406,6 +2408,7 @@
 				D03766C919EDA60000A782A9 /* NSObjectRACPropertySubscribingSpec.m in Sources */,
 				D03766C319EDA60000A782A9 /* NSObjectRACDeallocatingSpec.m in Sources */,
 				D03766BD19EDA60000A782A9 /* NSEnumeratorRACSequenceAdditionsSpec.m in Sources */,
+				0995ECFE1BCC7C4B000AE3F1 /* AtomicSpec.swift in Sources */,
 				D037670119EDA60000A782A9 /* RACSubclassObject.m in Sources */,
 				D03766CD19EDA60000A782A9 /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,
 				D037671519EDA60000A782A9 /* RACTupleSpec.m in Sources */,
@@ -2585,6 +2588,7 @@
 				D03766C419EDA60000A782A9 /* NSObjectRACDeallocatingSpec.m in Sources */,
 				D03766BE19EDA60000A782A9 /* NSEnumeratorRACSequenceAdditionsSpec.m in Sources */,
 				D037672019EDA60000A782A9 /* UIButtonRACSupportSpec.m in Sources */,
+				0995ECFF1BCC7C4C000AE3F1 /* AtomicSpec.swift in Sources */,
 				D0C3132519EF2D9700984962 /* RACTestUIButton.m in Sources */,
 				D037670219EDA60000A782A9 /* RACSubclassObject.m in Sources */,
 				D03766CE19EDA60000A782A9 /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -72,3 +72,206 @@ internal final class Atomic<Value> {
 		return result
 	}
 }
+
+
+protocol AtomicInteger {
+	
+	typealias IntegerStorageType // should be Int32 or Int64
+	
+	func ifEqualTo(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool
+	func ifEqualToBarrier(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool
+	
+	var value : IntegerStorageType { get }
+	
+	init(_ value: IntegerStorageType)
+	
+}
+
+internal final class AtomicInt32 : AtomicInteger {
+	
+	typealias IntegerStorageType = Int32
+	
+	var __value : IntegerStorageType
+	
+	func increment() -> IntegerStorageType {
+		return OSAtomicIncrement32(&__value)
+	}
+	func decrement() -> IntegerStorageType {
+		return OSAtomicDecrement32(&__value)
+	}
+	func incrementBarrier() -> IntegerStorageType {
+		return OSAtomicIncrement32Barrier(&__value)
+	}
+	func decrementBarrier() -> IntegerStorageType {
+		return OSAtomicDecrement32Barrier(&__value)
+	}
+	func add(theAmount: IntegerStorageType) -> IntegerStorageType {
+		return OSAtomicAdd32(theAmount,&__value)
+	}
+	func addBarrier(theAmount: IntegerStorageType) -> IntegerStorageType {
+		return OSAtomicAdd32Barrier(theAmount,&__value)
+	}
+	func ifEqualTo(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool {
+		return OSAtomicCompareAndSwap32(value,thenReplaceWith,&__value)
+	}
+	func ifEqualToBarrier(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool {
+		return OSAtomicCompareAndSwap32Barrier(value,thenReplaceWith,&__value)
+	}
+	/// Atomically gets or sets the value of the variable.
+	var value: IntegerStorageType {
+		get {
+			OSMemoryBarrier()
+			return __value
+		}
+		set(newValue) {
+			self.modify { _ in newValue }
+		}
+	}
+	
+   // Initializes the variable with the given initial value.
+	init(_ value: Int32) {
+		__value = value
+	}
+}
+
+internal final class AtomicInt64 : AtomicInteger {
+	
+	typealias IntegerStorageType = Int64
+	
+	var __value : IntegerStorageType
+	
+	func increment() -> IntegerStorageType {
+		return OSAtomicIncrement64(&__value)
+	}
+	func decrement() -> IntegerStorageType {
+		return OSAtomicDecrement64(&__value)
+	}
+	func incrementBarrier() -> IntegerStorageType {
+		return OSAtomicIncrement64Barrier(&__value)
+	}
+	func decrementBarrier() -> IntegerStorageType {
+		return OSAtomicDecrement64Barrier(&__value)
+	}
+	func add(theAmount: IntegerStorageType) -> IntegerStorageType {
+		return OSAtomicAdd64(theAmount,&__value)
+	}
+	func addBarrier(theAmount: IntegerStorageType) -> IntegerStorageType {
+		return OSAtomicAdd64Barrier(theAmount,&__value)
+	}
+	func ifEqualTo(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool {
+		return OSAtomicCompareAndSwap64(value,thenReplaceWith,&__value)
+	}
+	func ifEqualToBarrier(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool {
+		return OSAtomicCompareAndSwap64Barrier(value,thenReplaceWith,&__value)
+	}
+	/// Atomically gets or sets the value of the variable.
+	var value: IntegerStorageType {
+		get {
+			OSMemoryBarrier()
+			return __value
+		}
+		set(newValue) {
+			self.modify { _ in newValue }
+		}
+	}
+	
+	// Initializes the variable with the given initial value.
+	init(_ value: Int64) {
+		__value = value
+	}
+}
+
+extension Int32 {
+	init(bool : Bool) {
+		self = bool ? 1 : 0
+	}
+}
+
+extension Bool : IntegerLiteralConvertible  {
+	public typealias IntegerLiteralType = Int32
+	public init(integerLiteral value: Int32) {
+		self = value != 0
+	}
+}
+
+
+internal final class AtomicBool : AtomicInteger {
+	
+	typealias IntegerStorageType = Bool
+	
+	var __value : Int32
+	
+	func ifEqualTo(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool {
+		assert(  {
+				let currentValue = self.rawValue
+				return ((currentValue == 0) || (currentValue == 1))
+			}(), "rawValue isn't 1 or 0, so isEqualTo may fail!")
+		return OSAtomicCompareAndSwap32(Int32(bool: value),Int32(bool:thenReplaceWith),&__value)
+	}
+	func ifEqualToBarrier(value : IntegerStorageType, thenReplaceWith : IntegerStorageType) -> Bool {
+		assert(  {
+			let currentValue = self.rawValue
+			return ((currentValue == 0) || (currentValue == 1))
+			}(), "rawValue isn't 1 or 0, so isEqualTo may fail!")
+		return OSAtomicCompareAndSwap32Barrier(Int32(bool: value),Int32(bool:thenReplaceWith),&__value)
+	}
+	
+	/// Atomically gets or sets the value of the variable.
+	var rawValue: Int32 {
+		get {
+			OSMemoryBarrier()
+			return __value
+		}
+	}
+
+	
+	/// Atomically gets or sets the value of the variable.
+	var value: IntegerStorageType {
+		get {
+			return rawValue != 0
+		}
+		set(newValue) {
+			self.modify { _ in newValue }
+		}
+	}
+	
+	// Initializes the variable with the given initial value.
+	init(_ value: Bool) {
+		__value = Int32(bool: value)
+	}
+}
+
+
+
+extension AtomicInteger where IntegerStorageType : IntegerLiteralConvertible {
+
+	/// Atomically replaces the contents of the variable.
+	///
+	/// Returns the old value.
+	func swap(newValue: IntegerStorageType) -> IntegerStorageType {
+		return modify { _ in newValue }
+	}
+	
+	func modifyTry(@noescape action: IntegerStorageType -> IntegerStorageType) -> (Bool,IntegerStorageType) {
+		let currentValue = self.value
+		let newValue = action(currentValue)
+		let success = ifEqualTo(currentValue, thenReplaceWith: newValue)
+		return (success,currentValue)
+	}
+
+	/// Atomically modifies the variable.
+	///
+	/// Returns the old value.
+	func modify(@noescape action: IntegerStorageType -> IntegerStorageType) -> IntegerStorageType {
+		
+		var done = false
+		var currentValue : IntegerStorageType = 0
+		while !done {
+			(done,currentValue) = modifyTry(action)
+		}
+		return currentValue
+	}
+	
+	
+
+}

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -18,7 +18,7 @@ public protocol Disposable {
 /// A disposable that only flips `disposed` upon disposal, and performs no other
 /// work.
 public final class SimpleDisposable: Disposable {
-	private let _disposed = Atomic(false)
+	private let _disposed = AtomicBool(false)
 
 	public var disposed: Bool {
 		return _disposed.value

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -34,7 +34,7 @@ public final class Signal<Value, Error: ErrorType> {
 		let generatorDisposable = SerialDisposable()
 
 		/// When set to `true`, the Signal should interrupt as soon as possible.
-		let interrupted = Atomic(false)
+		let interrupted = AtomicBool(false)
 
 		let sink: Observer = { event in
 			if case .Interrupted = event {

--- a/ReactiveCocoaTests/Swift/AtomicSpec.swift
+++ b/ReactiveCocoaTests/Swift/AtomicSpec.swift
@@ -8,7 +8,7 @@
 
 import Nimble
 import Quick
-import ReactiveCocoa
+@testable import ReactiveCocoa
 
 class AtomicSpec: QuickSpec {
 	override func spec() {
@@ -35,13 +35,6 @@ class AtomicSpec: QuickSpec {
 			expect(atomic.value).to(equal(2))
 		}
 
-		it("should modify the value and return some data") {
-			let (orig, data) = atomic.modify { ($0 + 1, "foobar") }
-			expect(orig).to(equal(1))
-			expect(data).to(equal("foobar"))
-			expect(atomic.value).to(equal(2))
-		}
-
 		it("should perform an action with the value") {
 			let result: Bool = atomic.withValue { $0 == 1 }
 			expect(result).to(beTruthy())
@@ -49,3 +42,93 @@ class AtomicSpec: QuickSpec {
 		}
 	}
 }
+
+class AtomicInt32Spec : QuickSpec {
+	override func spec() {
+		var atomic: AtomicInt32!
+		
+		beforeEach {
+			atomic = AtomicInt32(1)
+		}
+		
+		it("should read and write the value directly") {
+			expect(atomic.value).to(equal(1))
+			
+			atomic.value = 2
+			expect(atomic.value).to(equal(2))
+		}
+		
+		it("should swap the value atomically") {
+			expect(atomic.swap(2)).to(equal(1))
+			expect(atomic.value).to(equal(2))
+		}
+		
+		it("should modify the value atomically") {
+			expect(atomic.modify({ $0 + 1 })).to(equal(1))
+			expect(atomic.value).to(equal(2))
+		}
+		
+	}
+}
+
+class AtomicInt64Spec : QuickSpec {
+	override func spec() {
+		var atomic: AtomicInt64!
+		
+		beforeEach {
+			atomic = AtomicInt64(1)
+		}
+		
+		it("should read and write the value directly") {
+			expect(atomic.value).to(equal(1))
+			
+			atomic.value = 2
+			expect(atomic.value).to(equal(2))
+		}
+		
+		it("should swap the value atomically") {
+			expect(atomic.swap(2)).to(equal(1))
+			expect(atomic.value).to(equal(2))
+		}
+		
+		it("should modify the value atomically") {
+			expect(atomic.modify({ $0 + 1 })).to(equal(1))
+			expect(atomic.value).to(equal(2))
+		}
+		
+	}
+}
+
+class AtomicBoolSpec : QuickSpec {
+	override func spec() {
+		var atomic: AtomicBool!
+		
+		beforeEach {
+			atomic = AtomicBool(true)
+		}
+		
+		it("should read and write the value directly") {
+			expect(atomic.value).to(equal(true))
+			
+			atomic.value = false
+			expect(atomic.value).to(equal(false))
+		}
+		
+		it("should swap the value atomically") {
+			expect(atomic.swap(false)).to(equal(true))
+			expect(atomic.value).to(equal(false))
+		}
+		
+		it("should modify the value atomically") {
+			expect(atomic.modify({ !$0 })).to(equal(true))
+			expect(atomic.value).to(equal(false))
+		}
+		
+	}
+}
+
+
+
+
+
+


### PR DESCRIPTION
Added support for using faster OSAtomicCompareAndSwap32 to Atomic.swift

For sharing Ints, Bools, it's even faster to use OSAtomicCompareAndSwap32 etc.  Which should result in faster composition of Signals.

Added AtomicInt32, AtomicInt64 and AtomicBool.
Changed the Signal disposable Atomic<Bool> to use AtomicBool()

Added the @testable import and added AtomicSpec.swift BACK into the test targets.