### PR TITLE
Added a failing test to illustrate bug in SignalProducer.sampleOn(SignalProducer)

### DIFF
--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1692,6 +1692,20 @@ class SignalProducerSpec: QuickSpec {
 				expect(upstreamDisposable.disposed).to(beTruthy())
 			}
 		}
+
+		describe("sampleOn") {
+			it("should emit an initial value if the sampler is a synchronous SignalProducer") {
+				let producer = SignalProducer<Int, NoError>(values: [1])
+				let sampler = SignalProducer<(), NoError>(value: ())
+
+				let result = producer.sampleOn(sampler)
+
+				var valueReceived: Int?
+				result.startWithNext { valueReceived = $0 }
+
+				expect(valueReceived) == 1
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The docs read "If `sampler` fires before a value has been observed on `self`, nothing happens.".
However, in this case the sampler "fires" synchronously upon subscription. Thus, I don't think this is the expected behavior.

If I change the test slightly:
```swift
let sampler = SignalProducer<(), NoError>(value: ())
	.delay(0.1, onScheduler: QueueScheduler())

let result = producer.sampleOn(sampler)

var valueReceived: Int?
result.startWithNext { valueReceived = $0 }

expect(valueReceived).toEventually(equal(1))
```

Then the test passes. So adding a small `delay` to introduce a scheduler jump is a workaround.