### PR TITLE
MutablePropertyType: added "immutableView" property

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -121,6 +121,13 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	}
 }
 
+extension MutablePropertyType {
+	/// Returns a "view" of this property that can only be observed, but not modified.
+	public var immutableView: AnyProperty<Value> {
+		return AnyProperty(self)
+	}
+}
+
 /// Wraps a `dynamic` property, or one defined in Objective-C, using Key-Value
 /// Coding and Key-Value Observing.
 ///


### PR DESCRIPTION
This simplifies a very common use case where types want to have a `MutablePropertyType`, but they only want to expose it as immutable.

```swift
class Example {
    public var currentValue: AnyProperty<Int> {
        return self.currentValueImmutableProperty.immutableView
    }

    private let currentValueImmutableProperty = MutableProperty<Int>(0)
}
```