### PR TITLE
Add overloaded version of sampleOn that collects values.

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -813,7 +813,7 @@ extension SignalType where Value: EventType, Error == NoError {
 }
 
 private struct SampleState<Value> {
-	var latestValue: Value? = nil
+	var latestValues: [Value] = []
 	var signalCompleted: Bool = false
 	var samplerCompleted: Bool = false
 }
@@ -830,6 +830,20 @@ extension SignalType {
 	/// completed, or interrupt if either input signal is interrupted.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func sampleOn(sampler: Signal<(), NoError>) -> Signal<Value, Error> {
+		return sampleOn(sampler)
+			.combinePrevious([])
+			.map { $1.last ?? $0.last }
+			.ignoreNil()
+	}
+	
+	/// Forwards an array of values sent from `signal` since the last time
+	/// `sampler` sent a Next event.
+	///
+	/// Returns a signal that will yield an array of values from `signal`,
+	/// sampled by `sampler`, then complete once both input signals have
+	/// completed, or interrupt if either input signal is interrupted.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func sampleOn(sampler: Signal<(), NoError>) -> Signal<[Value], Error> {
 		return Signal { observer in
 			let state = Atomic(SampleState<Value>())
 			let disposable = CompositeDisposable()
@@ -838,7 +852,7 @@ extension SignalType {
 				switch event {
 				case let .Next(value):
 					state.modify { (var st) in
-						st.latestValue = value
+						st.latestValues.append(value)
 						return st
 					}
 				case let .Error(error):
@@ -860,8 +874,10 @@ extension SignalType {
 			disposable += sampler.observe { event in
 				switch event {
 				case .Next:
-					if let value = state.value.latestValue {
-						sendNext(observer, value)
+					sendNext(observer, state.value.latestValues)
+					state.modify { (var st) in
+						st.latestValues = []
+						return st
 					}
 				case .Completed:
 					let oldState = state.modify { (var st) in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -510,17 +510,6 @@ extension SignalProducerType {
 		return lift(Signal.sampleOn)(sampler)
 	}
 	
-	/// Forwards an array of values sent from `signal` since the last time
-	/// `sampler` sent a Next event.
-	///
-	/// Returns a signal that will yield an array of values from `signal`,
-	/// sampled by `sampler`, then complete once both input signals have
-	/// completed, or interrupt if either input signal is interrupted.
-	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<[Value], Error> {
-		return lift(Signal.sampleOn)(sampler)
-	}
-
 	/// Forwards the latest value from `self` whenever `sampler` sends a Next
 	/// event.
 	///
@@ -532,6 +521,17 @@ extension SignalProducerType {
 	/// completed, or interrupt if either input is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func sampleOn(sampler: Signal<(), NoError>) -> SignalProducer<Value, Error> {
+		return lift(Signal.sampleOn)(sampler)
+	}
+	
+	/// Forwards an array of values sent from `signal` since the last time
+	/// `sampler` sent a Next event.
+	///
+	/// Returns a signal that will yield an array of values from `signal`,
+	/// sampled by `sampler`, then complete once both input signals have
+	/// completed, or interrupt if either input signal is interrupted.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<[Value], Error> {
 		return lift(Signal.sampleOn)(sampler)
 	}
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -524,10 +524,10 @@ extension SignalProducerType {
 		return lift(Signal.sampleOn)(sampler)
 	}
 	
-	/// Forwards an array of values sent from `signal` since the last time
+	/// Forwards an array of values sent from `self` since the last time
 	/// `sampler` sent a Next event.
 	///
-	/// Returns a signal that will yield an array of values from `signal`,
+	/// Returns a producer that will yield an array of values from `self`,
 	/// sampled by `sampler`, then complete once both input signals have
 	/// completed, or interrupt if either input signal is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -509,7 +509,7 @@ extension SignalProducerType {
 	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
 		return lift(Signal.sampleOn)(sampler)
 	}
-	
+
 	/// Forwards the latest value from `self` whenever `sampler` sends a Next
 	/// event.
 	///

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -534,6 +534,17 @@ extension SignalProducerType {
 	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<[Value], Error> {
 		return lift(Signal.sampleOn)(sampler)
 	}
+	
+	/// Forwards an array of values sent from `self` since the last time
+	/// `sampler` sent a Next event.
+	///
+	/// Returns a producer that will yield an array of values from `self`,
+	/// sampled by `sampler`, then complete once both input signals have
+	/// completed, or interrupt if either input signal is interrupted.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func sampleOn(sampler: Signal<(), NoError>) -> SignalProducer<[Value], Error> {
+		return lift(Signal.sampleOn)(sampler)
+	}
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned producer will complete.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -509,6 +509,17 @@ extension SignalProducerType {
 	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
 		return lift(Signal.sampleOn)(sampler)
 	}
+	
+	/// Forwards an array of values sent from `signal` since the last time
+	/// `sampler` sent a Next event.
+	///
+	/// Returns a signal that will yield an array of values from `signal`,
+	/// sampled by `sampler`, then complete once both input signals have
+	/// completed, or interrupt if either input signal is interrupted.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func sampleOn(sampler: SignalProducer<(), NoError>) -> SignalProducer<[Value], Error> {
+		return lift(Signal.sampleOn)(sampler)
+	}
 
 	/// Forwards the latest value from `self` whenever `sampler` sends a Next
 	/// event.


### PR DESCRIPTION
These changes aim to implement the idea conveyed in #2469 The Right Way™.

As mentioned in the linked issue, this could also be added for `throttle` which I'd be happy to submit changes for.

Please review :pray: