### PR TITLE
Added overloads for flatMap and flatten for Signals/Producers which can't emit errors

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -388,6 +388,30 @@ extension SignalType {
 	}
 }
 
+extension SignalType where Error == NoError {
+	/// Maps each event from `signal` to a new producer, then flattens the
+	/// resulting producers (into a signal of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// If `signal` or any of the created producers fail, the returned signal
+	/// will forward that failure immediately.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func flatMap<NewValue, NewError>(strategy: FlattenStrategy, transform: Value -> SignalProducer<NewValue, NewError>) -> Signal<NewValue, NewError> {
+		return map(transform).flatten(strategy)
+	}
+
+	/// Maps each event from `signal` to a new signal, then flattens the
+	/// resulting signals (into a signal of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// If `signal` or any of the created signals emit an error, the returned
+	/// signal will forward that error immediately.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func flatMap<NewValue, NewError>(strategy: FlattenStrategy, transform: Value -> Signal<NewValue, NewError>) -> Signal<NewValue, NewError> {
+		return map(transform).flatten(strategy)
+	}
+}
+
 extension SignalType where Value: SignalProducerType, Error == Value.Error {
 	/// Returns a signal which sends all the values from producer signal emitted from
 	/// `signal`, waiting until each inner producer completes before beginning to

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -310,6 +310,21 @@ extension SignalType where Value: SignalType, Error == Value.Error {
 	}
 }
 
+extension SignalType where Value: SignalType, Error == NoError {
+	/// Flattens the inner signals sent upon `signal` (into a single signal of
+	/// values), according to the semantics of the given strategy.
+	///
+	/// If `signal` or an active inner signal emits an error, the returned
+	/// signal will forward that error immediately.
+	///
+	/// `Interrupted` events on inner signals will be treated like `Completed`
+	/// events on inner signals.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func flatten(strategy: FlattenStrategy) -> Signal<Value.Value, Value.Error> {
+		return self.promoteErrors(Value.Error.self).flatten(strategy)
+	}
+}
+
 extension SignalType where Value: SignalProducerType, Error == Value.Error {
 	/// Flattens the inner producers sent upon `signal` (into a single signal of
 	/// values), according to the semantics of the given strategy.
@@ -331,6 +346,21 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 		case .Latest:
 			return self.switchToLatest()
 		}
+	}
+}
+
+extension SignalType where Value: SignalProducerType, Error == NoError {
+	/// Flattens the inner producers sent upon `signal` (into a single signal of
+	/// values), according to the semantics of the given strategy.
+	///
+	/// If `signal` or an active inner producer fails, the returned signal will
+	/// forward that failure immediately.
+	///
+	/// `Interrupted` events on inner producers will be treated like `Completed`
+	/// events on inner producers.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func flatten(strategy: FlattenStrategy) -> Signal<Value.Value, Value.Error> {
+		return self.promoteErrors(Value.Error.self).flatten(strategy)
 	}
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1020,6 +1020,23 @@ extension SignalProducerType where Value: SignalProducerType, Error == Value.Err
 	}
 }
 
+extension SignalProducerType where Value: SignalProducerType, Error == NoError {
+	/// Flattens the inner producers sent upon `producer` (into a single producer of
+	/// values), according to the semantics of the given strategy.
+	///
+	/// If `producer` or an active inner producer fails, the returned
+	/// producer will forward that failure immediately.
+	///
+	/// `Interrupted` events on inner producers will be treated like `Completed`
+	/// events on inner producers.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func flatten(strategy: FlattenStrategy) -> SignalProducer<Value.Value, Value.Error> {
+		return self.lift { (signal: Signal<Value, Error>) -> Signal<Value.Value, Value.Error> in
+			return signal.flatten(strategy)
+		}
+	}
+}
+
 extension SignalProducerType where Value: SignalType, Error == Value.Error {
 	/// Flattens the inner signals sent upon `producer` (into a single producer of
 	/// values), according to the semantics of the given strategy.
@@ -1035,6 +1052,22 @@ extension SignalProducerType where Value: SignalType, Error == Value.Error {
 	}
 }
 
+extension SignalProducerType where Value: SignalType, Error == NoError {
+	/// Flattens the inner signals sent upon `producer` (into a single producer of
+	/// values), according to the semantics of the given strategy.
+	///
+	/// If `producer` or an active inner signal emits an error, the returned
+	/// producer will forward that error immediately.
+	///
+	/// `Interrupted` events on inner signals will be treated like `Completed`
+	/// events on inner signals.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func flatten(strategy: FlattenStrategy) -> SignalProducer<Value.Value, Value.Error> {
+		return self.lift { (signal: Signal<Value, Error>) -> Signal<Value.Value, Value.Error> in
+			return signal.flatten(strategy)
+		}
+	}
+}
 
 extension SignalProducerType {
 	/// Maps each event from `producer` to a new producer, then flattens the

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1106,6 +1106,30 @@ extension SignalProducerType {
 	}
 }
 
+extension SignalProducerType where Error == NoError {
+	/// Maps each event from `producer` to a new producer, then flattens the
+	/// resulting producers (into a single producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// If `producer` or any of the created producers fail, the returned
+	/// producer will forward that failure immediately.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func flatMap<NewValue, NewError>(strategy: FlattenStrategy, transform: Value -> SignalProducer<NewValue, NewError>) -> SignalProducer<NewValue, NewError> {
+		return map(transform).flatten(strategy)
+	}
+
+	/// Maps each event from `producer` to a new signal, then flattens the
+	/// resulting signals (into a single producer of values), according to the
+	/// semantics of the given strategy.
+	///
+	/// If `producer` or any of the created signals emit an error, the returned
+	/// producer will forward that error immediately.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func flatMap<NewValue, NewError>(strategy: FlattenStrategy, transform: Value -> Signal<NewValue, NewError>) -> SignalProducer<NewValue, NewError> {
+		return map(transform).flatten(strategy)
+	}
+}
+
 extension SignalProducerType {
 	/// Repeats `self` a total of `count` times. Repeating `1` times results in
 	/// an equivalent signal producer.


### PR DESCRIPTION
Added overloads for `flatMap` and `flatten` for `Signal`s or `SignalProducer`s which can't emit errors.
This makes the methods friendlier to newcomers who might struggle with type errors because the outer type is `NoError`.

It is unfortunate that this requires so much duplication, but it's probably for the best to put the burden on the framework, rather than users struggling with this.

*Thanks to @andymatuschak for the original idea!*