### PR TITLE
Overload `<~` to automatically bridge values to Objective-C

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -254,6 +254,11 @@ public func <~ <Value: _ObjectiveCBridgeable>(property: DynamicProperty, produce
 	return property <~ producer.map { $0._bridgeToObjectiveC() }
 }
 
+/// Binds `destinationProperty` to the latest values of `sourceProperty`, automatically bridging values to Objective-C.
+public func <~ <Value: _ObjectiveCBridgeable, Source: PropertyType where Source.Value == Value>(destinationProperty: DynamicProperty, sourceProperty: Source) -> Disposable {
+	return destinationProperty <~ sourceProperty.producer
+}
+
 
 /// Binds `destinationProperty` to the latest values of `sourceProperty`.
 ///

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -244,6 +244,17 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 }
 
 
+/// Binds a signal to a `DynamicProperty`, automatically bridging values to Objective-C.
+public func <~ <Value: _ObjectiveCBridgeable>(property: DynamicProperty, signal: Signal<Value, NoError>) -> Disposable {
+	return property <~ signal.map { $0._bridgeToObjectiveC() }
+}
+
+/// Binds a signal producer to a `DynamicProperty`, automatically bridging values to Objective-C.
+public func <~ <Value: _ObjectiveCBridgeable>(property: DynamicProperty, producer: SignalProducer<Value, NoError>) -> Disposable {
+	return property <~ producer.map { $0._bridgeToObjectiveC() }
+}
+
+
 /// Binds `destinationProperty` to the latest values of `sourceProperty`.
 ///
 /// The binding will automatically terminate when either property is

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -672,6 +672,35 @@ class PropertySpec: QuickSpec {
 					expect(bindingDisposable.disposed) == true
 				}
 			}
+
+			describe("to a dynamic property") {
+				var object: ObservableObject!
+				var property: DynamicProperty!
+
+				beforeEach {
+					object = ObservableObject()
+					expect(object.rac_value) == 0
+
+					property = DynamicProperty(object: object, keyPath: "rac_value")
+				}
+
+				afterEach {
+					object = nil
+				}
+
+				it("should bridge values sent on a signal to Objective-C") {
+					let (signal, observer) = Signal<Int, NoError>.pipe()
+					property <~ signal
+					observer.sendNext(1)
+					expect(object.rac_value) == 1
+				}
+
+				it("should bridge values sent on a signal producer to Objective-C") {
+					let producer = SignalProducer<Int, NoError>(value: 1)
+					property <~ producer
+					expect(object.rac_value) == 1
+				}
+			}
 		}
 	}
 }

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -700,6 +700,12 @@ class PropertySpec: QuickSpec {
 					property <~ producer
 					expect(object.rac_value) == 1
 				}
+
+				it("should bridge values from a source property to Objective-C") {
+					let source = MutableProperty(1)
+					property <~ source
+					expect(object.rac_value) == 1
+				}
 			}
 		}
 	}


### PR DESCRIPTION
There seems to a [good](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2425) [amount](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2198) [of](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1884) [evidence](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/1858) that doing this kind of thing is no fun:

```swift
DynamicProperty(object: myLabel, keyPath: "text") <~ gimmeStrings.map { $0 } // 😞
```

I worked out a way to overload `<~` for types that are `_ObjectiveCBridgeable` and automatically bridge them.

```swift
DynamicProperty(object: myLabel, keyPath: "text") <~ gimmeStrings // \o/
```

I'm not sure how I feel about the use of `_ObjectiveCBridgeable` and `_bridgeToObjectiveC()`. But I think this is pretty nice to have, and it should be equivalent to the implicitly bridged version.

-----

P.S.

I didn't include it in the PR, but I also add this function to my project which brings it back to RAC 2 levels of awesomeness:

```swift
func RAC(object: NSObject?, _ keyPath: String) -> DynamicProperty {
  return DynamicProperty(object: object, keyPath: keyPath)
}

RAC(myLabel, "text") <~ gimmeStrings
```