### PR TITLE
Enable "Require Only App-Extension-Safe API" for RAC 2

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "jspahrsummers/xcconfigs" >= 0.7.1
+github "jspahrsummers/xcconfigs" >= 0.8
 github "Quick/Quick"
 github "Quick/Nimble"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" >= 0.8
-github "Quick/Quick" ~> 0.3.1
-github "Quick/Nimble" ~> 1.0
+github "Quick/Quick" == 0.3.1
+github "Quick/Nimble" == 0.4.2

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" >= 0.8
-github "Quick/Quick"
-github "Quick/Nimble"
+github "Quick/Quick" ~> 0.3.1
+github "Quick/Nimble" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v3.0.0"
-github "Quick/Quick" "v0.8.0"
+github "Quick/Nimble" "v1.0.0"
+github "Quick/Quick" "v0.3.1"
 github "jspahrsummers/xcconfigs" "0.8.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v1.0.0"
+github "Quick/Nimble" "v0.4.2"
 github "Quick/Quick" "v0.3.1"
 github "jspahrsummers/xcconfigs" "0.8.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v0.4.2"
-github "Quick/Quick" "v0.3.1"
-github "jspahrsummers/xcconfigs" "0.7.2"
+github "Quick/Nimble" "v3.0.0"
+github "Quick/Quick" "v0.8.0"
+github "jspahrsummers/xcconfigs" "0.8.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v1.0.0"
-github "Quick/Quick" "v0.3.1"
+github "Quick/Nimble" "v3.0.0"
+github "Quick/Quick" "v0.8.0"
 github "jspahrsummers/xcconfigs" "0.8.1"


### PR DESCRIPTION
This ports #1891 back to RAC 2. I couldn't find a living branch for RAC 2, so I created `2.x-maintenance`.

I've tested this so far by pointing to this branch from the Cartfile of the project where I originally experienced the "linking to dylib not safe" warning.

I opened an equivalent PR against Mantle 1: https://github.com/Mantle/Mantle/pull/639