### PR TITLE
Associative lift operators to fix synchronous sampleOn

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -393,7 +393,16 @@ extension SignalProducerType {
 	/// Note: starting the returned producer will start the receiver of the operator,
 	/// which may not be adviseable for some operators.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func liftRight<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
+	public func lift<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
+		return liftRight(transform)
+	}
+
+	/// Right-associative lifting of a binary signal operator over producers. That
+	/// is, the argument producer will be started before the receiver. When both
+	/// producers are synchronous this order can be important depending on the operator
+	/// to generate correct results.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	private func liftRight<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
 		return { otherProducer in
 			return SignalProducer { observer, outerDisposable in
 				self.startWithSignal { signal, disposable in
@@ -409,17 +418,12 @@ extension SignalProducerType {
 		}
 	}
 
-	/// Lifts a binary Signal operator to operate upon SignalProducers instead.
-	///
-	/// In other words, this will create a new SignalProducer which will apply
-	/// the given Signal operator to _every_ Signal created from the two
-	/// producers, just as if the operator had been applied to each Signal
-	/// yielded from start().
-	///
-	/// Note: starting the returned producer will start the receiver of the operator,
-	/// which may not be adviseable for some operators.
+	/// Left-associative lifting of a binary signal operator over producers. That
+	/// is, the receiver will be started before the argument producer. When both
+	/// producers are synchronous this order can be important depending on the operator
+	/// to generate correct results.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func liftLeft<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
+	private func liftLeft<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
 		return { otherProducer in
 			return SignalProducer { observer, outerDisposable in
 				otherProducer.startWithSignal { otherSignal, otherDisposable in

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -831,6 +831,18 @@ class SignalProducerLiftingSpec: QuickSpec {
 				samplerObserver.sendCompleted()
 				expect(completed).to(beTruthy())
 			}
+
+			it("should emit an initial value if the sampler is a synchronous SignalProducer") {
+				let producer = SignalProducer<Int, NoError>(values: [1])
+				let sampler = SignalProducer<(), NoError>(value: ())
+				
+				let result = producer.sampleOn(sampler)
+				
+				var valueReceived: Int?
+				result.startWithNext { valueReceived = $0 }
+				
+				expect(valueReceived) == 1
+			}
 		}
 
 		describe("combineLatestWith") {

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -724,7 +724,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-					let producer = baseProducer.lift(transform)(otherProducer)
+					let producer = baseProducer.liftRight(transform)(otherProducer)
 					expect(counter).to(equal(0))
 
 					producer.start()
@@ -744,7 +744,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-					let producer = baseProducer.lift(transform)(otherProducer)
+					let producer = baseProducer.liftRight(transform)(otherProducer)
 					let result = producer.collect().single()
 
 					expect(result?.value).to(equal([5, 7, 9]))

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -724,7 +724,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-					let producer = baseProducer.liftRight(transform)(otherProducer)
+					let producer = baseProducer.lift(transform)(otherProducer)
 					expect(counter).to(equal(0))
 
 					producer.start()
@@ -744,7 +744,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-					let producer = baseProducer.liftRight(transform)(otherProducer)
+					let producer = baseProducer.lift(transform)(otherProducer)
 					let result = producer.collect().single()
 
 					expect(result?.value).to(equal([5, 7, 9]))

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1692,20 +1692,6 @@ class SignalProducerSpec: QuickSpec {
 				expect(upstreamDisposable.disposed).to(beTruthy())
 			}
 		}
-
-		describe("sampleOn") {
-			it("should emit an initial value if the sampler is a synchronous SignalProducer") {
-				let producer = SignalProducer<Int, NoError>(values: [1])
-				let sampler = SignalProducer<(), NoError>(value: ())
-
-				let result = producer.sampleOn(sampler)
-
-				var valueReceived: Int?
-				result.startWithNext { valueReceived = $0 }
-
-				expect(valueReceived) == 1
-			}
-		}
 	}
 }
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1692,6 +1692,20 @@ class SignalProducerSpec: QuickSpec {
 				expect(upstreamDisposable.disposed).to(beTruthy())
 			}
 		}
+
+		describe("sampleOn") {
+			it("should emit an initial value if the sampler is a synchronous SignalProducer") {
+				let producer = SignalProducer<Int, NoError>(values: [1])
+				let sampler = SignalProducer<(), NoError>(value: ())
+
+				let result = producer.sampleOn(sampler)
+
+				var valueReceived: Int?
+				result.startWithNext { valueReceived = $0 }
+
+				expect(valueReceived) == 1
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
I decided to keep `liftLeft` and `liftRight` private for now. I don't think this is a complexity we should expose in the API given that these only matter for some operators and only when both producers are synchronous.