### PR TITLE
refactored and re-implemented combineLatest() to use a single OSSpinLock regardless of tuple size

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1540,9 +1540,6 @@ public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: Signal<A, Erro
 	}
 }
 
-
-
-
 /// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`. No events will be sent if the sequence is empty.
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
@@ -1563,6 +1560,7 @@ public func combineLatest<S: CollectionType where S.Generator.Element : SignalTy
 		return disposable
 	}
 }
+
 /// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`. No events will be sent if the sequence is empty.
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1258,11 +1258,6 @@ extension SignalType {
 		return self.map { $0 }
 	}
 }
-@warn_unused_result(message="Did you forget to call `observe` on the signal?")
-public func combineLatest<A : SignalType, B : SignalType where A.Error == B.Error>(a: A, _ b: B) -> Signal<(A.Value, B.Value), A.Error> {
-	let anySignals: [Signal<Any,A.Error>] = [a.mapToAny(),b.mapToAny()]
-	return combineLatest(anySignals).map { $0.toTuple() }
-}
 
 /// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
@@ -1270,8 +1265,8 @@ public func combineLatest<A : SignalType, B : SignalType where A.Error == B.Erro
 public func combineLatest<A, B, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>) -> Signal<(A, B), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny()]
+		[a.mapToAny(),
+		 b.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 
@@ -1281,9 +1276,9 @@ public func combineLatest<A, B, Error>(a: Signal<A, Error>, _ b: Signal<B, Error
 public func combineLatest<A, B, C, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>, _ c: Signal<C, Error>) -> Signal<(A, B, C), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny()]
+		[a.mapToAny(),
+		 b.mapToAny(),
+		 c.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 
@@ -1293,10 +1288,10 @@ public func combineLatest<A, B, C, Error>(a: Signal<A, Error>, _ b: Signal<B, Er
 public func combineLatest<A, B, C, D, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>, _ c: Signal<C, Error>, _ d: Signal<D, Error>) -> Signal<(A, B, C, D), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny()]
+		[a.mapToAny(),
+	 	 b.mapToAny(),
+		 c.mapToAny(),
+		 d.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 
@@ -1307,11 +1302,11 @@ public func combineLatest<A, B, C, D, Error>(a: Signal<A, Error>, _ b: Signal<B,
 public func combineLatest<A, B, C, D, E, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>, _ c: Signal<C, Error>, _ d: Signal<D, Error>, _ e: Signal<E, Error>) -> Signal<(A, B, C, D, E), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny()]
+		[a.mapToAny(),
+		 b.mapToAny(),
+		 c.mapToAny(),
+		 d.mapToAny(),
+		 e.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 
@@ -1321,12 +1316,12 @@ public func combineLatest<A, B, C, D, E, Error>(a: Signal<A, Error>, _ b: Signal
 public func combineLatest<A, B, C, D, E, F, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>, _ c: Signal<C, Error>, _ d: Signal<D, Error>, _ e: Signal<E, Error>, _ f: Signal<F, Error>) -> Signal<(A, B, C, D, E, F), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny()]
