### PR TITLE
Add test case for issue 2585

### DIFF
--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -453,6 +453,12 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(1)
 				expect(lastValue).to(equal("2"))
 			}
+
+			it("should not keep resulting signal alive indefinitely") {
+				weak var signal: Signal<AnyObject, NoError>? = Signal.never.map { $0 }
+
+				expect(signal).to(beNil())
+			}
 		}
 		
 		

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -459,6 +459,18 @@ class SignalSpec: QuickSpec {
 
 				expect(signal).to(beNil())
 			}
+
+			it("should not keep resulting signal alive indefinitely after observing and disposing") {
+				var disposable: Disposable? = nil
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }
+					disposable = signal.observe(Observer())
+					return signal
+				}()
+				expect(signal).toNot(beNil())
+				disposable?.dispose()
+				expect(signal).to(beNil())
+			}
 		}
 		
 		


### PR DESCRIPTION
SignalSpec map should not keep resulting signal alive indefinitely (fails)