### PR TITLE
Attempt to fix flakey test in travis

### DIFF
--- a/ReactiveCocoaTests/Objective-C/RACSequenceExamples.m
+++ b/ReactiveCocoaTests/Objective-C/RACSequenceExamples.m
@@ -56,7 +56,8 @@ QuickConfigurationBegin(RACSequenceExampleGroups)
 			});
 
 			qck_it(@"should only evaluate one value per scheduling", ^{
-				RACSignal *signal = [sequence signalWithScheduler:RACScheduler.mainThreadScheduler];
+				RACScheduler* scheduler = [RACScheduler schedulerWithPriority:RACSchedulerPriorityHigh];
+				RACSignal *signal = [sequence signalWithScheduler:scheduler];
 
 				__block BOOL flag = YES;
 				__block BOOL completed = NO;
@@ -64,7 +65,7 @@ QuickConfigurationBegin(RACSequenceExampleGroups)
 					expect(@(flag)).to(beTruthy());
 					flag = NO;
 
-					[RACScheduler.mainThreadScheduler schedule:^{
+					[scheduler schedule:^{
 						// This should get executed before the next value (which
 						// verifies that it's YES).
 						flag = YES;


### PR DESCRIPTION
Maybe using a background queue instead of the main thread scheduler will fix this on travis since the errors always look like

```
failed - expected to eventually match (Stall on main thread)., got <1.0000>
```

cf. #2578