### PR TITLE
Remove [at]testable from BagSpec

### DIFF
--- a/ReactiveCocoaTests/Swift/BagSpec.swift
+++ b/ReactiveCocoaTests/Swift/BagSpec.swift
@@ -8,7 +8,7 @@
 
 import Nimble
 import Quick
-@testable import ReactiveCocoa
+import ReactiveCocoa
 
 class BagSpec: QuickSpec {
 	override func spec() {


### PR DESCRIPTION
`Bag` is now public.