### PR TITLE
Implement `skipRepeats` for SignalType with optional value

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1022,6 +1022,15 @@ extension SignalType where Value: Equatable {
 	}
 }
 
+extension SignalType where Value: OptionalType, Value.Wrapped: Equatable {
+	/// Forwards only those values from `self` which are not duplicates of the
+	/// immedately preceding value. The first value is always forwarded.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func skipRepeats() -> Signal<Value, Error> {
+		return skipRepeats{ $0.optional == $1.optional }
+	}
+}
+
 extension SignalType {
 	/// Forwards only those values from `self` which do not pass `isRepeat` with
 	/// respect to the previous value. The first value is always forwarded.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -726,6 +726,15 @@ extension SignalProducerType where Value: Equatable {
 	}
 }
 
+extension SignalProducerType where Value: OptionalType, Value.Wrapped: Equatable {
+	/// Forwards only those values from `self` which are not duplicates of the
+	/// immedately preceding value. The first value is always forwarded.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func skipRepeats() -> SignalProducer<Value, Error> {
+		return lift { $0.skipRepeats() }
+	}
+}
+
 
 /// Creates a repeating timer of the given interval, with a reasonable
 /// default leeway, sending updates on the given scheduler.

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -236,6 +236,48 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(values).to(equal([ true, false, true ]))
 			}
 
+			it("should skip duplicate optional values") {
+				let (baseProducer, observer) = SignalProducer<Bool?, NoError>.buffer()
+				let producer = baseProducer.skipRepeats()
+
+				var values: [Bool?] = []
+				producer.startWithNext { values.append($0) }
+
+				expect(values.count).to(equal(0))
+
+				observer.sendNext(true)
+				expect(values.count).to(equal(1))
+				expect(values[0]).to(equal(true))
+
+				observer.sendNext(true)
+				expect(values.count).to(equal(1))
+				expect(values[0]).to(equal(true))
+
+				observer.sendNext(false)
+				expect(values.count).to(equal(2))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+
+				observer.sendNext(nil)
+				expect(values.count).to(equal(3))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+				expect(values[2]).to(beNil())
+
+				observer.sendNext(nil)
+				expect(values.count).to(equal(3))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+				expect(values[2]).to(beNil())
+
+				observer.sendNext(true)
+				expect(values.count).to(equal(4))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+				expect(values[2]).to(beNil())
+				expect(values[3]).to(equal(true))
+			}
+
 			it("should skip values according to a predicate") {
 				let (baseProducer, observer) = SignalProducer<String, NoError>.buffer()
 				let producer = baseProducer.skipRepeats { $0.characters.count == $1.characters.count }

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -658,6 +658,48 @@ class SignalSpec: QuickSpec {
 				expect(values).to(equal([ true, false, true ]))
 			}
 
+			it("should skip duplicate optional values") {
+				let (baseSignal, observer) = Signal<Bool?, NoError>.pipe()
+				let signal = baseSignal.skipRepeats()
+
+				var values: [Bool?] = []
+				signal.observeNext { values.append($0) }
+
+				expect(values.count).to(equal(0))
+
+				observer.sendNext(true)
+				expect(values.count).to(equal(1))
+				expect(values[0]).to(equal(true))
+
+				observer.sendNext(true)
+				expect(values.count).to(equal(1))
+				expect(values[0]).to(equal(true))
+
+				observer.sendNext(false)
+				expect(values.count).to(equal(2))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+
+				observer.sendNext(nil)
+				expect(values.count).to(equal(3))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+				expect(values[2]).to(beNil())
+
+				observer.sendNext(nil)
+				expect(values.count).to(equal(3))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+				expect(values[2]).to(beNil())
+
+				observer.sendNext(true)
+				expect(values.count).to(equal(4))
+				expect(values[0]).to(equal(true))
+				expect(values[1]).to(equal(false))
+				expect(values[2]).to(beNil())
+				expect(values[3]).to(equal(true))
+			}
+
 			it("should skip values according to a predicate") {
 				let (baseSignal, observer) = Signal<String, NoError>.pipe()
 				let signal = baseSignal.skipRepeats { $0.characters.count == $1.characters.count }


### PR DESCRIPTION
Before, it was not possible to just use `skipRepeats()` in such a scenario:

```
let signal = Signal<Int?, NoError>
let signalSkipRepeates = signal.skipRepeats()
```

:exclamation: `Cannot invoke 'skipRepeats' with no arguments`
:exclamation: `Expected an argument list of type '((Self.Value, Self.Value) -> Bool)'`

Thats because the version of `skipRepeats` that needs no argument is only implemented for Signals where the Value conforms to `Equatable`, but Optionals do not conform to `Equatable` (even though comparison is actually implemented and "just works")