+		[a.mapToAny(),
+		 b.mapToAny(),
+		 c.mapToAny(),
+		 d.mapToAny(),
+		 e.mapToAny(),
+		 f.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 
@@ -1336,13 +1331,13 @@ public func combineLatest<A, B, C, D, E, F, Error>(a: Signal<A, Error>, _ b: Sig
 public func combineLatest<A, B, C, D, E, F, G, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>, _ c: Signal<C, Error>, _ d: Signal<D, Error>, _ e: Signal<E, Error>, _ f: Signal<F, Error>, _ g: Signal<G, Error>) -> Signal<(A, B, C, D, E, F, G), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny(),
-		g.mapToAny()]
+		[a.mapToAny(),
+		 b.mapToAny(),
+		 c.mapToAny(),
+		 d.mapToAny(),
+		 e.mapToAny(),
+		 f.mapToAny(),
+		 g.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 
@@ -1352,14 +1347,14 @@ public func combineLatest<A, B, C, D, E, F, G, Error>(a: Signal<A, Error>, _ b: 
 public func combineLatest<A, B, C, D, E, F, G, H, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>, _ c: Signal<C, Error>, _ d: Signal<D, Error>, _ e: Signal<E, Error>, _ f: Signal<F, Error>, _ g: Signal<G, Error>, _ h: Signal<H, Error>) -> Signal<(A, B, C, D, E, F, G, H), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny(),
-		g.mapToAny(),
-		h.mapToAny()]
+		[a.mapToAny(),
+		 b.mapToAny(),
+		 c.mapToAny(),
+		 d.mapToAny(),
+		 e.mapToAny(),
+		 f.mapToAny(),
+		 g.mapToAny(),
+		 h.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 
@@ -1369,15 +1364,15 @@ public func combineLatest<A, B, C, D, E, F, G, H, Error>(a: Signal<A, Error>, _ 
 public func combineLatest<A, B, C, D, E, F, G, H, I, Error>(a: Signal<A, Error>, _ b: Signal<B, Error>, _ c: Signal<C, Error>, _ d: Signal<D, Error>, _ e: Signal<E, Error>, _ f: Signal<F, Error>, _ g: Signal<G, Error>, _ h: Signal<H, Error>, _ i: Signal<I, Error>) -> Signal<(A, B, C, D, E, F, G, H, I), Error> {
 	
 	let anySignals: [Signal<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny(),
-		g.mapToAny(),
-		h.mapToAny(),
-		i.mapToAny()]
+		[a.mapToAny(),
+		 b.mapToAny(),
+		 c.mapToAny(),
+		 d.mapToAny(),
+		 e.mapToAny(),
+		 f.mapToAny(),
+		 g.mapToAny(),
+		 h.mapToAny(),
+		 i.mapToAny()]
 	return combineLatest(anySignals).map { $0.toTuple() }
 }
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1550,9 +1550,7 @@ public func combineLatest<S: CollectionType where S.Generator.Element : SignalTy
 						  S.Index.Distance == Int>(signals: S) -> Signal<[S.Generator.Element.Value], S.Generator.Element.Error> {
 	return Signal { observer in
 		
-		typealias Value = S.Generator.Element.Value
-		typealias Error = S.Generator.Element.Error
-		let collector = ArrayCollector<Value>(count: signals.count)
+		let collector = ArrayCollector<S.Generator.Element.Value>(count: signals.count)
 		let states = Atomic(CombineLatestStates(collector))
 		let disposable = CompositeDisposable()
 		

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -823,10 +823,19 @@ extension SignalProducerType {
 /// `combineLatestWith`.
 @warn_unused_result(message="Did you forget to call `start` on the producer?")
 public func combineLatest<A, B, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>) -> SignalProducer<(A, B), Error> {
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	   [a.mapToAny(),
-		b.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 
 
@@ -834,11 +843,21 @@ public func combineLatest<A, B, Error>(a: SignalProducer<A, Error>, _ b: SignalP
 /// `combineLatestWith`.
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>) -> SignalProducer<(A, B, C), Error> {
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 
 /// Combines the values of all the given signals, in the manner described by
@@ -846,12 +865,23 @@ public func combineLatest<A, B, C, Error>(a: SignalProducer<A, Error>, _ b: Sign
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>) -> SignalProducer<(A, B, C, D), Error> {
 	
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		let (signal_d,observer_d) = Signal<D,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c,signal_d)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += d.start(observer_d)
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 
 /// Combines the values of all the given signals, in the manner described by
@@ -859,13 +889,25 @@ public func combineLatest<A, B, C, D, Error>(a: SignalProducer<A, Error>, _ b: S
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>) -> SignalProducer<(A, B, C, D, E), Error> {
 	
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		let (signal_d,observer_d) = Signal<D,Error>.pipe()
+		let (signal_e,observer_e) = Signal<E,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c,signal_d,signal_e)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += e.start(observer_e)
+		disposable += d.start(observer_d)
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 
 /// Combines the values of all the given signals, in the manner described by
@@ -873,29 +915,56 @@ public func combineLatest<A, B, C, D, E, Error>(a: SignalProducer<A, Error>, _ b
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>) -> SignalProducer<(A, B, C, D, E, F), Error> {
 	
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		let (signal_d,observer_d) = Signal<D,Error>.pipe()
+		let (signal_e,observer_e) = Signal<E,Error>.pipe()
+		let (signal_f,observer_f) = Signal<F,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c,signal_d,signal_e,signal_f)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += f.start(observer_f)
+		disposable += e.start(observer_e)
+		disposable += d.start(observer_d)
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 /// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>) -> SignalProducer<(A, B, C, D, E, F, G), Error> {
 	
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny(),
-		g.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		let (signal_d,observer_d) = Signal<D,Error>.pipe()
+		let (signal_e,observer_e) = Signal<E,Error>.pipe()
+		let (signal_f,observer_f) = Signal<F,Error>.pipe()
+		let (signal_g,observer_g) = Signal<G,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c,signal_d,signal_e,signal_f,signal_g)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += g.start(observer_g)
+		disposable += f.start(observer_f)
+		disposable += e.start(observer_e)
+		disposable += d.start(observer_d)
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 
 /// Combines the values of all the given signals, in the manner described by
@@ -903,16 +972,31 @@ public func combineLatest<A, B, C, D, E, F, G, Error>(a: SignalProducer<A, Error
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, H, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>) -> SignalProducer<(A, B, C, D, E, F, G, H), Error> {
 	
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny(),
-		g.mapToAny(),
-		h.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		let (signal_d,observer_d) = Signal<D,Error>.pipe()
+		let (signal_e,observer_e) = Signal<E,Error>.pipe()
+		let (signal_f,observer_f) = Signal<F,Error>.pipe()
+		let (signal_g,observer_g) = Signal<G,Error>.pipe()
+		let (signal_h,observer_h) = Signal<H,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c,signal_d,signal_e,signal_f,signal_g,signal_h)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += h.start(observer_h)
+		disposable += g.start(observer_g)
+		disposable += f.start(observer_f)
+		disposable += e.start(observer_e)
+		disposable += d.start(observer_d)
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 
 /// Combines the values of all the given signals, in the manner described by
@@ -920,17 +1004,33 @@ public func combineLatest<A, B, C, D, E, F, G, H, Error>(a: SignalProducer<A, Er
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, H, I, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>) -> SignalProducer<(A, B, C, D, E, F, G, H, I), Error> {
 	
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny(),
-		g.mapToAny(),
-		h.mapToAny(),
-		i.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+		
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		let (signal_d,observer_d) = Signal<D,Error>.pipe()
+		let (signal_e,observer_e) = Signal<E,Error>.pipe()
+		let (signal_f,observer_f) = Signal<F,Error>.pipe()
+		let (signal_g,observer_g) = Signal<G,Error>.pipe()
+		let (signal_h,observer_h) = Signal<H,Error>.pipe()
+		let (signal_i,observer_i) = Signal<I,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c,signal_d,signal_e,signal_f,signal_g,signal_h,signal_i)
+		
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += i.start(observer_i)
+		disposable += h.start(observer_h)
+		disposable += g.start(observer_g)
+		disposable += f.start(observer_f)
+		disposable += e.start(observer_e)
+		disposable += d.start(observer_d)
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 
 /// Combines the values of all the given signals, in the manner described by
@@ -938,25 +1038,43 @@ public func combineLatest<A, B, C, D, E, F, G, H, I, Error>(a: SignalProducer<A,
 @warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>, _ j: SignalProducer<J, Error>) -> SignalProducer<(A, B, C, D, E, F, G, H, I, J), Error> {
 	
-	let anySignalProducers: [SignalProducer<Any,Error>] =
-	[a.mapToAny(),
-		b.mapToAny(),
-		c.mapToAny(),
-		d.mapToAny(),
-		e.mapToAny(),
-		f.mapToAny(),
-		g.mapToAny(),
-		h.mapToAny(),
-		i.mapToAny(),
-		j.mapToAny()]
-	return combineLatest(anySignalProducers).map { $0.toTuple() }
+	return SignalProducer { observer, disposable in
+
+		let (signal_a,observer_a) = Signal<A,Error>.pipe()
+		let (signal_b,observer_b) = Signal<B,Error>.pipe()
+		let (signal_c,observer_c) = Signal<C,Error>.pipe()
+		let (signal_d,observer_d) = Signal<D,Error>.pipe()
+		let (signal_e,observer_e) = Signal<E,Error>.pipe()
+		let (signal_f,observer_f) = Signal<F,Error>.pipe()
+		let (signal_g,observer_g) = Signal<G,Error>.pipe()
+		let (signal_h,observer_h) = Signal<H,Error>.pipe()
+		let (signal_i,observer_i) = Signal<I,Error>.pipe()
+		let (signal_j,observer_j) = Signal<J,Error>.pipe()
+		
+		let combined = combineLatest(signal_a,signal_b,signal_c,signal_d,signal_e,signal_f,signal_g,signal_h,signal_i,signal_j)
+
+		disposable += combined.observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+
+		
+		// why start backwards?  cause the old logic started them in this order.
+		disposable += j.start(observer_j)
+		disposable += i.start(observer_i)
+		disposable += h.start(observer_h)
+		disposable += g.start(observer_g)
+		disposable += f.start(observer_f)
+		disposable += e.start(observer_e)
+		disposable += d.start(observer_d)
+		disposable += c.start(observer_c)
+		disposable += b.start(observer_b)
+		disposable += a.start(observer_a)
+	}
 }
 /// Combines the values of all the given producers, in the manner described by
 /// `combineLatestWith`. Will return an empty `SignalProducer` if the sequence is empty.
 @warn_unused_result(message="Did you forget to call `start` on the producer?")
 public func combineLatest<S: SequenceType, Value, Error where S.Generator.Element == SignalProducer<Value, Error>>(producers: S) -> SignalProducer<[Value], Error> {
 	
-	return SignalProducer { observer, outerDisposable in
+	return SignalProducer { observer, disposable in
 		
 		// let's make a set of proxy Signals that will actually be combined.
 		// Since producers can return a completed signal instantly, we need to call combineLatest on a set of proxy signals
@@ -966,15 +1084,12 @@ public func combineLatest<S: SequenceType, Value, Error where S.Generator.Elemen
 			return (producer,signal,observer)
 		}
 		let signals = psoTuples.map { $0.1 }  // extract all the Signals and combineThen!
-		outerDisposable += combineLatest(signals).observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		disposable += combineLatest(signals).observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
 		
 		// why are we calling reverse()?  cause the old logic would actually execute the producer startWithSignal() in reverse array order.
 		// This keeps expected behavior the same as earlier logic, but the side effects are minor if we remove reverse()
-		for (producer,_,observer) in psoTuples.reverse() {
-			producer.startWithSignal { producersignal, innerDisposable in
-				producersignal.observe(observer)
-				outerDisposable += innerDisposable
-			}
+		for (producer,_,innerobserver) in psoTuples.reverse() {
+			disposable += producer.start(innerobserver)
 		}
 	}
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -812,100 +812,171 @@ extension SignalProducerType {
 			}
 		}
 	}
+	
+	private func mapToAny() -> SignalProducer<Any,Error> {
+		return self.map	{ $0 }
+	}
+
 }
 
 /// Combines the values of all the given producers, in the manner described by
 /// `combineLatestWith`.
 @warn_unused_result(message="Did you forget to call `start` on the producer?")
 public func combineLatest<A, B, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>) -> SignalProducer<(A, B), Error> {
-	return a.combineLatestWith(b)
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	   [a.mapToAny(),
+		b.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
 
-/// Combines the values of all the given producers, in the manner described by
+
+// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>) -> SignalProducer<(A, B, C), Error> {
-	return combineLatest(a, b)
-		.combineLatestWith(c)
-		.map(repack)
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
 
-/// Combines the values of all the given producers, in the manner described by
+/// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>) -> SignalProducer<(A, B, C, D), Error> {
-	return combineLatest(a, b, c)
-		.combineLatestWith(d)
-		.map(repack)
+	
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny(),
+		d.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
 
-/// Combines the values of all the given producers, in the manner described by
+/// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>) -> SignalProducer<(A, B, C, D, E), Error> {
-	return combineLatest(a, b, c, d)
-		.combineLatestWith(e)
-		.map(repack)
+	
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny(),
+		d.mapToAny(),
+		e.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
 
-/// Combines the values of all the given producers, in the manner described by
+/// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>) -> SignalProducer<(A, B, C, D, E, F), Error> {
-	return combineLatest(a, b, c, d, e)
-		.combineLatestWith(f)
-		.map(repack)
+	
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny(),
+		d.mapToAny(),
+		e.mapToAny(),
+		f.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
-
-/// Combines the values of all the given producers, in the manner described by
+/// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>) -> SignalProducer<(A, B, C, D, E, F, G), Error> {
-	return combineLatest(a, b, c, d, e, f)
-		.combineLatestWith(g)
-		.map(repack)
+	
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny(),
+		d.mapToAny(),
+		e.mapToAny(),
+		f.mapToAny(),
+		g.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
 
-/// Combines the values of all the given producers, in the manner described by
+/// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, H, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>) -> SignalProducer<(A, B, C, D, E, F, G, H), Error> {
-	return combineLatest(a, b, c, d, e, f, g)
-		.combineLatestWith(h)
-		.map(repack)
+	
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny(),
+		d.mapToAny(),
+		e.mapToAny(),
+		f.mapToAny(),
+		g.mapToAny(),
+		h.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
 
-/// Combines the values of all the given producers, in the manner described by
+/// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, H, I, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>) -> SignalProducer<(A, B, C, D, E, F, G, H, I), Error> {
-	return combineLatest(a, b, c, d, e, f, g, h)
-		.combineLatestWith(i)
-		.map(repack)
+	
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny(),
+		d.mapToAny(),
+		e.mapToAny(),
+		f.mapToAny(),
+		g.mapToAny(),
+		h.mapToAny(),
+		i.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
 
-/// Combines the values of all the given producers, in the manner described by
+/// Combines the values of all the given signals, in the manner described by
 /// `combineLatestWith`.
-@warn_unused_result(message="Did you forget to call `start` on the producer?")
+@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 public func combineLatest<A, B, C, D, E, F, G, H, I, J, Error>(a: SignalProducer<A, Error>, _ b: SignalProducer<B, Error>, _ c: SignalProducer<C, Error>, _ d: SignalProducer<D, Error>, _ e: SignalProducer<E, Error>, _ f: SignalProducer<F, Error>, _ g: SignalProducer<G, Error>, _ h: SignalProducer<H, Error>, _ i: SignalProducer<I, Error>, _ j: SignalProducer<J, Error>) -> SignalProducer<(A, B, C, D, E, F, G, H, I, J), Error> {
-	return combineLatest(a, b, c, d, e, f, g, h, i)
-		.combineLatestWith(j)
-		.map(repack)
+	
+	let anySignalProducers: [SignalProducer<Any,Error>] =
+	[a.mapToAny(),
+		b.mapToAny(),
+		c.mapToAny(),
+		d.mapToAny(),
+		e.mapToAny(),
+		f.mapToAny(),
+		g.mapToAny(),
+		h.mapToAny(),
+		i.mapToAny(),
+		j.mapToAny()]
+	return combineLatest(anySignalProducers).map { $0.toTuple() }
 }
-
 /// Combines the values of all the given producers, in the manner described by
 /// `combineLatestWith`. Will return an empty `SignalProducer` if the sequence is empty.
 @warn_unused_result(message="Did you forget to call `start` on the producer?")
 public func combineLatest<S: SequenceType, Value, Error where S.Generator.Element == SignalProducer<Value, Error>>(producers: S) -> SignalProducer<[Value], Error> {
-	var generator = producers.generate()
-	if let first = generator.next() {
-		let initial = first.map { [$0] }
-		return GeneratorSequence(generator).reduce(initial) { producer, next in
-			producer.combineLatestWith(next).map { $0.0 + [$0.1] }
+	
+	return SignalProducer { observer, outerDisposable in
+		
+		// let's make a set of proxy Signals that will actually be combined.
+		// Since producers can return a completed signal instantly, we need to call combineLatest on a set of proxy signals
+		// create an array of Tuples that map a producer to a new Signal/Observer pair.
+		let psoTuples = producers.map { producer -> (SignalProducer<Value,Error>,Signal<Value,Error>,Observer<Value,Error>)in
+			let (signal,observer) = Signal<Value,Error>.pipe()
+			return (producer,signal,observer)
+		}
+		let signals = psoTuples.map { $0.1 }  // extract all the Signals and combineThen!
+		outerDisposable += combineLatest(signals).observe(observer) // we must bind the proxy signals first, cause some producer signals will complete instantly on start.
+		
+		// why are we calling reverse()?  cause the old logic would actually execute the producer startWithSignal() in reverse array order.
+		// This keeps expected behavior the same as earlier logic, but the side effects are minor if we remove reverse()
+		for (producer,_,observer) in psoTuples.reverse() {
+			producer.startWithSignal { producersignal, innerDisposable in
+				producersignal.observe(observer)
+				outerDisposable += innerDisposable
+			}
 		}
 	}
-	
-	return .empty
 }
 
 /// Zips the values of all the given producers, in the manner described by

--- a/ReactiveCocoa/Swift/TupleExtensions.swift
+++ b/ReactiveCocoa/Swift/TupleExtensions.swift
@@ -40,3 +40,125 @@ internal func repack<A, B, C, D, E, F, G, H, I>(t: (A, B, C, D, E, F, G, H), val
 internal func repack<A, B, C, D, E, F, G, H, I, J>(t: (A, B, C, D, E, F, G, H, I), value: J) -> (A, B, C, D, E, F, G, H, I, J) {
 	return (t.0, t.1, t.2, t.3, t.4, t.5, t.6, t.7, t.8, value)
 }
+
+
+// This will extend 'indexable' collections that can use an integer Index, 
+/// like Arrays to allow some conviences tuple implementations
+public extension SequenceType where Self:Indexable, Self.Index : IntegerLiteralConvertible {
+	
+	private func _get_element<T>(index : Index) -> T {
+		let x = self[index]
+		let t = x as? T
+		precondition(t != nil, "\(x) is not of type \(T.self) at index \(index) of \(Self.self)")
+		return t!
+	}
+	
+	public func toTuple<A,B>() -> (A,B) {
+		return
+			(self._get_element(0),
+				self._get_element(1))
+	}
+	public func toTuple<A, B, C>() -> (A, B, C) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2))
+	}
+	public func toTuple<A, B, C, D>() -> (A, B, C, D) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3))
+	}
+	public func toTuple<A, B, C, D, E>() -> (A, B, C, D, E) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4))
+	}
+	public func toTuple<A, B, C, D, E, F>() -> (A, B, C, D, E, F) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4),
+			self._get_element(5))
+	}
+	public func toTuple<A, B, C, D, E, F, G>() -> (A, B, C, D, E, F, G) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4),
+			self._get_element(5),
+			self._get_element(6))
+	}
+	public func toTuple<A, B, C, D, E, F, G, H>() -> (A, B, C, D, E, F, G, H) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4),
+			self._get_element(5),
+			self._get_element(6),
+			self._get_element(7))
+	}
+	public func toTuple<A, B, C, D, E, F, G, H, I>() -> (A, B, C, D, E, F, G, H, I) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4),
+			self._get_element(5),
+			self._get_element(6),
+			self._get_element(7),
+			self._get_element(8))
+	}
+	public func toTuple<A, B, C, D, E, F, G, H, I, J>() -> (A, B, C, D, E, F, G, H, I, J) {
+		return (self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4),
+			self._get_element(5),
+			self._get_element(6),
+			self._get_element(7),
+			self._get_element(8),
+			self._get_element(9))
+	}
+	public func toTuple<A, B, C, D, E, F, G, H, I, J, K>() -> (A, B, C, D, E, F, G, H, I, J, K) {
+		return (
+			self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4),
+			self._get_element(5),
+			self._get_element(6),
+			self._get_element(7),
+			self._get_element(8),
+			self._get_element(9),
+			self._get_element(10))
+	}
+	public func toTuple<A, B, C, D, E, F, G, H, I, J, K, L>() -> (A, B, C, D, E, F, G, H, I, J, K, L) {
+		return (self._get_element(0),
+			self._get_element(1),
+			self._get_element(2),
+			self._get_element(3),
+			self._get_element(4),
+			self._get_element(5),
+			self._get_element(6),
+			self._get_element(7),
+			self._get_element(8),
+			self._get_element(9),
+			self._get_element(10),
+			self._get_element(11))
+	}
+}

