### PR TITLE
Make Xcode configuration dependency public

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "antitypical/Result" ~> 1.0.0
+github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,2 @@
-github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
 github "Quick/Quick" ~> 0.8
 github "Quick/Nimble" ~> 3.0


### PR DESCRIPTION
The Mac framework is failing to build when including ReactiveCocoa as an Xcode subproject due to missing xcconfigs. I believe the xcconfigs dependency is required to build, therefore I've made it public in this PR.