### PR TITLE
MutableCollectionProperty

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -130,6 +130,155 @@ extension MutableProperty: SinkType {
 	}
 }
 
+public enum CollectionChange<T> {
+    case Deletion(Int, T)
+    case Addition(Int, T)
+    case Insertion(Int, T)
+    case Replaced(Int, T)
+    case Replacement([T])
+    case StartChange
+    case EndChange
+}
+
+public final class MutableCollectionProperty<T>: PropertyType {
+
+    public typealias Value = [T]
+
+    
+    // MARK: - Private attributes
+
+    private let _valueObserver: Signal<Value, NoError>.Observer
+    private let _changesObserver: Signal<CollectionChange<Value.Element>, NoError>.Observer
+    private var _value: Value
+    private let _lock = NSRecursiveLock()
+
+    // MARK: - Public Attributes
+
+    public var producer: SignalProducer<Value, NoError>
+    public var changes: SignalProducer<CollectionChange<Value.Element>, NoError>
+    public var value: Value {
+        get {
+            let value = _value
+            return value
+        }
+        set {
+            _value = newValue
+            sendNext(_valueObserver, newValue)
+            sendNext(_changesObserver, .StartChange)
+            sendNext(_changesObserver, .Replacement(_value))
+            sendNext(_changesObserver, .EndChange)
+        }
+    }
+
+    // MARK: - Init/Deinit
+
+    public init(_ initialValue: Value) {
+        _lock.name = "org.reactivecocoa.ReactiveCocoa.MutableCollectionProperty"
+        _value = initialValue
+        (producer, _valueObserver) = SignalProducer<Value, NoError>.buffer(1)
+        (changes, _changesObserver) = SignalProducer<CollectionChange<Value.Element>, NoError>.buffer(1)
+    }
+
+    deinit {
+        sendCompleted(_valueObserver)
+        sendCompleted(_changesObserver)
+    }
+    
+    
+    // MARK: - Public
+
+    public func removeFirst() {
+        if (_value.count == 0) { return }
+        _lock.lock()
+        let deletedElement = _value.removeFirst()
+        sendNext(_changesObserver, .StartChange)
+        sendNext(_changesObserver, CollectionChange.Deletion(0, deletedElement))
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+
+    public func removeLast() {
+        _lock.lock()
+        if (_value.count == 0) { return }
+        let index = _value.count - 1
+        let deletedElement = _value.removeLast()
+        sendNext(_changesObserver, .StartChange)
+        sendNext(_changesObserver, .Deletion(index, deletedElement))
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+    
+    public func removeAll() {
+        _lock.lock()
+        sendNext(_changesObserver, .StartChange)
+        for i in (0...(_value.count-1)).reverse() {
+            let object = _value[i]
+            _value.removeAtIndex(i)
+            sendNext(_changesObserver, CollectionChange.Deletion(_value.count, object))
+        }
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+
+    public func removeAtIndex(index: Int) {
+        _lock.lock()
+        let deletedElement = _value.removeAtIndex(index)
+        sendNext(_changesObserver, .StartChange)
+        sendNext(_changesObserver, CollectionChange.Deletion(index, deletedElement))
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+    
+    public func append(element: T) {
+        _lock.lock()
+        _value.append(element)
+        sendNext(_changesObserver, .StartChange)
+        sendNext(_changesObserver, CollectionChange.Addition(_value.count - 1, element))
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+    
+    public func appendContentsOf(elements: [T]) {
+        _lock.lock()
+        sendNext(_changesObserver, .StartChange)
+        for element in elements {
+            _value.append(element)
+            sendNext(_changesObserver, CollectionChange.Addition(_value.count - 1, element))
+        }
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+    
+    public func insert(newElement: T, atIndex index: Int) {
+        _lock.lock()
+        sendNext(_changesObserver, .StartChange)
+        _value.insert(newElement, atIndex: index)
+        sendNext(_changesObserver, CollectionChange.Insertion(index, newElement))
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+    
+    public func replace(subRange: Range<Int>, with elements: [T]) {
+        _lock.lock()
+        precondition(subRange.startIndex + subRange.count <= _value.count, "Range out of bounds")
+        sendNext(_changesObserver, .StartChange)
+        for (index, element) in elements.enumerate() {
+            _value.replaceRange(Range<Int>(start: subRange.startIndex+index, end: subRange.startIndex+index+1), with: [element])
+            sendNext(_changesObserver, CollectionChange.Replaced(subRange.startIndex+index, element))
+        }
+        sendNext(_changesObserver, .EndChange)
+        sendNext(_valueObserver, _value)
+        _lock.unlock()
+    }
+}
+
 /// Wraps a `dynamic` property, or one defined in Objective-C, using Key-Value
 /// Coding and Key-Value Observing.
 ///

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -158,6 +158,461 @@ class PropertySpec: QuickSpec {
 			}
 		}
 
+		describe("MutableCollectionProperty") {
+			describe("initialization") {
+
+	            it("should properly update the value once initialized") {
+	                let array: [String] = ["test1, test2"]
+	                let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                expect(property.value) == array
+	            }
+	        }
+
+	        describe("updates") {
+
+	            context("full update") {
+
+	                it("should notify the main producer") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: { event in
+	                            switch event {
+	                            case .Next(_):
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.value = ["test2", "test3"]
+	                    })
+	                }
+
+	                it("should notify the changes producer with the replaced enum type") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let newArray: [String] = ["test2", "test3"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: {
+	                        (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Replacement(let newValue):
+	                                    expect(newValue) == newArray
+	                                    expect(i) == 1
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                                i++
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.value = newArray
+	                    })
+	                }
+	            }
+
+	        }
+
+	        describe("deletion") {
+
+	            context("delete at a given index") {
+
+	                it("should notify the main producer") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: {
+	                        (done) -> Void in
+	                        property.producer.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let newValue):
+	                                expect(newValue) == ["test1"]
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.removeAtIndex(1)
+	                    })
+	                }
+
+	                it("should notify the changes producer with the right type") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: {
+	                        (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Deletion(let index, let element):
+	                                    expect(i) == 1
+	                                    expect(index) == 1
+	                                    expect(element) == "test2"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.removeAtIndex(1)
+	                    })
+	                }
+	            }
+	            
+	            context("deleting the last element", {
+	                
+	                it("should notify the deletion to the main producer") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                expect(change) == ["test1"]
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.removeLast()
+	                    })
+	                }
+	                
+	                it("should notify the deletion to the changes producer with the right type") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Deletion(let index, let element):
+	                                    expect(i) == 1
+	                                    expect(index) == 1
+	                                    expect(element) == "test2"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.removeLast()
+	                    })
+	                }
+	                
+	            })
+	            
+	            context("deleting the first element", {
+	                it("should notify the deletion to the main producer") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                expect(change) == ["test2"]
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.removeFirst()
+	                    })
+	                }
+	                
+	                it("should notify the deletion to the changes producer with the right type") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Deletion(let index, let element):
+	                                    expect(i) == 1
+	                                    expect(index) == 0
+	                                    expect(element) == "test1"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.removeFirst()
+	                    })
+	                }
+	            })
+	            
+	            context("remove all elements", {
+	                it("should notify the deletion to the main producer") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                expect(change) == []
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.removeAll()
+	                    })
+	                }
+	                
+	                it("should notify the deletion to the changes producer with the right type") {
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Deletion(let index, let element):
+	                                    expect(i) >= 1
+	                                    expect(index) == array.count - i
+	                                    expect(element) == "test\(array.count - (i-1))"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.removeAll()
+	                    })
+	                }
+	            })
+
+	        }
+	        
+	        context("adding elements") { () -> Void in
+	            
+	            context("appending elements individually", { () -> Void in
+	                
+	                it("should notify about the change to the main producer", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: { (event) in
+	                            switch event {
+	                            case .Next(let next):
+	                                expect(next) == ["test1", "test2", "test3"]
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.append("test3")
+	                    })
+	                })
+	                
+	                it("should notify the changes producer about the adition", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Addition(let index, let element):
+	                                    expect(i) == 1
+	                                    expect(index) == 2
+	                                    expect(element) == "test3"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.append("test3")
+	                    })
+	                })
+	                
+	            })
+	            
+	            context("appending elements from another array", { () -> Void in
+	                
+	                it("should notify about the change to the main producer", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: { (event) in
+	                            switch event {
+	                            case .Next(let next):
+	                                expect(next) == ["test1", "test2", "test3", "test4"]
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.appendContentsOf(["test3", "test4"])
+	                    })
+	                })
+	                
+	                it("should notify the changes producer about the adition", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Addition(let index, let element):
+	                                    expect(i) >= 1
+	                                    expect(index) == i+1
+	                                    expect(element) == "test\(i+2)"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.appendContentsOf(["test3", "test4"])
+	                    })
+	                })
+	                
+	            })
+	            
+	            context("inserting elements", { () -> Void in
+	                
+	                it("should notify about the change to the main producer", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: { (event) in
+	                            switch event {
+	                            case .Next(let next):
+	                                expect(next) == ["test0", "test1", "test2"]
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.insert("test0", atIndex: 0)
+	                    })
+	                })
+	                
+	                it("should notify the changes producer about the adition", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Insertion(let index, let element):
+	                                    expect(i) == 1
+	                                    expect(index) == 0
+	                                    expect(element) == "test0"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.insert("test0", atIndex: 0)
+	                    })
+	                })
+	                
+	            })
+	            
+	            context("replacing elements", { () -> Void in
+	                
+	                it("should notify about the change to the main producer", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        property.producer.on(event: { (event) in
+	                            switch event {
+	                            case .Next(let next):
+	                                expect(next) == ["test3", "test4"]
+	                                done()
+	                            default: break
+	                            }
+	                        }).start()
+	                        property.replace(Range<Int>(start: 0, end: 1), with: ["test3", "test4"])
+	                    })
+	                })
+	                
+	                it("should notify the changes producer about the adition", closure: { () -> () in
+	                    let array: [String] = ["test1", "test2"]
+	                    let property: MutableCollectionProperty<String> = MutableCollectionProperty(array)
+	                    waitUntil(action: { (done) -> Void in
+	                        var i: Int = 0
+	                        property.changes.on(event: {
+	                            event in
+	                            switch event {
+	                            case .Next(let change):
+	                                switch change {
+	                                case .StartChange:
+	                                    expect(i) == 0
+	                                case .Replaced(let index, let element):
+	                                    expect(i) >= 1
+	                                    expect(index) == i - 1
+	                                    expect(element) == "test\(index+3)"
+	                                case .EndChange:
+	                                    done()
+	                                default: break
+	                                }
+	                            default: break
+	                            }
+	                            i++
+	                        }).start()
+	                        property.replace(Range<Int>(start: 0, end: 1), with: ["test3", "test4"])
+	                    })
+	                })
+	                
+	            })
+	            
+	        }
+		}
+
 		describe("DynamicProperty") {
 			var object: ObservableObject!
 			var property: DynamicProperty!


### PR DESCRIPTION
### What?
I thought it would be useful having a custom property in ReactiveCocoa for collections that notified about changes in the collection with more details *(elements updated, removed, inserted, ...)*. That way if you use the property to represent for example a TableViewCollection you can update on the view only the elements that have actually changed.

I originally implemented the feature on this repository https://github.com/gitdoapp/RAC-MutableCollectionProperty

The component  is *fully tested*.  