--- a/ReactiveCocoa/Swift/TupleExtensions.swift
+++ b/ReactiveCocoa/Swift/TupleExtensions.swift
@@ -42,123 +42,523 @@ internal func repack<A, B, C, D, E, F, G, H, I, J>(t: (A, B, C, D, E, F, G, H, I
 }
 
 
-// This will extend 'indexable' collections that can use an integer Index, 
-/// like Arrays to allow some conviences tuple implementations
-public extension SequenceType where Self:Indexable, Self.Index : IntegerLiteralConvertible {
+
+// will allow you to build an Array or Tuple value, one value at time.
+protocol IndexedCollectorType {
+	// the type of the final tuple or Array
+	typealias Value
 	
-	private func _get_element<T>(index : Index) -> T {
-		let x = self[index]
-		let t = x as? T
-		precondition(t != nil, "\(x) is not of type \(T.self) at index \(index) of \(Self.self)")
-		return t!
+	// number of elements in the tuple or array.
+	var count : Int { get }
+
+	// will update the tuple at index for a given input of type T
+	// if T is the 'wrong' type than this method may throw an execption
+	// return true if this is the first value for that index
+	mutating func setValueAtIndex<T>(index:Int, value:T) -> Bool
+	
+	// convert the current values the desired final Tuple or Array
+	// do not call until all values have at least one value, or you will get an nil exception
+	func toValue() -> Value
+}
+
+
+class ArrayCollector<Element> : IndexedCollectorType {
+
+	typealias Value = [Element]
+
+	var values: [Element?]
+	
+	var count : Int
+
+	required init(count:Int) {
+		self.count = count
+		self.values = [Element?](count: count,repeatedValue: nil)
 	}
 	
-	public func toTuple<A,B>() -> (A,B) {
-		return
-			(self._get_element(0),
-				self._get_element(1))
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		let isFirstValue = (self.values[index] == nil)
+		self.values[index] = (value as! Element)
+		return isFirstValue
 	}
-	public func toTuple<A, B, C>() -> (A, B, C) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2))
+
+	final func toValue() -> Value {
+		return self.values.map { $0! }
 	}
-	public func toTuple<A, B, C, D>() -> (A, B, C, D) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3))
+	
+}
+
+class TupleCollector10<A,B,C,D,E,F,G,H,I,J> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C,D,E,F,G,H,I,J)
+	
+	var values: (A?,B?,C?,D?,E?,F?,G?,H?,I?,J?)
+	
+	let count = 10
+	
+	required init() {
+		self.values = (nil,nil,nil,nil,nil,nil,nil,nil,nil,nil)
 	}
