### PR TITLE
Scope usage of private libextobjc headers

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -149,6 +149,10 @@
 		7A7065821A3F88B8001E8354 /* RACKVOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */; };
 		7A7065841A3F8967001E8354 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */; };
 		7A7065851A3F8967001E8354 /* RACKVOProxySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */; };
+		A1046B7A1BFF5661004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A1046B7B1BFF5662004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A1046B7C1BFF5662004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A1046B7D1BFF5664004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A9B3155E1B3940750001CB9C /* EXTRuntimeExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037666819EDA57100A782A9 /* EXTRuntimeExtensions.m */; };
 		A9B315601B3940750001CB9C /* NSArray+RACSequenceAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D037642B19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m */; };
 		A9B315631B3940750001CB9C /* NSData+RACSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D037643119EDA41200A782A9 /* NSData+RACSupport.m */; };
@@ -1660,6 +1664,7 @@
 			files = (
 				57A4D20A1BA13D7A00F7D4B1 /* ReactiveCocoa.h in Headers */,
 				57A4D20B1BA13D7A00F7D4B1 /* EXTKeyPathCoding.h in Headers */,
+				A1046B7D1BFF5664004D8045 /* EXTRuntimeExtensions.h in Headers */,
 				57A4D20C1BA13D7A00F7D4B1 /* EXTScope.h in Headers */,
 				57A4D20D1BA13D7A00F7D4B1 /* metamacros.h in Headers */,
 				57A4D20E1BA13D7A00F7D4B1 /* NSArray+RACSequenceAdditions.h in Headers */,
@@ -1715,6 +1720,7 @@
 			files = (
 				A9B315CA1B3940AB0001CB9C /* ReactiveCocoa.h in Headers */,
 				A9B315CB1B3940AB0001CB9C /* EXTKeyPathCoding.h in Headers */,
+				A1046B7C1BFF5662004D8045 /* EXTRuntimeExtensions.h in Headers */,
 				A9B315CD1B3940AB0001CB9C /* EXTScope.h in Headers */,
 				A9B315CE1B3940AB0001CB9C /* metamacros.h in Headers */,
 				A9B315D01B3940AB0001CB9C /* NSArray+RACSequenceAdditions.h in Headers */,
@@ -1813,6 +1819,7 @@
 				D037652C19EDA41200A782A9 /* NSOrderedSet+RACSequenceAdditions.h in Headers */,
 				D03764F019EDA41200A782A9 /* NSControl+RACTextSignalSupport.h in Headers */,
 				D03765EA19EDA41200A782A9 /* RACSubject.h in Headers */,
+				A1046B7A1BFF5661004D8045 /* EXTRuntimeExtensions.h in Headers */,
 				D037652819EDA41200A782A9 /* NSObject+RACSelectorSignal.h in Headers */,
 				D037654419EDA41200A782A9 /* NSURLConnection+RACSupport.h in Headers */,
 				D03764E819EDA41200A782A9 /* NSArray+RACSequenceAdditions.h in Headers */,
@@ -1888,6 +1895,7 @@
 				D03765D319EDA41200A782A9 /* RACSignal.h in Headers */,
 				D03765F519EDA41200A782A9 /* RACSubscriptingAssignmentTrampoline.h in Headers */,
 				D03765C719EDA41200A782A9 /* RACScopedDisposable.h in Headers */,
+				A1046B7B1BFF5662004D8045 /* EXTRuntimeExtensions.h in Headers */,
 				D037661119EDA41200A782A9 /* RACUnit.h in Headers */,
 				D03765FD19EDA41200A782A9 /* RACTargetQueueScheduler.h in Headers */,
 				D037661919EDA41200A782A9 /* UIActionSheet+RACSignalSupport.h in Headers */,

--- a/ReactiveCocoa/Objective-C/NSControl+RACTextSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/NSControl+RACTextSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSControl+RACTextSignalSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDescription.h"
 #import "RACDisposable.h"
 #import "RACSignal.h"

--- a/ReactiveCocoa/Objective-C/NSNotificationCenter+RACSupport.m
+++ b/ReactiveCocoa/Objective-C/NSNotificationCenter+RACSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSNotificationCenter+RACSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACSignal.h"
 #import "RACSubscriber.h"
 #import "RACDisposable.h"

--- a/ReactiveCocoa/Objective-C/NSObject+RACAppKitBindings.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACAppKitBindings.m
@@ -7,8 +7,8 @@
 //
 
 #import "NSObject+RACAppKitBindings.h"
-#import "EXTKeyPathCoding.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "RACChannel.h"
 #import "RACCompoundDisposable.h"

--- a/ReactiveCocoa/Objective-C/NSObject+RACKVOWrapper.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACKVOWrapper.m
@@ -7,8 +7,8 @@
 //
 
 #import "NSObject+RACKVOWrapper.h"
-#import "EXTRuntimeExtensions.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTRuntimeExtensions.h>
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSString+RACKeyPathUtilities.h"
 #import "RACCompoundDisposable.h"

--- a/ReactiveCocoa/Objective-C/NSObject+RACLifting.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACLifting.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSObject+RACLifting.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSInvocation+RACTypeParsing.h"
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACDescription.h"

--- a/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "metamacros.h"
 
 /// Creates a signal which observes `KEYPATH` on `TARGET` for changes.

--- a/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSObject+RACPropertySubscribing.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACDescription.h"
 #import "NSObject+RACKVOWrapper.h"

--- a/ReactiveCocoa/Objective-C/NSObject+RACSelectorSignal.m
+++ b/ReactiveCocoa/Objective-C/NSObject+RACSelectorSignal.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSObject+RACSelectorSignal.h"
-#import "EXTRuntimeExtensions.h"
+#import <ReactiveCocoa/EXTRuntimeExtensions.h>
 #import "NSInvocation+RACTypeParsing.h"
 #import "NSObject+RACDeallocating.h"
 #import "RACCompoundDisposable.h"

--- a/ReactiveCocoa/Objective-C/NSText+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/NSText+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSText+RACSignalSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDescription.h"
 #import "RACDisposable.h"
 #import "RACSignal.h"

--- a/ReactiveCocoa/Objective-C/NSUserDefaults+RACSupport.m
+++ b/ReactiveCocoa/Objective-C/NSUserDefaults+RACSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "NSUserDefaults+RACSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSNotificationCenter+RACSupport.h"
 #import "NSObject+RACDeallocating.h"
 #import "RACChannel.h"

--- a/ReactiveCocoa/Objective-C/RACCommand.m
+++ b/ReactiveCocoa/Objective-C/RACCommand.m
@@ -7,7 +7,7 @@
 //
 
 #import "RACCommand.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSArray+RACSequenceAdditions.h"
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACDescription.h"

--- a/ReactiveCocoa/Objective-C/RACDynamicSignal.m
+++ b/ReactiveCocoa/Objective-C/RACDynamicSignal.m
@@ -7,7 +7,7 @@
 //
 
 #import "RACDynamicSignal.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACCompoundDisposable.h"
 #import "RACPassthroughSubscriber.h"
 #import "RACScheduler+Private.h"

--- a/ReactiveCocoa/Objective-C/RACKVOChannel.h
+++ b/ReactiveCocoa/Objective-C/RACKVOChannel.h
@@ -7,7 +7,7 @@
 //
 
 #import "RACChannel.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "metamacros.h"
 
 /// Creates a RACKVOChannel to the given key path. When the targeted object

--- a/ReactiveCocoa/Objective-C/RACKVOChannel.m
+++ b/ReactiveCocoa/Objective-C/RACKVOChannel.m
@@ -7,7 +7,7 @@
 //
 
 #import "RACKVOChannel.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACKVOWrapper.h"
 #import "NSString+RACKeyPathUtilities.h"

--- a/ReactiveCocoa/Objective-C/RACSubject.m
+++ b/ReactiveCocoa/Objective-C/RACSubject.m
@@ -7,7 +7,7 @@
 //
 
 #import "RACSubject.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACCompoundDisposable.h"
 #import "RACPassthroughSubscriber.h"
 

--- a/ReactiveCocoa/Objective-C/RACSubscriber.m
+++ b/ReactiveCocoa/Objective-C/RACSubscriber.m
@@ -8,7 +8,7 @@
 
 #import "RACSubscriber.h"
 #import "RACSubscriber+Private.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACCompoundDisposable.h"
 
 @interface RACSubscriber ()

--- a/ReactiveCocoa/Objective-C/RACSubscriptingAssignmentTrampoline.h
+++ b/ReactiveCocoa/Objective-C/RACSubscriptingAssignmentTrampoline.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 
 @class RACSignal;
 

--- a/ReactiveCocoa/Objective-C/RACTestScheduler.m
+++ b/ReactiveCocoa/Objective-C/RACTestScheduler.m
@@ -7,7 +7,7 @@
 //
 
 #import "RACTestScheduler.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACCompoundDisposable.h"
 #import "RACDisposable.h"
 #import "RACScheduler+Private.h"

--- a/ReactiveCocoa/Objective-C/RACTuple.m
+++ b/ReactiveCocoa/Objective-C/RACTuple.m
@@ -7,7 +7,7 @@
 //
 
 #import "RACTuple.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "RACTupleSequence.h"
 
 @implementation RACTupleNil

--- a/ReactiveCocoa/Objective-C/RACUnarySequence.m
+++ b/ReactiveCocoa/Objective-C/RACUnarySequence.m
@@ -7,7 +7,7 @@
 //
 
 #import "RACUnarySequence.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "NSObject+RACDescription.h"
 
 @interface RACUnarySequence ()

--- a/ReactiveCocoa/Objective-C/UIBarButtonItem+RACCommandSupport.m
+++ b/ReactiveCocoa/Objective-C/UIBarButtonItem+RACCommandSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UIBarButtonItem+RACCommandSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "RACCommand.h"
 #import "RACDisposable.h"
 #import "RACSignal+Operations.h"

--- a/ReactiveCocoa/Objective-C/UIButton+RACCommandSupport.m
+++ b/ReactiveCocoa/Objective-C/UIButton+RACCommandSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UIButton+RACCommandSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "RACCommand.h"
 #import "RACDisposable.h"
 #import "RACSignal+Operations.h"

--- a/ReactiveCocoa/Objective-C/UIControl+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UIControl+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UIControl+RACSignalSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACCompoundDisposable.h"
 #import "RACDisposable.h"
 #import "RACSignal.h"

--- a/ReactiveCocoa/Objective-C/UIDatePicker+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UIDatePicker+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UIDatePicker+RACSignalSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "UIControl+RACSignalSupportPrivate.h"
 
 @implementation UIDatePicker (RACSignalSupport)

--- a/ReactiveCocoa/Objective-C/UIGestureRecognizer+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UIGestureRecognizer+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UIGestureRecognizer+RACSignalSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACDescription.h"
 #import "RACCompoundDisposable.h"

--- a/ReactiveCocoa/Objective-C/UIRefreshControl+RACCommandSupport.m
+++ b/ReactiveCocoa/Objective-C/UIRefreshControl+RACCommandSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UIRefreshControl+RACCommandSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "RACCommand.h"
 #import "RACCompoundDisposable.h"
 #import "RACDisposable.h"

--- a/ReactiveCocoa/Objective-C/UISegmentedControl+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UISegmentedControl+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UISegmentedControl+RACSignalSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "UIControl+RACSignalSupportPrivate.h"
 
 @implementation UISegmentedControl (RACSignalSupport)

--- a/ReactiveCocoa/Objective-C/UISlider+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UISlider+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UISlider+RACSignalSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "UIControl+RACSignalSupportPrivate.h"
 
 @implementation UISlider (RACSignalSupport)

--- a/ReactiveCocoa/Objective-C/UIStepper+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UIStepper+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UIStepper+RACSignalSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "UIControl+RACSignalSupportPrivate.h"
 
 @implementation UIStepper (RACSignalSupport)

--- a/ReactiveCocoa/Objective-C/UISwitch+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UISwitch+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UISwitch+RACSignalSupport.h"
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "UIControl+RACSignalSupportPrivate.h"
 
 @implementation UISwitch (RACSignalSupport)

--- a/ReactiveCocoa/Objective-C/UITextField+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UITextField+RACSignalSupport.m
@@ -7,8 +7,8 @@
 //
 
 #import "UITextField+RACSignalSupport.h"
-#import "EXTKeyPathCoding.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACDescription.h"
 #import "RACSignal+Operations.h"

--- a/ReactiveCocoa/Objective-C/UITextView+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UITextView+RACSignalSupport.m
@@ -7,7 +7,7 @@
 //
 
 #import "UITextView+RACSignalSupport.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACDescription.h"
 #import "RACDelegateProxy.h"

--- a/ReactiveCocoa/Objective-C/extobjc/EXTRuntimeExtensions.m
+++ b/ReactiveCocoa/Objective-C/extobjc/EXTRuntimeExtensions.m
@@ -7,7 +7,7 @@
 //  Released under the MIT license.
 //
 
-#import "EXTRuntimeExtensions.h"
+#import <ReactiveCocoa/EXTRuntimeExtensions.h>
 
 #import <ctype.h>
 #import <Foundation/Foundation.h>

--- a/ReactiveCocoaTests/Objective-C/NSObjectRACAppKitBindingsSpec.m
+++ b/ReactiveCocoaTests/Objective-C/NSObjectRACAppKitBindingsSpec.m
@@ -11,7 +11,7 @@
 
 #import "RACChannelExamples.h"
 
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "NSObject+RACAppKitBindings.h"
 
 QuickSpecBegin(NSObjectRACAppKitBindingsSpec)

--- a/ReactiveCocoaTests/Objective-C/NSObjectRACPropertySubscribingExamples.m
+++ b/ReactiveCocoaTests/Objective-C/NSObjectRACPropertySubscribingExamples.m
@@ -12,7 +12,7 @@
 #import "RACTestObject.h"
 #import "NSObjectRACPropertySubscribingExamples.h"
 
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACPropertySubscribing.h"
 #import "RACCompoundDisposable.h"

--- a/ReactiveCocoaTests/Objective-C/RACKVOWrapperSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACKVOWrapperSpec.m
@@ -11,7 +11,7 @@
 
 #import "NSObject+RACKVOWrapper.h"
 
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "NSObject+RACDeallocating.h"
 #import "RACCompoundDisposable.h"
 #import "RACDisposable.h"

--- a/ReactiveCocoaTests/Objective-C/RACPropertySignalExamples.m
+++ b/ReactiveCocoaTests/Objective-C/RACPropertySignalExamples.m
@@ -11,7 +11,7 @@
 
 #import "RACTestObject.h"
 
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACPropertySubscribing.h"
 #import "NSObject+RACSelectorSignal.h"

--- a/ReactiveCocoaTests/Objective-C/RACSchedulerSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACSchedulerSpec.m
@@ -13,7 +13,7 @@
 #import "RACScheduler+Private.h"
 #import "RACQueueScheduler+Subclass.h"
 #import "RACDisposable.h"
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACTestExampleScheduler.h"
 #import <libkern/OSAtomic.h>
 

--- a/ReactiveCocoaTests/Objective-C/RACSignalSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACSignalSpec.m
@@ -14,7 +14,7 @@
 #import "RACStreamExamples.h"
 #import "RACTestObject.h"
 
-#import "EXTKeyPathCoding.h"
+#import <ReactiveCocoa/EXTKeyPathCoding.h>
 #import "NSObject+RACDeallocating.h"
 #import "NSObject+RACPropertySubscribing.h"
 #import "RACBehaviorSubject.h"

--- a/ReactiveCocoaTests/Objective-C/RACSubjectSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACSubjectSpec.m
@@ -12,7 +12,7 @@
 #import "RACSubscriberExamples.h"
 
 #import <libkern/OSAtomic.h>
-#import "EXTScope.h"
+#import <ReactiveCocoa/EXTScope.h>
 #import "RACBehaviorSubject.h"
 #import "RACDisposable.h"
 #import "RACReplaySubject.h"


### PR DESCRIPTION
This makes RAC still compile if both its own private copy and the original libextobjc headers are available in its header search paths.