### PR TITLE
Moved `on` operator to Signal

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -762,34 +762,19 @@ extension SignalProducerType {
 	public func on(started started: (() -> ())? = nil, event: (Event<Value, Error> -> ())? = nil, failed: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil, next: (Value -> ())? = nil) -> SignalProducer<Value, Error> {
 		return SignalProducer { observer, compositeDisposable in
 			started?()
-			_ = disposed.map(compositeDisposable.addDisposable)
-
 			self.startWithSignal { signal, disposable in
-				compositeDisposable.addDisposable(disposable)
-
-				signal.observe { receivedEvent in
-					event?(receivedEvent)
-
-					switch receivedEvent {
-					case let .Next(value):
-						next?(value)
-
-					case let .Failed(error):
-						failed?(error)
-
-					case .Completed:
-						completed?()
-
-					case .Interrupted:
-						interrupted?()
-					}
-
-					if receivedEvent.isTerminating {
-						terminated?()
-					}
-
-					observer.action(receivedEvent)
-				}
+				compositeDisposable += disposable
+				compositeDisposable += signal
+					.on(
+						event: event,
+						failed: failed,
+						completed: completed,
+						interrupted: interrupted,
+						terminated: terminated,
+						disposed: disposed,
+						next: next
+					)
+					.observe(observer)
 			}
 		}
 	}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -918,6 +918,21 @@ class SignalProducerSpec: QuickSpec {
 				expect(completed).to(equal(2))
 				expect(terminated).to(equal(2))
 			}
+
+			it("should attach event handlers for disposal") {
+				let (baseProducer, _) = SignalProducer<Int, TestError>.buffer()
+
+				var disposed: Bool = false
+
+				let producer = baseProducer
+					.on(disposed: { disposed = true })
+
+				let disposable = producer.start()
+
+				expect(disposed) == false
+				disposable.dispose()
+				expect(disposed) == true
+			}
 		}
 
 		describe("startOn") {


### PR DESCRIPTION
Note that `Signal.on` is equivalent to `SignalProducer.on` except for the `started` event, which wouldn't make sense on `Signal`.

I also added a test to verify that `disposed` is invoked at the right time.