### PR TITLE
Fix explicit requirements of 'self.' by XCode7.1 Swift Compiler

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -128,7 +128,7 @@ public final class Signal<T, E: ErrorType> {
 
 		if let token = token {
 			return ActionDisposable {
-				atomicObservers.modify { (var observers) in
+				self.atomicObservers.modify { (var observers) in
 					observers?.removeValueForToken(token)
 					return observers
 				}


### PR DESCRIPTION
To fix this error which landed with the new XCode 7.1 Swift Compiler 

```
The following build commands failed:
	CompileSwift normal x86_64
	CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
(2 failures)
/Users/Project/Carthage/Checkouts/ReactiveCocoa/ReactiveCocoa/Swift/Signal.swift:131:5: error: reference to property 'atomicObservers' in closure requires explicit 'self.' to make capture semantics explicit
A shell task failed with exit code 65:
** BUILD FAILED **
```