### PR TITLE
Failing test with concat() + take(): incorrect or expected behavior?

### DIFF
--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1692,6 +1692,34 @@ class SignalProducerSpec: QuickSpec {
 				expect(upstreamDisposable.disposed).to(beTruthy())
 			}
 		}
+
+		describe("take") {
+			it("Should not start concat'ed producer if the first one sends a value when using take(1)") {
+				let producer1 = SignalProducer<(), NoError>() { handler, _ in
+					handler.sendNext(())
+					handler.sendCompleted()
+				}.startOn(QueueScheduler()) // Delaying producer1 from sending a value to test whether producer2 is started in the mean-time.
+
+				let producer2 = SignalProducer<(), NoError>() { handler, _ in
+					XCTFail("producer2 shouldn't be started because producer1 sends enough values for the subscriber")
+
+					handler.sendNext(())
+					handler.sendCompleted()
+				}
+
+				let resultProducer = producer1.concat(producer2).take(1)
+
+				guard let result = resultProducer.collect().first() else {
+					XCTFail("Result shouldn't be nil")
+					return
+				}
+
+				switch result {
+					case .Success(let values): XCTAssertEqual(values.count, 1, "result producer should only send one value")
+					case .Failure(let error): XCTFail("Error shouldn't occur: \(error)")
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
When `concat`-ing 2 producers, the second one is started even if the first one sends enough values for the observer, when using `take()`.

A real world example of this:

`Producer1`: Asynchronously retrieve data from cache
`Producer2`: Load data from the network

`ResultProducer`: Ask `Producer1` to load the data. Concat that with `Producer2`, and do `take(1)`, such that, if the cache returns data, we don't hit the network. The current implementation of `concat` actually starts the second producer, which results in an unnecessary network request.

Is this expected behavior, and should I implement this pattern a different way? From my point of view, `concat` and `take` behaving this way was at least counter-intuitive.

I didn't attempt at making this test pass, since I only wanted to surface the issue that I ran into to figure out if it's a bug or not :) 