### PR TITLE
Fix "Will never be executed" warning

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -156,8 +156,8 @@ public final class MutableProperty<Value>: MutablePropertyType {
 			return object.rac_valuesForKeyPath(keyPath, observer: nil).toSignalProducer()
 				// Errors aren't possible, but the compiler doesn't know that.
 				.flatMapError { error in
+					0 // suppresses implicit return error on fatalError
 					fatalError("Received unexpected error from KVO signal: \(error)")
-					return .empty
 				}
 		} else {
 			return .empty


### PR DESCRIPTION
The only warning I get when building ReactiveCocoa in Xcode 7.1.1 (besides "Update to recommended settings") is "Will never be executed", after a `fatalError` in `Property.swift`. It looks like the return statement was included to prevent Swift from assuming that it should return the value of `fatalError` from the one-line closure, or... something like that (`fatalError` is `@noreturn`...).

I replaced this with a meaningless `0` statement to break out of the implicit return. I think this might be better? If there's an equivalent to `#pragma clang` in Swift, that might be preferable, but I don't think there is?