### PR TITLE
use #import, not @import

### DIFF
--- a/ReactiveCocoa/Objective-C/RACDynamicPropertySuperclass.h
+++ b/ReactiveCocoa/Objective-C/RACDynamicPropertySuperclass.h
@@ -1,6 +1,6 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 /// This superclass is an implementation detail of DynamicProperty. Do
 /// not use it.


### PR DESCRIPTION
As far as I can tell, there is no way to enable module support in a project that uses *any* Objective-C++. This means that importing the ReactiveCocoa headers -- even from a pure Objective-C file -- will result in an error on this line.

Since it's the only use of `@import` in the codebase, it seems nice from a consistency standpoint as well.