-	public func toTuple<A, B, C, D, E>() -> (A, B, C, D, E) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4))
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		case 3:
+			let isFirstValue = (self.values.3  == nil)
+			self.values.3 = (value as! D)
+			return isFirstValue
+		case 4:
+			let isFirstValue = (self.values.4  == nil)
+			self.values.4 = (value as! E)
+			return isFirstValue
+		case 5:
+			let isFirstValue = (self.values.5  == nil)
+			self.values.5 = (value as! F)
+			return isFirstValue
+		case 6:
+			let isFirstValue = (self.values.6  == nil)
+			self.values.6 = (value as! G)
+			return isFirstValue
+		case 7:
+			let isFirstValue = (self.values.7  == nil)
+			self.values.7 = (value as! H)
+			return isFirstValue
+		case 8:
+			let isFirstValue = (self.values.8  == nil)
+			self.values.8 = (value as! I)
+			return isFirstValue
+		case 9:
+			let isFirstValue = (self.values.9  == nil)
+			self.values.9 = (value as! J)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
 	}
-	public func toTuple<A, B, C, D, E, F>() -> (A, B, C, D, E, F) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4),
-			self._get_element(5))
-	}
-	public func toTuple<A, B, C, D, E, F, G>() -> (A, B, C, D, E, F, G) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4),
-			self._get_element(5),
-			self._get_element(6))
-	}
-	public func toTuple<A, B, C, D, E, F, G, H>() -> (A, B, C, D, E, F, G, H) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4),
-			self._get_element(5),
-			self._get_element(6),
-			self._get_element(7))
-	}
-	public func toTuple<A, B, C, D, E, F, G, H, I>() -> (A, B, C, D, E, F, G, H, I) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4),
-			self._get_element(5),
-			self._get_element(6),
-			self._get_element(7),
-			self._get_element(8))
-	}
-	public func toTuple<A, B, C, D, E, F, G, H, I, J>() -> (A, B, C, D, E, F, G, H, I, J) {
-		return (self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4),
-			self._get_element(5),
-			self._get_element(6),
-			self._get_element(7),
-			self._get_element(8),
-			self._get_element(9))
-	}
-	public func toTuple<A, B, C, D, E, F, G, H, I, J, K>() -> (A, B, C, D, E, F, G, H, I, J, K) {
-		return (
-			self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4),
-			self._get_element(5),
-			self._get_element(6),
-			self._get_element(7),
-			self._get_element(8),
-			self._get_element(9),
-			self._get_element(10))
-	}
-	public func toTuple<A, B, C, D, E, F, G, H, I, J, K, L>() -> (A, B, C, D, E, F, G, H, I, J, K, L) {
-		return (self._get_element(0),
-			self._get_element(1),
-			self._get_element(2),
-			self._get_element(3),
-			self._get_element(4),
-			self._get_element(5),
-			self._get_element(6),
-			self._get_element(7),
-			self._get_element(8),
-			self._get_element(9),
-			self._get_element(10),
-			self._get_element(11))
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!,
+			values.3!,
+			values.4!,
+			values.5!,
+			values.6!,
+			values.7!,
+			values.8!,
+			values.9!)
 	}
 }
