### PR TITLE
Event.Error → Event.Failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ If you're new to the Swift API and migrating from RAC 2, start with the
 ReactiveCocoa 4.0 targets Swift 2 and the current focus is on leveraging the
 improvements from Swift 1.2 to provide a simpler API.
 
+## Alpha 3
+
+#### Renamed Event.Error to Event.Failed
+
+The `Error` case of `Event` has changed to `Failed`. This aims to help clarify
+the terminating nature of failure/error events and puts them in the same tense
+as other terminating cases (`Interrupted` and `Completed`). Likewise, some
+operations and parameters have been renamed (e.g. `Signal.observeError` is now
+`Signal.observeFailed`, `Observer.sendError` is now `Observer.sendFailed`).
+
 ## Alpha 2
 
 #### Simplified Observer API
@@ -60,10 +70,6 @@ This is in-line with changes to the standard library in Swift 2.
 
 `Bag` and `Atomic` are now public. These are useful when creating custom
 operators for RAC types.
-
-#### Renaming Event.Error to Event.Failed
-
-Maybe coming to a later alpha. See #2360.
 
 ## Alpha 1
 

--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -38,10 +38,10 @@ types will be referred to by name.
   1. [Merging](#merging)
   1. [Switching to the latest](#switching-to-the-latest)
 
-**[Handling errors](#handling-errors)**
+**[Handling failures](#handling-failures)**
 
-  1. [Catching errors](#catch)
-  1. [Mapping errors](#mapping-error)
+  1. [Catching failures](#catch)
+  1. [Mapping errors](#mapping-errors)
   1. [Retrying](#retrying)
 
 ## Performing side effects with event streams
@@ -55,8 +55,8 @@ signal.observe(Signal.Observer { event in
     switch event {
     case let .Next(next):
         print("Next: \(next)")
-    case let .Error(error):
-        print("Error: \(error)")
+    case let .Failed(error):
+        print("Failed: \(error)")
     case .Completed:
         print("Completed")
     case .Interrupted:
@@ -65,14 +65,14 @@ signal.observe(Signal.Observer { event in
 })
 ```
 
-Alternatively, callbacks for the `Next`, `Error`, `Completed` and `Interrupted` events can be provided which will be called when a corresponding event occurs.
+Alternatively, callbacks for the `Next`, `Failed`, `Completed` and `Interrupted` events can be provided which will be called when a corresponding event occurs.
 
 ```Swift
 signal.observeNext { next in 
   print("Next: \(next)") 
 }
-signal.observeError { error in 
-  print("Error: \(error)") 
+signal.observeFailed { error in
+  print("Failed: \(error)")
 }
 signal.observeCompleted { 
   print("Completed") 
@@ -94,8 +94,8 @@ let producer = signalProducer
         print("Started")
     }, event: { event in
         print("Event: \(event)")
-    }, error: { error in
-        print("Error: \(error)")
+    }, failed: { error in
+        print("Failed: \(error)")
     }, completed: {
         print("Completed")
     }, interrupted: {
@@ -104,8 +104,8 @@ let producer = signalProducer
         print("Terminated")
     }, disposed: {
         print("Disposed")
-    }, next: { next in
-        print("Next: \(next)")
+    }, next: { value in
+        print("Next: \(value)")
     })
 ```
 
@@ -300,7 +300,7 @@ Note, how the values interleave and which values are even included in the result
 
 ### Merging
 
-The `.Merge` strategy immediately forwards every value of the inner `SignalProducer`s to the outer `SignalProducer`. Any error sent on the outer producer or any inner producer is immediately sent on the flattened producer and terminates it.
+The `.Merge` strategy immediately forwards every value of the inner `SignalProducer`s to the outer `SignalProducer`. Any failure sent on the outer producer or any inner producer is immediately sent on the flattened producer and terminates it.
 
 ```Swift
 let (producerA, lettersObserver) = SignalProducer<String, NoError>.buffer(5)
@@ -325,7 +325,7 @@ numbersObserver.sendNext("3")    // prints "3"
 
 ### Concatenating
 
-The `.Concat` strategy is used to serialize work of the inner `SignalProducer`s. The outer producer is started immediately. Each subsequent producer is not started until the preceeding one has completed. Errors are immediately forwarded to the flattened producer.
+The `.Concat` strategy is used to serialize work of the inner `SignalProducer`s. The outer producer is started immediately. Each subsequent producer is not started until the preceeding one has completed. Failures are immediately forwarded to the flattened producer.
 
 ```Swift
 let (producerA, lettersObserver) = SignalProducer<String, NoError>.buffer(5)
@@ -376,13 +376,13 @@ observerB.sendNext("3")        // nothing printed
 observerC.sendNext("Z")        // prints "Z"
 ```
 
-## Handling errors
+## Handling failures
 
-These operators are used to handle errors that might occur on an event stream.
+These operators are used to handle failures that might occur on an event stream.
 
-### Catching errors
+### Catching failures
 
-The `flatMapError` operator catches any error that may occur on the input `SignalProducer`, then starts a new `SignalProducer` in its place.
+The `flatMapError` operator catches any failure that may occur on the input `SignalProducer`, then starts a new `SignalProducer` in its place.
 
 ```Swift
 let (producer, observer) = SignalProducer<String, NSError>.buffer(5)
@@ -395,12 +395,12 @@ producer
 
 observer.sendNext("First")     // prints "First"
 observer.sendNext("Second")    // prints "Second"
-observer.sendError(error)      // prints "Default"
+observer.sendFailed(error)     // prints "Default"
 ```
 
 ### Retrying
 
-The `retry` operator will restart the original `SignalProducer` on error up to `count` times.
+The `retry` operator will restart the original `SignalProducer` on failure up to `count` times.
 
 ```Swift
 var tries = 0
@@ -408,7 +408,7 @@ let limit = 2
 let error = NSError(domain: "domain", code: 0, userInfo: nil)
 let producer = SignalProducer<String, NSError> { (observer, _) in
     if tries++ < limit {
-        observer.sendError(error)
+        observer.sendFailed(error)
     } else {
         observer.sendNext("Success")
         observer.sendCompleted()
@@ -416,14 +416,14 @@ let producer = SignalProducer<String, NSError> { (observer, _) in
 }
 
 producer
-    .on(error: {e in print("Error")})             // prints "Error" twice
+    .on(failed: {e in print("Failure")})    // prints "Failure" twice
     .retry(2)
     .start { event in
         switch event {
         case let .Next(next):
             print(next)                     // prints "Success"
-        case let .Error(error):
-            print("Error: \(error)")
+        case let .Failed(error):
+            print("Failed: \(error)")
         case .Completed:
             print("Completed")
         case .Interrupted:
@@ -432,11 +432,11 @@ producer
     }
 ```
 
-If the `SignalProducer` does not succeed after `count` tries, the resulting `SignalProducer` will fail. E.g., if  `retry(1)` is used in the example above instead of `retry(2)`, `"Signal Error"` will be printed instead of `"Success"`.
+If the `SignalProducer` does not succeed after `count` tries, the resulting `SignalProducer` will fail. E.g., if  `retry(1)` is used in the example above instead of `retry(2)`, `"Signal Failure"` will be printed instead of `"Success"`.
 
 ### Mapping errors
 
-The `mapError` operator transforms any error in an event stream into a new error. 
+The `mapError` operator transforms the error of any failure in an event stream into a new error.
 
 ```Swift
 enum CustomError: String, ErrorType {
@@ -466,16 +466,16 @@ signal
             return .Other
         }
     }
-    .observeError { error in
+    .observeFailed { error in
         print(error)
     }
 
-observer.sendError(NSError(domain: "com.example.foo", code: 42, userInfo: nil))    // prints "Foo Error"
+observer.sendFailed(NSError(domain: "com.example.foo", code: 42, userInfo: nil))    // prints "Foo Error"
 ```
 
 ### Promote
 
-The `promoteErrors` operator promotes an event stream that does not generate errors into one that can. 
+The `promoteErrors` operator promotes an event stream that does not generate failures into one that can. 
 
 ```Swift
 let (numbersSignal, numbersObserver) = Signal<Int, NoError>.pipe()
@@ -486,7 +486,7 @@ numbersSignal
     .combineLatestWith(lettersSignal)
 ```
 
-The given stream will still not _actually_ generate errors, but this is useful
+The given stream will still not _actually_ generate failures, but this is useful
 because some operators to [combine streams](#combining-event-streams) require
 the inputs to have matching error types.
 

--- a/Documentation/DesignGuidelines.md
+++ b/Documentation/DesignGuidelines.md
@@ -11,7 +11,7 @@ resource for getting up to speed on the main types and concepts provided by RAC.
 **[The `Event` contract](#the-event-contract)**
 
  1. [`Next`s provide values or indicate the occurrence of events](#nexts-provide-values-or-indicate-the-occurrence-of-events)
- 1. [Errors behave like exceptions and propagate immediately](#errors-behave-like-exceptions-and-propagate-immediately)
+ 1. [Failures behave like exceptions and propagate immediately](#failures-behave-like-exceptions-and-propagate-immediately)
  1. [Completion indicates success](#completion-indicates-success)
  1. [Interruption cancels outstanding work and usually propagates immediately](#interruption-cancels-outstanding-work-and-usually-propagates-immediately)
  1. [Events are serial](#events-are-serial)
@@ -46,7 +46,7 @@ resource for getting up to speed on the main types and concepts provided by RAC.
 
  1. [Prefer writing operators that apply to both signals and producers](#prefer-writing-operators-that-apply-to-both-signals-and-producers)
  1. [Compose existing operators when possible](#compose-existing-operators-when-possible)
- 1. [Forward error and interruption events as soon as possible](#forward-error-and-interruption-events-as-soon-as-possible)
+ 1. [Forward failure and interruption events as soon as possible](#forward-failure-and-interruption-events-as-soon-as-possible)
  1. [Switch over `Event` values](#switch-over-event-values)
  1. [Avoid introducing concurrency](#avoid-introducing-concurrency)
  1. [Avoid blocking in operators](#avoid-blocking-in-operators)
@@ -59,13 +59,13 @@ events, and may be collectively called “event streams.”
 Event streams must conform to the following grammar:
 
 ```
-Next* (Interrupted | Error | Completed)?
+Next* (Interrupted | Failed | Completed)?
 ```
 
 This states that an event stream consists of:
 
  1. Any number of `Next` events
- 1. Optionally followed by one terminating event, which is any of `Interrupted`, `Error`, or `Completed`
+ 1. Optionally followed by one terminating event, which is any of `Interrupted`, `Failed`, or `Completed`
 
 After a terminating event, no other events will be received.
 
@@ -85,24 +85,21 @@ what that something was.
 Most of the event stream [operators][] act upon `Next` events, as they represent the
 “meaningful data” of a signal or producer.
 
-#### Errors behave like exceptions and propagate immediately
+#### Failures behave like exceptions and propagate immediately
 
-`Error` events indicate that something went wrong, and contain a concrete error
-that indicates what happened. Errors are fatal, and propagate as quickly as
+`Failed` events indicate that something went wrong, and contain a concrete error
+that indicates what happened. Failures are fatal, and propagate as quickly as
 possible to the consumer for handling.
 
-Errors also behave like exceptions, in that they “skip” operators, terminating
-them along the way. In other words, most [operators][] immediately stop doing work
-when an error is received, and then propagate the error onward. This even
-applies to time-shifted operators, like [`delay`][delay]—which, despite its name, will
-forward any errors immediately.
+Failures also behave like exceptions, in that they “skip” operators, terminating
+them along the way. In other words, most [operators][] immediately stop doing
+work when a failure is received, and then propagate the failure onward. This even applies to time-shifted operators, like [`delay`][delay]—which, despite its name, will forward any failures immediately.
 
-Consequently, errors should only be used to represent “abnormal” termination. If
-it is important to let operators (or consumers) finish their work, a `Next`
+Consequently, failures should only be used to represent “abnormal” termination. If it is important to let operators (or consumers) finish their work, a `Next`
 event describing the result might be more appropriate.
 
-If an event stream can _never_ error out, it should be parameterized with the
-special [`NoError`][NoError] type, which statically guarantees that an error
+If an event stream can _never_ fail, it should be parameterized with the
+special [`NoError`][NoError] type, which statically guarantees that a `Failed`
 event cannot be sent upon the stream.
 
 #### Completion indicates success
@@ -123,7 +120,7 @@ outcome will usually depend on all the inputs.
 
 An `Interrupted` event is sent when an event stream should cancel processing.
 Interruption is somewhere between [success](#completion-indicates-success)
-and [failure](#errors-behave-like-exceptions-and-propagate-immediately)—the
+and [failure](#failures-behave-like-exceptions-and-propagate-immediately)—the
 operation was not successful, because it did not get to finish, but it didn’t
 necessarily “fail” either.
 
@@ -453,18 +450,18 @@ To minimize duplication and possible bugs, use the provided operators as much as
 possible in a custom operator implementation. Generally, there should be very
 little code written from scratch.
 
-#### Forward error and interruption events as soon as possible
+#### Forward failure and interruption events as soon as possible
 
 Unless an operator is specifically built to handle
-[errors](#errors-behave-like-exceptions-and-propagate-immediately) and
+[failures](#failures-behave-like-exceptions-and-propagate-immediately) and
 [interruption](#interruption-cancels-outstanding-work-and-usually-propagates-immedaitely)
 in a custom way, it should propagate those events to the observer as soon as
 possible, to ensure that their semantics are honored.
 
 #### Switch over `Event` values
 
-Instead of using [`start(error:completed:interrupted:next:)`][start] or
-[`observe(error:completed:interrupted:next:)`][observe], create your own
+Instead of using [`start(failed:completed:interrupted:next:)`][start] or
+[`observe(failed:completed:interrupted:next:)`][observe], create your own
 [observer][Observers] to process raw [`Event`][Events] values, and use
 a `switch` statement to determine the event type.
 
@@ -476,8 +473,8 @@ producer.start { event in
     case let .Next(value):
         println("Next event: \(value)")
 
-    case let .Error(error):
-        println("Error event: \(error)")
+    case let .Failed(error):
+        println("Failed event: \(error)")
 
     case .Completed:
         println("Completed event")

--- a/Documentation/FrameworkOverview.md
+++ b/Documentation/FrameworkOverview.md
@@ -21,9 +21,9 @@ of a long-running operation. In any case, something generates the events and sen
 terminal events:
 
  * The `Next` event provides a new value from the source.
- * The `Error` event indicates that an error occurred before the signal could
+ * The `Failed` event indicates that an error occurred before the signal could
    finish. Events are parameterized by an `ErrorType`, which determines the kind
-   of error that’s permitted to appear in the event. If an error is not
+   of failure that’s permitted to appear in the event. If a failure is not
    permitted, the event can use type `NoError` to prevent any from being
    provided.
  * The `Completed` event indicates that the signal finished successfully, and
@@ -55,7 +55,7 @@ Typical primitives to manipulate a single signal like `filter`, `map` and
 at once (`zip`). Primitives operate only on the `Next` events of a signal.
 
 The lifetime of a signal consists of any number of `Next` events, followed by
-one terminating event, which may be any one of `Error`, `Completed`, or
+one terminating event, which may be any one of `Failed`, `Completed`, or
 `Interrupted` (but not a combination).
 Terminating events are not included in the signal’s values—they must be
 handled specially.
@@ -123,8 +123,8 @@ Observers can be implicitly created by using the callback-based versions of the
 ## Actions
 
 An **action**, represented by the [`Action`][Action] type, will do some work when
-executed with an input. While executing, zero or more output values and/or an
-error may be generated.
+executed with an input. While executing, zero or more output values and/or a
+failure may be generated.
 
 Actions are useful for performing side-effecting work upon user interaction, like when a button is
 clicked. Actions can also be automatically disabled based on a [property](#properties), and this

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ Here, we watch for the `Next` [event][Events], which contains our results, and
 just log them to the console. This could easily do something else instead, like
 update a table view or a label on screen.
 
-#### Handling errors
+#### Handling failures
 
-In this example so far, any network error will generate an `Error`
+In this example so far, any network error will generate a `Failed`
 [event][Events], which will terminate the event stream. Unfortunately, this
 means that future queries won’t even be attempted.
 
-To remedy this, we need to decide what to do with errors that occur. The
+To remedy this, we need to decide what to do with failures that occur. The
 quickest solution would be to log them, then ignore them:
 
 ```swift
@@ -141,7 +141,7 @@ quickest solution would be to log them, then ignore them:
     }
 ```
 
-By replacing errors with the `empty` event stream, we’re able to effectively
+By replacing failures with the `empty` event stream, we’re able to effectively
 ignore them.
 
 However, it’s probably more appropriate to retry at least a couple of times
@@ -264,14 +264,14 @@ easy](http://www.infoq.com/presentations/Simple-Made-Easy)**.
 
 ### Typed errors
 
-When [signals][] and [signal producers][] are allowed to [error][Events] in ReactiveCocoa,
+When [signals][] and [signal producers][] are allowed to [fail][Events] in ReactiveCocoa,
 the kind of error must be specified in the type system. For example,
-`Signal<Int, NSError>` is a signal of integer values that may send an error of
-type `NSError`.
+`Signal<Int, NSError>` is a signal of integer values that may fail with an error
+of type `NSError`.
 
 More importantly, RAC allows the special type `NoError` to be used instead,
-which _statically guarantees_ that an event stream is not allowed to send an
-error. **This eliminates many bugs caused by unexpected error events.**
+which _statically guarantees_ that an event stream is not allowed to send a
+failure. **This eliminates many bugs caused by unexpected failure events.**
 
 In Rx systems with types, event streams only specify the type of their
 values—not the type of their errors—so this sort of guarantee is impossible.

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -1,7 +1,7 @@
 /// Represents an action that will do some work when executed with a value of
-/// type `Input`, then return zero or more values of type `Output` and/or error
-/// out with an error of type `Error`. If no errors should be possible, NoError
-/// can be specified for the `Error` parameter.
+/// type `Input`, then return zero or more values of type `Output` and/or fail
+/// with an error of type `Error`. If no failure should be possible, NoError can
+/// be specified for the `Error` parameter.
 ///
 /// Actions enforce serial execution. Any attempt to execute an action multiple
 /// times concurrently will return an error.
@@ -106,7 +106,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 			}
 
 			if !startedExecuting {
-				observer.sendError(.NotEnabled)
+				observer.sendFailed(.NotEnabled)
 				return
 			}
 

--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -10,13 +10,13 @@
 ///
 /// Signals must conform to the grammar:
 /// `Next* (Failed | Completed | Interrupted)?`
-public enum Event<Value, Err: ErrorType> {
+public enum Event<Value, Error: ErrorType> {
 	/// A value provided by the signal.
 	case Next(Value)
 
 	/// The signal terminated because of an error. No further events will be
 	/// received.
-	case Failed(Err)
+	case Failed(Error)
 
 	/// The signal successfully terminated. No further events will be received.
 	case Completed
@@ -39,7 +39,7 @@ public enum Event<Value, Err: ErrorType> {
 	}
 
 	/// Lifts the given function over the event's value.
-	public func map<U>(f: Value -> U) -> Event<U, Err> {
+	public func map<U>(f: Value -> U) -> Event<U, Error> {
 		switch self {
 		case let .Next(value):
 			return .Next(f(value))
@@ -56,7 +56,7 @@ public enum Event<Value, Err: ErrorType> {
 	}
 
 	/// Lifts the given function over the event's error.
-	public func mapError<F>(f: Err -> F) -> Event<Value, F> {
+	public func mapError<F>(f: Error -> F) -> Event<Value, F> {
 		switch self {
 		case let .Next(value):
 			return .Next(value)
@@ -82,7 +82,7 @@ public enum Event<Value, Err: ErrorType> {
 	}
 
 	/// Unwraps the contained `Error` value.
-	public var error: Err? {
+	public var error: Error? {
 		if case let .Failed(error) = self {
 			return error
 		} else {
@@ -91,7 +91,7 @@ public enum Event<Value, Err: ErrorType> {
 	}
 }
 
-public func == <Value: Equatable, Err: Equatable> (lhs: Event<Value, Err>, rhs: Event<Value, Err>) -> Bool {
+public func == <Value: Equatable, Error: Equatable> (lhs: Event<Value, Error>, rhs: Event<Value, Error>) -> Bool {
 	switch (lhs, rhs) {
 	case let (.Next(left), .Next(right)):
 		return left == right
@@ -133,13 +133,13 @@ public protocol EventType {
 	// The value type of an event.
 	typealias Value
 	/// The error type of an event. If errors aren't possible then `NoError` can be used.
-	typealias Err: ErrorType
+	typealias Error: ErrorType
 	/// Extracts the event from the receiver.
-	var event: Event<Value, Err> { get }
+	var event: Event<Value, Error> { get }
 }
 
 extension Event: EventType {
-	public var event: Event<Value, Err> {
+	public var event: Event<Value, Error> {
 		return self
 	}
 }

--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -9,14 +9,14 @@
 /// Represents a signal event.
 ///
 /// Signals must conform to the grammar:
-/// `Next* (Error | Completed | Interrupted)?`
+/// `Next* (Failed | Completed | Interrupted)?`
 public enum Event<Value, Err: ErrorType> {
 	/// A value provided by the signal.
 	case Next(Value)
 
 	/// The signal terminated because of an error. No further events will be
 	/// received.
-	case Error(Err)
+	case Failed(Err)
 
 	/// The signal successfully terminated. No further events will be received.
 	case Completed
@@ -33,7 +33,7 @@ public enum Event<Value, Err: ErrorType> {
 		case .Next:
 			return false
 
-		case .Error, .Completed, .Interrupted:
+		case .Failed, .Completed, .Interrupted:
 			return true
 		}
 	}
@@ -44,8 +44,8 @@ public enum Event<Value, Err: ErrorType> {
 		case let .Next(value):
 			return .Next(f(value))
 
-		case let .Error(error):
-			return .Error(error)
+		case let .Failed(error):
+			return .Failed(error)
 
 		case .Completed:
 			return .Completed
@@ -61,8 +61,8 @@ public enum Event<Value, Err: ErrorType> {
 		case let .Next(value):
 			return .Next(value)
 
-		case let .Error(error):
-			return .Error(f(error))
+		case let .Failed(error):
+			return .Failed(f(error))
 
 		case .Completed:
 			return .Completed
@@ -83,7 +83,7 @@ public enum Event<Value, Err: ErrorType> {
 
 	/// Unwraps the contained `Error` value.
 	public var error: Err? {
-		if case let .Error(error) = self {
+		if case let .Failed(error) = self {
 			return error
 		} else {
 			return nil
@@ -96,7 +96,7 @@ public func == <Value: Equatable, Err: Equatable> (lhs: Event<Value, Err>, rhs: 
 	case let (.Next(left), .Next(right)):
 		return left == right
 
-	case let (.Error(left), .Error(right)):
+	case let (.Failed(left), .Failed(right)):
 		return left == right
 
 	case (.Completed, .Completed):
@@ -116,8 +116,8 @@ extension Event: CustomStringConvertible {
 		case let .Next(value):
 			return "NEXT \(value)"
 
-		case let .Error(error):
-			return "ERROR \(error)"
+		case let .Failed(error):
+			return "FAILED \(error)"
 
 		case .Completed:
 			return "COMPLETED"

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -37,7 +37,7 @@ extension NSURLSession {
 					observer.sendNext((data, response))
 					observer.sendCompleted()
 				} else {
-					observer.sendError(error ?? defaultSessionError)
+					observer.sendFailed(error ?? defaultSessionError)
 				}
 			}
 

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -59,15 +59,15 @@ extension RACSignal {
 				observer.sendNext(obj)
 			}
 
-			let error = { nsError in
-				observer.sendError(nsError ?? defaultNSError("Nil RACSignal error", file: file, line: line))
+			let failed = { nsError in
+				observer.sendFailed(nsError ?? defaultNSError("Nil RACSignal error", file: file, line: line))
 			}
 
 			let completed = {
 				observer.sendCompleted()
 			}
 
-			disposable += self.subscribeNext(next, error: error, completed: completed)
+			disposable += self.subscribeNext(next, error: failed, completed: completed)
 		}
 	}
 }
@@ -116,7 +116,7 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(producer: SignalProduc
 			switch event {
 			case let .Next(value):
 				subscriber.sendNext(value)
-			case let .Error(error):
+			case let .Failed(error):
 				subscriber.sendError(error)
 			case .Completed:
 				subscriber.sendCompleted()
@@ -164,7 +164,7 @@ public func toRACSignal<Value: AnyObject, Error: NSError>(signal: Signal<Value?,
             switch event {
             case let .Next(value):
                 subscriber.sendNext(value)
-            case let .Error(error):
+            case let .Failed(error):
                 subscriber.sendError(error)
             case .Completed:
                 subscriber.sendCompleted()

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -40,7 +40,7 @@ public struct Observer<Value, Error: ErrorType> {
 		action(.Next(value))
 	}
 
-	/// Puts a `Failed` event into the given observer.
+	/// Puts an `Failed` event into the given observer.
 	public func sendFailed(error: Error) {
 		action(.Failed(error))
 	}

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -8,8 +8,8 @@
 
 /// An Observer is a simple wrapper around a function which can receive Events
 /// (typically from a Signal).
-public struct Observer<Value, Err: ErrorType> {
-	public typealias Action = Event<Value, Err> -> ()
+public struct Observer<Value, Error: ErrorType> {
+	public typealias Action = Event<Value, Error> -> ()
 
 	public let action: Action
 
@@ -17,14 +17,14 @@ public struct Observer<Value, Err: ErrorType> {
 		self.action = action
 	}
 
-	public init(failed: (Err -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (Value -> ())? = nil) {
+	public init(failed: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (Value -> ())? = nil) {
 		self.init { event in
 			switch event {
 			case let .Next(value):
 				next?(value)
 
-			case let .Failed(err):
-				failed?(err)
+			case let .Failed(error):
+				failed?(error)
 
 			case .Completed:
 				completed?()
@@ -41,7 +41,7 @@ public struct Observer<Value, Err: ErrorType> {
 	}
 
 	/// Puts a `Failed` event into the given observer.
-	public func sendFailed(error: Err) {
+	public func sendFailed(error: Error) {
 		action(.Failed(error))
 	}
 

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -17,14 +17,14 @@ public struct Observer<Value, Err: ErrorType> {
 		self.action = action
 	}
 
-	public init(error: (Err -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (Value -> ())? = nil) {
+	public init(failed: (Err -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (Value -> ())? = nil) {
 		self.init { event in
 			switch event {
 			case let .Next(value):
 				next?(value)
 
-			case let .Error(err):
-				error?(err)
+			case let .Failed(err):
+				failed?(err)
 
 			case .Completed:
 				completed?()
@@ -40,9 +40,9 @@ public struct Observer<Value, Err: ErrorType> {
 		action(.Next(value))
 	}
 
-	/// Puts an `Error` event into the given observer.
-	public func sendError(error: Err) {
-		action(.Error(error))
+	/// Puts a `Failed` event into the given observer.
+	public func sendFailed(error: Err) {
+		action(.Failed(error))
 	}
 
 	/// Puts a `Completed` event into the given observer.

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -823,8 +823,8 @@ extension SignalType where Value: EventType, Error == NoError {
 	/// The inverse of materialize(), this will translate a signal of `Event`
 	/// _values_ into a signal of those events themselves.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
-	public func dematerialize() -> Signal<Value.Value, Value.Err> {
-		return Signal<Value.Value, Value.Err> { observer in
+	public func dematerialize() -> Signal<Value.Value, Value.Error> {
+		return Signal<Value.Value, Value.Error> { observer in
 			return self.observe { event in
 				switch event {
 				case let .Next(innerEvent):

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1,8 +1,8 @@
 import Result
 
 /// A push-driven stream that sends Events over time, parameterized by the type
-/// of values being sent (`Value`) and the type of error that can occur (`Error`).
-/// If no errors should be possible, NoError can be specified for `Error`.
+/// of values being sent (`Value`) and the type of failure that can occur (`Error`).
+/// If no failures should be possible, NoError can be specified for `Error`.
 ///
 /// An observer of a Signal will see the exact same sequence of events as all
 /// other observers. In other words, events will be sent to all observers at the
@@ -188,14 +188,14 @@ extension SignalType {
 		return observe(Observer(completed: completed))
 	}
 	
-	/// Observes the Signal by invoking the given callback when an `error` event is
+	/// Observes the Signal by invoking the given callback when a `failed` event is
 	/// received.
 	///
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeError(error: Error -> ()) -> Disposable? {
-		return observe(Observer(error: error))
+	public func observeFailed(error: Error -> ()) -> Disposable? {
+		return observe(Observer(failed: error))
 	}
 	
 	/// Observes the Signal by invoking the given callback when an `interrupted` event is
@@ -287,8 +287,8 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
 	///
-	/// If `signal` or an active inner producer emits an error, the returned
-	/// signal will forward that error immediately.
+	/// If `signal` or an active inner producer fails, the returned signal will
+	/// forward that failure immediately.
 	///
 	/// `Interrupted` events on inner producers will be treated like `Completed`
 	/// events on inner producers.
@@ -312,8 +312,8 @@ extension SignalType {
 	/// resulting producers (into a signal of values), according to the
 	/// semantics of the given strategy.
 	///
-	/// If `signal` or any of the created producers emit an error, the returned
-	/// signal will forward that error immediately.
+	/// If `signal` or any of the created producers fail, the returned signal
+	/// will forward that failure immediately.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func flatMap<U>(strategy: FlattenStrategy, transform: Value -> SignalProducer<U, Error>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
@@ -336,8 +336,8 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 	/// `signal`, waiting until each inner producer completes before beginning to
 	/// send the values from the next inner producer.
 	///
-	/// If any of the inner producers emit an error, the returned signal will emit
-	/// that error.
+	/// If any of the inner producers fail, the returned signal will forward
+	/// that failure immediately
 	///
 	/// The returned signal completes only when `signal` and all producers
 	/// emitted from `signal` complete.
@@ -352,8 +352,8 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 				case let .Next(value):
 					state.enqueueSignalProducer(value.producer)
 
-				case let .Error(error):
-					observer.sendError(error)
+				case let .Failed(error):
+					observer.sendFailed(error)
 
 				case .Completed:
 					// Add one last producer to the queue, whose sole job is to
@@ -486,8 +486,8 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 						}
 					}
 
-				case let .Error(error):
-					relayObserver.sendError(error)
+				case let .Failed(error):
+					relayObserver.sendFailed(error)
 
 				case .Completed:
 					decrementInFlight()
@@ -569,8 +569,8 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 							}
 						}
 					}
-				case let .Error(error):
-					observer.sendError(error)
+				case let .Failed(error):
+					observer.sendFailed(error)
 				case .Completed:
 					let original = state.modify { (var state) in
 						state.outerSignalComplete = true
@@ -678,7 +678,7 @@ private final class CombineLatestState<Value> {
 }
 
 extension SignalType {
-	private func observeWithStates<U>(signalState: CombineLatestState<Value>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ onBothNext: () -> (), _ onError: Error -> (), _ onBothCompleted: () -> (), _ onInterrupted: () -> ()) -> Disposable? {
+	private func observeWithStates<U>(signalState: CombineLatestState<Value>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ onBothNext: () -> (), _ onFailed: Error -> (), _ onBothCompleted: () -> (), _ onInterrupted: () -> ()) -> Disposable? {
 		return self.observe { event in
 			switch event {
 			case let .Next(value):
@@ -691,8 +691,8 @@ extension SignalType {
 
 				lock.unlock()
 
-			case let .Error(error):
-				onError(error)
+			case let .Failed(error):
+				onFailed(error)
 
 			case .Completed:
 				lock.lock()
@@ -729,13 +729,13 @@ extension SignalType {
 				observer.sendNext((signalState.latestValue!, otherState.latestValue!))
 			}
 			
-			let onError = observer.sendError
+			let onFailed = observer.sendFailed
 			let onBothCompleted = observer.sendCompleted
 			let onInterrupted = observer.sendInterrupted
 
 			let disposable = CompositeDisposable()
-			disposable += self.observeWithStates(signalState, otherState, lock, onBothNext, onError, onBothCompleted, onInterrupted)
-			disposable += otherSignal.observeWithStates(otherState, signalState, lock, onBothNext, onError, onBothCompleted, onInterrupted)
+			disposable += self.observeWithStates(signalState, otherState, lock, onBothNext, onFailed, onBothCompleted, onInterrupted)
+			disposable += otherSignal.observeWithStates(otherState, signalState, lock, onBothNext, onFailed, onBothCompleted, onInterrupted)
 			
 			return disposable
 		}
@@ -744,7 +744,7 @@ extension SignalType {
 	/// Delays `Next` and `Completed` events by the given interval, forwarding
 	/// them on the given scheduler.
 	///
-	/// `Error` and `Interrupted` events are always scheduled immediately.
+	/// `Failed` and `Interrupted` events are always scheduled immediately.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func delay(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> Signal<Value, Error> {
 		precondition(interval >= 0)
@@ -752,7 +752,7 @@ extension SignalType {
 		return Signal { observer in
 			return self.observe { event in
 				switch event {
-				case .Error, .Interrupted:
+				case .Failed, .Interrupted:
 					scheduler.schedule {
 						observer.action(event)
 					}
@@ -795,7 +795,7 @@ extension SignalType {
 	///
 	/// In other words, this brings Events “into the monad.”
 	///
-	/// When a Completed or Error event is received, the resulting signal will send
+	/// When a Completed or Failed event is received, the resulting signal will send
 	/// the Event itself and then complete. When an Interrupted event is received,
 	/// the resulting signal will send the Event itself and then interrupt.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
@@ -808,7 +808,7 @@ extension SignalType {
 				case .Interrupted:
 					observer.sendInterrupted()
 
-				case .Completed, .Error:
+				case .Completed, .Failed:
 					observer.sendCompleted()
 
 				case .Next:
@@ -830,7 +830,7 @@ extension SignalType where Value: EventType, Error == NoError {
 				case let .Next(innerEvent):
 					observer.action(innerEvent.event)
 
-				case .Error:
+				case .Failed:
 					fatalError("NoError is impossible to construct")
 
 				case .Completed:
@@ -873,8 +873,8 @@ extension SignalType {
 						st.latestValue = value
 						return st
 					}
-				case let .Error(error):
-					observer.sendError(error)
+				case let .Failed(error):
+					observer.sendFailed(error)
 				case .Completed:
 					let oldState = state.modify { (var st) in
 						st.signalCompleted = true
@@ -928,7 +928,7 @@ extension SignalType {
 				case .Next, .Completed:
 					observer.sendCompleted()
 
-				case .Error, .Interrupted:
+				case .Failed, .Interrupted:
 					break
 				}
 			}
@@ -1037,7 +1037,7 @@ extension SignalType {
 
 	/// Forwards events from `self` until `replacement` begins sending events.
 	///
-	/// Returns a signal which passes through `Next`, `Error`, and `Interrupted`
+	/// Returns a signal which passes through `Next`, `Failed`, and `Interrupted`
 	/// events from `signal` until `replacement` sends an event, at which point the
 	/// returned signal will send that event and switch to passing through events
 	/// from `replacement` instead, regardless of whether `self` has sent events
@@ -1052,7 +1052,7 @@ extension SignalType {
 				case .Completed:
 					break
 
-				case .Next, .Error, .Interrupted:
+				case .Next, .Failed, .Interrupted:
 					observer.action(event)
 				}
 			}
@@ -1085,8 +1085,8 @@ extension SignalType {
 					}
 					
 					buffer.append(value)
-				case let .Error(error):
-					observer.sendError(error)
+				case let .Failed(error):
+					observer.sendFailed(error)
 				case .Completed:
 					for bufferedValue in buffer {
 						observer.sendNext(bufferedValue)
@@ -1158,7 +1158,7 @@ extension SignalType {
 				}
 			}
 			
-			let onError = { observer.sendError($0) }
+			let onFailed = { observer.sendFailed($0) }
 			let onInterrupted = { observer.sendInterrupted() }
 
 			disposable += self.observe { event in
@@ -1170,8 +1170,8 @@ extension SignalType {
 					}
 					
 					flush()
-				case let .Error(error):
-					onError(error)
+				case let .Failed(error):
+					onFailed(error)
 				case .Completed:
 					states.modify { (var states) in
 						states.0.completed = true
@@ -1193,8 +1193,8 @@ extension SignalType {
 					}
 					
 					flush()
-				case let .Error(error):
-					onError(error)
+				case let .Failed(error):
+					onFailed(error)
 				case .Completed:
 					states.modify { (var states) in
 						states.1.completed = true
@@ -1212,7 +1212,7 @@ extension SignalType {
 	}
 
 	/// Applies `operation` to values from `self` with `Success`ful results
-	/// forwarded on the returned signal and `Failure`s sent as `Error` events.
+	/// forwarded on the returned signal and `Failure`s sent as `Failed` events.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func attempt(operation: Value -> Result<(), Error>) -> Signal<Value, Error> {
 		return attemptMap { value in
@@ -1223,7 +1223,7 @@ extension SignalType {
 	}
 
 	/// Applies `operation` to values from `self` with `Success`ful results mapped
-	/// on the returned signal and `Failure`s sent as `Error` events.
+	/// on the returned signal and `Failure`s sent as `Failed` events.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func attemptMap<U>(operation: Value -> Result<U, Error>) -> Signal<U, Error> {
 		return Signal { observer in
@@ -1233,10 +1233,10 @@ extension SignalType {
 					operation(value).analysis(ifSuccess: { value in
 						observer.sendNext(value)
 						}, ifFailure: { error in
-							observer.sendError(error)
+							observer.sendFailed(error)
 					})
-				case let .Error(error):
-					observer.sendError(error)
+				case let .Failed(error):
+					observer.sendFailed(error)
 				case .Completed:
 					observer.sendCompleted()
 				case .Interrupted:
@@ -1499,7 +1499,7 @@ public func zip<S: SequenceType, Value, Error where S.Generator.Element == Signa
 
 extension SignalType {
 	/// Forwards events from `self` until `interval`. Then if signal isn't completed yet,
-	/// errors with `error` on `scheduler`.
+	/// fails with `error` on `scheduler`.
 	///
 	/// If the interval is 0, the timeout will be scheduled immediately. The signal
 	/// must complete synchronously (or on a faster scheduler) to avoid the timeout.
@@ -1512,7 +1512,7 @@ extension SignalType {
 			let date = scheduler.currentDate.dateByAddingTimeInterval(interval)
 
 			disposable += scheduler.scheduleAfter(date) {
-				observer.sendError(error)
+				observer.sendFailed(error)
 			}
 
 			disposable += self.observe(observer)
@@ -1522,10 +1522,10 @@ extension SignalType {
 }
 
 extension SignalType where Error == NoError {
-	/// Promotes a signal that does not generate errors into one that can.
+	/// Promotes a signal that does not generate failures into one that can.
 	///
-	/// This does not actually cause errors to be generated for the given signal,
-	/// but makes it easier to combine with other signals that may error; for
+	/// This does not actually cause failures to be generated for the given signal,
+	/// but makes it easier to combine with other signals that may fail; for
 	/// example, with operators like `combineLatestWith`, `zipWith`, `flatten`, etc.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func promoteErrors<F: ErrorType>(_: F.Type) -> Signal<Value, F> {
@@ -1534,7 +1534,7 @@ extension SignalType where Error == NoError {
 				switch event {
 				case let .Next(value):
 					observer.sendNext(value)
-				case .Error:
+				case .Failed:
 					fatalError("NoError is impossible to construct")
 				case .Completed:
 					observer.sendCompleted()

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -700,7 +700,7 @@ extension SignalProducerType where Value: EventType, Error == NoError {
 	/// The inverse of materialize(), this will translate a signal of `Event`
 	/// _values_ into a signal of those events themselves.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func dematerialize() -> SignalProducer<Value.Value, Value.Err> {
+	public func dematerialize() -> SignalProducer<Value.Value, Value.Error> {
 		return lift { $0.dematerialize() }
 	}
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1,7 +1,7 @@
 import Result
 
 /// A SignalProducer creates Signals that can produce values of type `Value` and/or
-/// error out with errors of type `Error`. If no errors should be possible, NoError
+/// fail with errors of type `Error`. If no failure should be possible, NoError
 /// can be specified for `Error`.
 ///
 /// SignalProducers can be used to represent operations or tasks, like network
@@ -53,16 +53,16 @@ public struct SignalProducer<Value, Error: ErrorType> {
 		}
 	}
 
-	/// Creates a producer for a Signal that will immediately send an error.
+	/// Creates a producer for a Signal that will immediately fail with the
+	/// given error.
 	public init(error: Error) {
 		self.init { observer, disposable in
-			observer.sendError(error)
+			observer.sendFailed(error)
 		}
 	}
 
 	/// Creates a producer for a Signal that will immediately send one value
-	/// then complete, or immediately send an error, depending on the given
-	/// Result.
+	/// then complete, or immediately fail, depending on the given Result.
 	public init(result: Result<Value, Error>) {
 		switch result {
 		case let .Success(value):
@@ -207,7 +207,7 @@ public struct SignalProducer<Value, Error: ErrorType> {
 	/// each invocation of start().
 	///
 	/// Upon success, the started signal will send the resulting value then
-	/// complete. Upon failure, the started signal will send the error that
+	/// complete. Upon failure, the started signal will fail with the error that
 	/// occurred.
 	public static func attempt(operation: () -> Result<Value, Error>) -> SignalProducer {
 		return self.init { observer, disposable in
@@ -215,7 +215,7 @@ public struct SignalProducer<Value, Error: ErrorType> {
 				observer.sendNext(value)
 				observer.sendCompleted()
 				}, ifFailure: { error in
-					observer.sendError(error)
+					observer.sendFailed(error)
 			})
 		}
 	}
@@ -348,13 +348,13 @@ extension SignalProducerType {
 	}
 	
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callback when an `error` event is
+	/// the Signal, which will invoke the given callback when a `failed` event is
 	/// received.
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal.
-	public func startWithError(error: Error -> ()) -> Disposable {
-		return start(Observer(error: error))
+	public func startWithFailed(failed: Error -> ()) -> Disposable {
+		return start(Observer(failed: failed))
 	}
 	
 	/// Creates a Signal from the producer, then adds exactly one observer to
@@ -490,7 +490,7 @@ extension SignalProducerType {
 	/// Delays `Next` and `Completed` events by the given interval, forwarding
 	/// them on the given scheduler.
 	///
-	/// `Error` and `Interrupted` events are always scheduled immediately.
+	/// `Failed` and `Interrupted` events are always scheduled immediately.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func delay(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> SignalProducer<Value, Error> {
 		return lift { $0.delay(interval, onScheduler: scheduler) }
@@ -508,7 +508,7 @@ extension SignalProducerType {
 	///
 	/// In other words, this brings Events “into the monad.”
 	///
-	/// When a Completed or Error event is received, the resulting producer will send
+	/// When a Completed or Failed event is received, the resulting producer will send
 	/// the Event itself and then complete. When an Interrupted event is received,
 	/// the resulting producer will send the Event itself and then interrupt.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
@@ -599,7 +599,7 @@ extension SignalProducerType {
 
 	/// Forwards events from `self` until `replacement` begins sending events.
 	///
-	/// Returns a producer which passes through `Next`, `Error`, and `Interrupted`
+	/// Returns a producer which passes through `Next`, `Failed`, and `Interrupted`
 	/// events from `self` until `replacement` sends an event, at which point the
 	/// returned producer will send that event and switch to passing through events
 	/// from `replacement` instead, regardless of whether `self` has sent events
@@ -650,14 +650,14 @@ extension SignalProducerType {
 	}
 
 	/// Applies `operation` to values from `self` with `Success`ful results
-	/// forwarded on the returned producer and `Failure`s sent as `Error` events.
+	/// forwarded on the returned producer and `Failure`s sent as `Failed` events.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func attempt(operation: Value -> Result<(), Error>) -> SignalProducer<Value, Error> {
 		return lift { $0.attempt(operation) }
 	}
 
 	/// Applies `operation` to values from `self` with `Success`ful results mapped
-	/// on the returned producer and `Failure`s sent as `Error` events.
+	/// on the returned producer and `Failure`s sent as `Failed` events.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func attemptMap<U>(operation: Value -> Result<U, Error>) -> SignalProducer<U, Error> {
 		return lift { $0.attemptMap(operation) }
@@ -677,7 +677,7 @@ extension SignalProducerType {
 	}
 
 	/// Forwards events from `self` until `interval`. Then if producer isn't completed yet,
-	/// errors with `error` on `scheduler`.
+	/// fails with `error` on `scheduler`.
 	///
 	/// If the interval is 0, the timeout will be scheduled immediately. The producer
 	/// must complete synchronously (or on a faster scheduler) to avoid the timeout.
@@ -706,10 +706,10 @@ extension SignalProducerType where Value: EventType, Error == NoError {
 }
 
 extension SignalProducerType where Error == NoError {
-	/// Promotes a producer that does not generate errors into one that can.
+	/// Promotes a producer that does not generate failures into one that can.
 	///
-	/// This does not actually cause errors to be generated for the given producer,
-	/// but makes it easier to combine with other producers that may error; for
+	/// This does not actually cause failers to be generated for the given producer,
+	/// but makes it easier to combine with other producers that may fail; for
 	/// example, with operators like `combineLatestWith`, `zipWith`, `flatten`, etc.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func promoteErrors<F: ErrorType>(_: F.Type) -> SignalProducer<Value, F> {
@@ -759,7 +759,7 @@ public func timer(interval: NSTimeInterval, onScheduler scheduler: DateScheduler
 extension SignalProducerType {
 	/// Injects side effects to be performed upon the specified signal events.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func on(started started: (() -> ())? = nil, event: (Event<Value, Error> -> ())? = nil, error: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil, next: (Value -> ())? = nil) -> SignalProducer<Value, Error> {
+	public func on(started started: (() -> ())? = nil, event: (Event<Value, Error> -> ())? = nil, failed: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil, next: (Value -> ())? = nil) -> SignalProducer<Value, Error> {
 		return SignalProducer { observer, compositeDisposable in
 			started?()
 			_ = disposed.map(compositeDisposable.addDisposable)
@@ -774,8 +774,8 @@ extension SignalProducerType {
 					case let .Next(value):
 						next?(value)
 
-					case let .Error(err):
-						error?(err)
+					case let .Failed(error):
+						failed?(error)
 
 					case .Completed:
 						completed?()
@@ -1007,8 +1007,8 @@ extension SignalProducerType where Value: SignalProducerType, Error == Value.Err
 	/// Flattens the inner producers sent upon `producer` (into a single producer of
 	/// values), according to the semantics of the given strategy.
 	///
-	/// If `producer` or an active inner producer emits an error, the returned
-	/// producer will forward that error immediately.
+	/// If `producer` or an active inner producer fails, the returned
+	/// producer will forward that failure immediately.
 	///
 	/// `Interrupted` events on inner producers will be treated like `Completed`
 	/// events on inner producers.
@@ -1041,8 +1041,8 @@ extension SignalProducerType {
 	/// resulting producers (into a single producer of values), according to the
 	/// semantics of the given strategy.
 	///
-	/// If `producer` or any of the created producers emit an error, the returned
-	/// producer will forward that error immediately.
+	/// If `producer` or any of the created producers fail, the returned
+	/// producer will forward that failure immediately.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func flatMap<U>(strategy: FlattenStrategy, transform: Value -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
 		return map(transform).flatten(strategy)
@@ -1059,7 +1059,7 @@ extension SignalProducerType {
 		return map(transform).flatten(strategy)
 	}
 
-	/// Catches any error that may occur on the input producer, mapping to a new producer
+	/// Catches any failure that may occur on the input producer, mapping to a new producer
 	/// that starts in its place.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func flatMapError<F>(handler: Error -> SignalProducer<Value, F>) -> SignalProducer<Value, F> {
@@ -1074,7 +1074,7 @@ extension SignalProducerType {
 					switch event {
 					case let .Next(value):
 						observer.sendNext(value)
-					case let .Error(error):
+					case let .Failed(error):
 						handler(error).startWithSignal { signal, signalDisposable in
 							serialDisposable.innerDisposable = signalDisposable
 							signal.observe(observer)
@@ -1136,7 +1136,7 @@ extension SignalProducerType {
 		}
 	}
 
-	/// Ignores errors up to `count` times.
+	/// Ignores failures up to `count` times.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func retry(count: Int) -> SignalProducer<Value, Error> {
 		precondition(count >= 0)
@@ -1151,7 +1151,7 @@ extension SignalProducerType {
 	}
 
 	/// Waits for completion of `producer`, *then* forwards all events from
-	/// `replacement`. Any error sent from `producer` is forwarded immediately, in
+	/// `replacement`. Any failure sent from `producer` is forwarded immediately, in
 	/// which case `replacement` will not be started, and none of its events will be
 	/// be forwarded. All values sent from `producer` are ignored.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
@@ -1162,8 +1162,8 @@ extension SignalProducerType {
 
 				signal.observe { event in
 					switch event {
-					case let .Error(error):
-						observer.sendError(error)
+					case let .Failed(error):
+						observer.sendFailed(error)
 					case .Completed:
 						observer.sendCompleted()
 					case .Interrupted:
@@ -1202,7 +1202,7 @@ extension SignalProducerType {
 					return
 				}
 				result = .Success(value)
-			case let .Error(error):
+			case let .Failed(error):
 				result = .Failure(error)
 				dispatch_semaphore_signal(semaphore)
 			case .Completed, .Interrupted:

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -44,7 +44,7 @@ class ActionSpec: QuickSpec {
 							}
 						} else {
 							scheduler.schedule {
-								observer.sendError(testError)
+								observer.sendFailed(testError)
 							}
 						}
 					}
@@ -61,7 +61,7 @@ class ActionSpec: QuickSpec {
 
 			it("should error if executed while disabled") {
 				var receivedError: ActionError<NSError>?
-				action.apply(0).startWithError {
+				action.apply(0).startWithFailed {
 					receivedError = $0
 				}
 
@@ -113,7 +113,7 @@ class ActionSpec: QuickSpec {
 				it("should execute with an error") {
 					var receivedError: ActionError<NSError>?
 
-					action.apply(1).startWithError {
+					action.apply(1).startWithFailed {
 						receivedError = $0
 					}
 

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -124,7 +124,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 						return
 					}
 
-					observer.sendError(expectedError)
+					observer.sendFailed(expectedError)
 					expect(error).to(equal(expectedError as NSError))
 				}
 				
@@ -139,7 +139,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 						return
 					}
 					
-					observer.sendError(testNSError)
+					observer.sendFailed(testNSError)
 					
 					let userInfoValue = error?.userInfo[key] as? String
 					expect(userInfoValue).to(equal(userInfo[key]))

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -43,11 +43,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				producer
 					.mapError { _ in producerError }
-					.startWithError { error = $0 }
+					.startWithFailed { error = $0 }
 
 				expect(error).to(beNil())
 
-				observer.sendError(TestError.Default)
+				observer.sendFailed(TestError.Default)
 				expect(error).to(equal(producerError))
 			}
 		}
@@ -434,10 +434,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				var error: TestError?
 
-				producer.startWithError { error = $0 }
+				producer.startWithFailed { error = $0 }
 
 				expect(error).to(beNil())
-				observer.sendError(.Default)
+				observer.sendFailed(.Default)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -683,7 +683,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					let observer = observer
 
 					testScheduler.schedule {
-						observer.sendError(TestError.Default)
+						observer.sendFailed(TestError.Default)
 					}
 				}
 				
@@ -691,7 +691,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				producer
 					.delay(10, onScheduler: testScheduler)
-					.startWithError { _ in errored = true }
+					.startWithFailed { _ in errored = true }
 				
 				testScheduler.advance()
 				expect(errored).to(beTruthy())
@@ -962,10 +962,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 				
-				observer.sendError(TestError.Default)
+				observer.sendFailed(TestError.Default)
 				if let latestEvent = latestEvent {
 					switch latestEvent {
-					case .Error(_):
+					case .Failed(_):
 						()
 					default:
 						fail()
@@ -1000,11 +1000,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should error out for Error events") {
 				var errored = false
-				dematerialized.startWithError { _ in errored = true }
+				dematerialized.startWithFailed { _ in errored = true }
 				
 				expect(errored).to(beFalsy())
 				
-				observer.sendNext(.Error(TestError.Default))
+				observer.sendNext(.Failed(TestError.Default))
 				expect(errored).to(beTruthy())
 			}
 
@@ -1059,7 +1059,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					switch event {
 					case let .Next(value):
 						result.append(value)
-					case .Error(_):
+					case .Failed(_):
 						errored = true
 					default:
 						break
@@ -1071,7 +1071,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(3)
 				expect(errored).to(beFalsy())
 				
-				observer.sendError(TestError.Default)
+				observer.sendFailed(TestError.Default)
 				expect(errored).to(beTruthy())
 				expect(result).to(beEmpty())
 			}
@@ -1096,7 +1096,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					switch event {
 					case .Completed:
 						completed = true
-					case .Error(_):
+					case .Failed(_):
 						errored = true
 					default:
 						break
@@ -1122,7 +1122,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					switch event {
 					case .Completed:
 						completed = true
-					case .Error(_):
+					case .Failed(_):
 						errored = true
 					default:
 						break
@@ -1167,7 +1167,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				producer.startWithError { err in
+				producer.startWithFailed { err in
 					error = err
 				}
 				
@@ -1202,7 +1202,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				producer.startWithError { err in
+				producer.startWithFailed { err in
 					error = err
 				}
 				

--- a/ReactiveCocoaTests/Swift/SignalProducerNimbleMatchers.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerNimbleMatchers.swift
@@ -33,7 +33,7 @@ public func sendValues<T: Equatable, E: Equatable>(values: [T], sendError maybeS
 					sentValues.append(value)
 				case .Completed:
 					signalCompleted = true
-				case let .Error(error):
+				case let .Failed(error):
 					sentError = error
 				default:
 					break

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -84,7 +84,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.start()
 				expect(addedDisposable.disposed).to(beFalsy())
 
-				observer.sendError(.Default)
+				observer.sendFailed(.Default)
 				expect(addedDisposable.disposed).to(beTruthy())
 			}
 
@@ -141,7 +141,7 @@ class SignalProducerSpec: QuickSpec {
 					switch event {
 					case let .Next(value):
 						values.append(value)
-					case let .Error(err):
+					case let .Failed(err):
 						error = err
 					case .Completed:
 						completed = true
@@ -172,7 +172,7 @@ class SignalProducerSpec: QuickSpec {
 
 				producer.start { event in
 					switch event {
-					case let .Error(err):
+					case let .Failed(err):
 						error = err
 					default:
 						break
@@ -181,7 +181,7 @@ class SignalProducerSpec: QuickSpec {
 
 				expect(error).to(beNil())
 
-				observer.sendError(sentError)
+				observer.sendFailed(sentError)
 				expect(error) == sentError
 			}
 		}
@@ -295,7 +295,7 @@ class SignalProducerSpec: QuickSpec {
 					switch event {
 					case let .Next(value):
 						values.append(value)
-					case let .Error(err):
+					case let .Failed(err):
 						error = err
 					default:
 						break
@@ -311,7 +311,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(values).to(equal([2, 3, 4]))
 				expect(error).to(beNil())
 
-				observer.sendError(.Default)
+				observer.sendFailed(.Default)
 
 				expect(values).to(equal([2, 3, 4]))
 				expect(error).to(equal(TestError.Default))
@@ -601,7 +601,7 @@ class SignalProducerSpec: QuickSpec {
 				producer.startWithSignal { _ in }
 				expect(addedDisposable.disposed).to(beFalsy())
 
-				observer.sendError(.Default)
+				observer.sendFailed(.Default)
 				expect(addedDisposable.disposed).to(beTruthy())
 			}
 		}
@@ -960,7 +960,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should invoke the handler and start new producer for an error") {
 				let (baseProducer, baseObserver) = SignalProducer<Int, TestError>.buffer()
 				baseObserver.sendNext(1)
-				baseObserver.sendError(.Default)
+				baseObserver.sendFailed(.Default)
 
 				var values: [Int] = []
 				var completed = false
@@ -1048,7 +1048,7 @@ class SignalProducerSpec: QuickSpec {
 					let outerProducer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: errorProducer)
 
 					var error: TestError?
-					(outerProducer.flatten(.Concat)).startWithError { e in
+					(outerProducer.flatten(.Concat)).startWithFailed { e in
 						error = e
 					}
 
@@ -1059,11 +1059,11 @@ class SignalProducerSpec: QuickSpec {
 					let (outerProducer, outerObserver) = SignalProducer<SignalProducer<Int, TestError>, TestError>.buffer()
 
 					var error: TestError?
-					outerProducer.flatten(.Concat).startWithError { e in
+					outerProducer.flatten(.Concat).startWithFailed { e in
 						error = e
 					}
 
-					outerObserver.sendError(TestError.Default)
+					outerObserver.sendFailed(TestError.Default)
 					expect(error).to(equal(TestError.Default))
 				}
 
@@ -1171,7 +1171,7 @@ class SignalProducerSpec: QuickSpec {
 						let outerProducer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: errorProducer)
 
 						var error: TestError?
-						outerProducer.flatten(.Merge).startWithError { e in
+						outerProducer.flatten(.Merge).startWithFailed { e in
 							error = e
 						}
 						expect(error).to(equal(TestError.Default))
@@ -1181,11 +1181,11 @@ class SignalProducerSpec: QuickSpec {
 						let (outerProducer, outerObserver) = SignalProducer<SignalProducer<Int, TestError>, TestError>.buffer()
 
 						var error: TestError?
-						outerProducer.flatten(.Merge).startWithError { e in
+						outerProducer.flatten(.Merge).startWithFailed { e in
 							error = e
 						}
 
-						outerObserver.sendError(TestError.Default)
+						outerObserver.sendFailed(TestError.Default)
 						expect(error).to(equal(TestError.Default))
 					}
 				}
@@ -1207,7 +1207,7 @@ class SignalProducerSpec: QuickSpec {
 							receivedValues.append(value)
 						case .Completed:
 							completed = true
-						case .Error(_):
+						case .Failed(_):
 							errored = true
 						default:
 							break
@@ -1421,7 +1421,7 @@ class SignalProducerSpec: QuickSpec {
 				let expectedEvents: [Event<Int, TestError>] = [
 					.Next(1),
 					.Next(2),
-					.Error(.Default)
+					.Failed(.Default)
 				]
 
 				// TODO: if let result = result where result.count == expectedEvents.count

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -39,14 +39,14 @@ class SignalSpec: QuickSpec {
 			it("should deallocate after erroring") {
 				weak var signal: Signal<AnyObject, TestError>? = Signal { observer in
 					testScheduler.schedule {
-						observer.sendError(TestError.Default)
+						observer.sendFailed(TestError.Default)
 					}
 					return nil
 				}
 				
 				var errored = false
 				
-				signal?.observeError { _ in errored = true }
+				signal?.observeFailed { _ in errored = true }
 				
 				expect(errored).to(beFalsy())
 				expect(signal).toNot(beNil())
@@ -142,14 +142,14 @@ class SignalSpec: QuickSpec {
 				
 				let signal: Signal<AnyObject, TestError> = Signal { observer in
 					testScheduler.schedule {
-						observer.sendError(TestError.Default)
+						observer.sendFailed(TestError.Default)
 					}
 					return disposable
 				}
 				
 				var errored = false
 				
-				signal.observeError { _ in errored = true }
+				signal.observeFailed { _ in errored = true }
 				
 				expect(errored).to(beFalsy())
 				expect(disposable.disposed).to(beFalsy())
@@ -225,7 +225,7 @@ class SignalSpec: QuickSpec {
 					let (signal, observer) = Signal<(), TestError>.pipe()
 					weakSignal = signal
 					testScheduler.schedule {
-						observer.sendError(TestError.Default)
+						observer.sendFailed(TestError.Default)
 					}
 				}
 				test()
@@ -464,11 +464,11 @@ class SignalSpec: QuickSpec {
 
 				signal
 					.mapError { _ in producerError }
-					.observeError { err in error = err }
+					.observeFailed { err in error = err }
 
 				expect(error).to(beNil())
 
-				observer.sendError(TestError.Default)
+				observer.sendFailed(TestError.Default)
 				expect(error).to(equal(producerError))
 			}
 		}
@@ -851,10 +851,10 @@ class SignalSpec: QuickSpec {
 
 				var error: TestError?
 
-				signal.observeError { error = $0 }
+				signal.observeFailed { error = $0 }
 
 				expect(error).to(beNil())
-				observer.sendError(.Default)
+				observer.sendFailed(.Default)
 				expect(error).to(equal(TestError.Default))
 			}
 		}
@@ -1098,7 +1098,7 @@ class SignalSpec: QuickSpec {
 				let testScheduler = TestScheduler()
 				let signal: Signal<Int, TestError> = Signal { observer in
 					testScheduler.schedule {
-						observer.sendError(TestError.Default)
+						observer.sendFailed(TestError.Default)
 					}
 					return nil
 				}
@@ -1107,7 +1107,7 @@ class SignalSpec: QuickSpec {
 				
 				signal
 					.delay(10, onScheduler: testScheduler)
-					.observeError { _ in errored = true }
+					.observeFailed { _ in errored = true }
 				
 				testScheduler.advance()
 				expect(errored).to(beTruthy())
@@ -1379,10 +1379,10 @@ class SignalSpec: QuickSpec {
 					}
 				}
 				
-				observer.sendError(TestError.Default)
+				observer.sendFailed(TestError.Default)
 				if let latestEvent = latestEvent {
 					switch latestEvent {
-					case .Error(_):
+					case .Failed(_):
 						()
 					default:
 						fail()
@@ -1417,11 +1417,11 @@ class SignalSpec: QuickSpec {
 
 			it("should error out for Error events") {
 				var errored = false
-				dematerialized.observeError { _ in errored = true }
+				dematerialized.observeFailed { _ in errored = true }
 				
 				expect(errored).to(beFalsy())
 				
-				observer.sendNext(.Error(TestError.Default))
+				observer.sendNext(.Failed(TestError.Default))
 				expect(errored).to(beTruthy())
 			}
 
@@ -1476,7 +1476,7 @@ class SignalSpec: QuickSpec {
 					switch event {
 					case let .Next(value):
 						result.append(value)
-					case .Error(_):
+					case .Failed(_):
 						errored = true
 					default:
 						break
@@ -1488,7 +1488,7 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(3)
 				expect(errored).to(beFalsy())
 				
-				observer.sendError(TestError.Default)
+				observer.sendFailed(TestError.Default)
 				expect(errored).to(beTruthy())
 				expect(result).to(beEmpty())
 			}
@@ -1513,7 +1513,7 @@ class SignalSpec: QuickSpec {
 					switch event {
 					case .Completed:
 						completed = true
-					case .Error(_):
+					case .Failed(_):
 						errored = true
 					default:
 						break
@@ -1539,7 +1539,7 @@ class SignalSpec: QuickSpec {
 					switch event {
 					case .Completed:
 						completed = true
-					case .Error(_):
+					case .Failed(_):
 						errored = true
 					default:
 						break
@@ -1584,7 +1584,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				signal.observeError { err in
+				signal.observeFailed { err in
 					error = err
 				}
 				
@@ -1619,7 +1619,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				var error: TestError?
-				signal.observeError { err in
+				signal.observeFailed { err in
 					error = err
 				}
 				


### PR DESCRIPTION
#2360 again, but against master

My last status was:
> There are a few bits I still think could use some clarity / outside opinions:
> 
> 1. `flatMapError` vs `flatMapFailure`, and relatedly, `mapError` vs `mapFailure`
> 1. The name `promoteErrors` throws me off a bit. `promoteFailures` doesn’t seem right either. ¯\\\_(ツ)_/¯

As it stands, I’m personally feeling no huge need to change `flatMapError` or `promoteErrors` to be `failure`-based. So unless others feel strongly, this should be safe to review.