+
+class TupleCollector9<A,B,C,D,E,F,G,H,I> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C,D,E,F,G,H,I)
+	
+	var values: (A?,B?,C?,D?,E?,F?,G?,H?,I?)
+	
+	let count = 9
+	
+	required init() {
+		self.values = (nil,nil,nil,nil,nil,nil,nil,nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		case 3:
+			let isFirstValue = (self.values.3  == nil)
+			self.values.3 = (value as! D)
+			return isFirstValue
+		case 4:
+			let isFirstValue = (self.values.4  == nil)
+			self.values.4 = (value as! E)
+			return isFirstValue
+		case 5:
+			let isFirstValue = (self.values.5  == nil)
+			self.values.5 = (value as! F)
+			return isFirstValue
+		case 6:
+			let isFirstValue = (self.values.6  == nil)
+			self.values.6 = (value as! G)
+			return isFirstValue
+		case 7:
+			let isFirstValue = (self.values.7  == nil)
+			self.values.7 = (value as! H)
+			return isFirstValue
+		case 8:
+			let isFirstValue = (self.values.8  == nil)
+			self.values.8 = (value as! I)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
+	}
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!,
+			values.3!,
+			values.4!,
+			values.5!,
+			values.6!,
+			values.7!,
+			values.8!)
+	}
+}
+
+
+class TupleCollector8<A,B,C,D,E,F,G,H> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C,D,E,F,G,H)
+	
+	var values: (A?,B?,C?,D?,E?,F?,G?,H?)
+	
+	let count = 8
+	
+	required init() {
+		self.values = (nil,nil,nil,nil,nil,nil,nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		case 3:
+			let isFirstValue = (self.values.3  == nil)
+			self.values.3 = (value as! D)
+			return isFirstValue
+		case 4:
+			let isFirstValue = (self.values.4  == nil)
+			self.values.4 = (value as! E)
+			return isFirstValue
+		case 5:
+			let isFirstValue = (self.values.5  == nil)
+			self.values.5 = (value as! F)
+			return isFirstValue
+		case 6:
+			let isFirstValue = (self.values.6  == nil)
+			self.values.6 = (value as! G)
+			return isFirstValue
+		case 7:
+			let isFirstValue = (self.values.7  == nil)
+			self.values.7 = (value as! H)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
+	}
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!,
+			values.3!,
+			values.4!,
+			values.5!,
+			values.6!,
+			values.7!)
+	}
+}
+
+class TupleCollector7<A,B,C,D,E,F,G> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C,D,E,F,G)
+	
+	var values: (A?,B?,C?,D?,E?,F?,G?)
+	
+	let count = 7
+	
+	required init() {
+		self.values = (nil,nil,nil,nil,nil,nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		case 3:
+			let isFirstValue = (self.values.3  == nil)
+			self.values.3 = (value as! D)
+			return isFirstValue
+		case 4:
+			let isFirstValue = (self.values.4  == nil)
+			self.values.4 = (value as! E)
+			return isFirstValue
+		case 5:
+			let isFirstValue = (self.values.5  == nil)
+			self.values.5 = (value as! F)
+			return isFirstValue
+		case 6:
+			let isFirstValue = (self.values.6  == nil)
+			self.values.6 = (value as! G)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
+	}
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!,
+			values.3!,
+			values.4!,
+			values.5!,
+			values.6!)
+	}
+}
+
+class TupleCollector6<A,B,C,D,E,F> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C,D,E,F)
+	
+	var values: (A?,B?,C?,D?,E?,F?)
+	
+	let count = 6
+	
+	required init() {
+		self.values = (nil,nil,nil,nil,nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		case 3:
+			let isFirstValue = (self.values.3  == nil)
+			self.values.3 = (value as! D)
+			return isFirstValue
+		case 4:
+			let isFirstValue = (self.values.4  == nil)
+			self.values.4 = (value as! E)
+			return isFirstValue
+		case 5:
+			let isFirstValue = (self.values.5  == nil)
+			self.values.5 = (value as! F)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
+	}
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!,
+			values.3!,
+			values.4!,
+			values.5!)
+	}
+}
+
+class TupleCollector5<A,B,C,D,E> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C,D,E)
+	
+	var values: (A?,B?,C?,D?,E?)
+	
+	let count = 5
+	
+	required init() {
+		self.values = (nil,nil,nil,nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		case 3:
+			let isFirstValue = (self.values.3  == nil)
+			self.values.3 = (value as! D)
+			return isFirstValue
+		case 4:
+			let isFirstValue = (self.values.4  == nil)
+			self.values.4 = (value as! E)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
+	}
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!,
+			values.3!,
+			values.4!)
+	}
+}
+
+class TupleCollector4<A,B,C,D> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C,D)
+	
+	var values: (A?,B?,C?,D?)
+	
+	let count = 4
+	
+	required init() {
+		self.values = (nil,nil,nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		case 3:
+			let isFirstValue = (self.values.3  == nil)
+			self.values.3 = (value as! D)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
+	}
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!,
+			values.3!)
+	}
+}
+
+class TupleCollector3<A,B,C> : IndexedCollectorType {
+	
+	typealias Value = (A,B,C)
+	
+	var values: (A?,B?,C?)
+	
+	let count = 3
+	
+	required init() {
+		self.values = (nil,nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		case 2:
+			let isFirstValue = (self.values.2  == nil)
+			self.values.2 = (value as! C)
+			return isFirstValue
+		default:
+			fatalError("index value must be 0..<\(self.count)")
+		}
+	}
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!,
+			values.2!)
+	}
+}
+
+class TupleCollector2<A,B> : IndexedCollectorType {
+	
+	typealias Value = (A,B)
+	
+	var values: (A?,B?)
+	
+	let count = 2
+	
+	required init() {
+		self.values = (nil,nil)
+	}
+	
+	final func setValueAtIndex<T>(index:Int, value:T) -> Bool {
+		switch index {
+		case 0:
+			let isFirstValue = (self.values.0  == nil)
+			self.values.0 = (value as! A)
+			return isFirstValue
+		case 1:
+			let isFirstValue = (self.values.1  == nil)
+			self.values.1 = (value as! B)
+			return isFirstValue
+		default:
+			fatalError("tuples bigger than \(self.count) items not supported")
+		}
+	}
+	
+	final func toValue() -> Value {
+		return (values.0!,
+			values.1!)
+	}
+}
+
+
+
+
+
+

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -858,7 +858,6 @@ class SignalProducerSpec: QuickSpec {
 				let producer = combineLatest(producerArray)
 				let result = producer.collect().single()
 				
-				
 				expect(result?.value?.last).to(equal(expectedResult))
 			}
 		}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -838,14 +838,19 @@ class SignalProducerSpec: QuickSpec {
 			
 			var producerArray: [SignalProducer<Int, NoError>]!
 			var scheduler : QueueScheduler!
+			var expectedResult: [Int]!
 
 			beforeEach {
 				scheduler = QueueScheduler(queue: dispatch_queue_create("big-time-contention", DISPATCH_QUEUE_SERIAL))
 
 				producerArray = []
 				for i in 0..<100 {
-					let p = SignalProducer<Int, NoError>(values: [ i, 100+i ]).startOn(scheduler)
+					let p = SignalProducer<Int, NoError>(values: [ i, i, i, 100+i ]).startOn(scheduler)
 					producerArray.append(p)
+				}
+				expectedResult = []
+				for i in 100..<200 {
+					expectedResult.append(i)
 				}
 			}
 			
@@ -853,10 +858,8 @@ class SignalProducerSpec: QuickSpec {
 				let producer = combineLatest(producerArray)
 				let result = producer.collect().single()
 				
-				NSLog("\(result)")
 				
-				
-				// it's almost impossible to verify this data, but we shouldn't crash!
+				expect(result?.value?.last).to(equal(expectedResult))
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1292,20 +1292,16 @@ class SignalSpec: QuickSpec {
 			}
 		}
 		
-		describe("combineLatest with big stuff") {
+		describe("combineLatest with 100 Signals") {
 			
 			var signals: [Signal<Int, NoError>]!
 			var observers: [Observer<Int, NoError>]!
-			var scheduler : QueueScheduler!
-			var expectedResult: [Int]!
 			var numberOfSignals : Int!
 
 			var combinedSignal: Signal<[Int], NoError>!
-			var observer: Signal<[Int], NoError>.Observer!
 			
 			beforeEach {
-				numberOfSignals = 1000
-				scheduler = QueueScheduler(queue: dispatch_queue_create("big-time-signal-contention", DISPATCH_QUEUE_SERIAL))
+				numberOfSignals = 100
 				
 				signals = []
 				observers = []


### PR DESCRIPTION
Added simple Tuple extensions for packing and unpacking Tuples into Arrays.
    
completely reimplemented  the combineLatest(signals : [Signal<Value,Error]) -> Signal<[Value],Error> to use a single array of values, and and a single spin lock, regardless of the number of elements in the array.   
    
No more 'climbing' chain of   .combineLatest().combineLatestWith().map(repack) for each additional tuple size.

Old Solution had  O(N) NSLocks, and copies of the 'latestValue' (where N = tuple or array size).

New solution uses a single array of latest Values, a single spin lock, a won't create a set of blocks that could overflow the stack.  O(1) stack depth!
