### PR TITLE
Remove var binding in functions and guards

### DIFF
--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -198,9 +198,10 @@ public final class SerialDisposable: Disposable {
 		}
 
 		set(d) {
-			let oldState = state.modify { (var state) in
-				state.innerDisposable = d
-				return state
+			let oldState = state.modify { state in
+				var mutableState = state
+				mutableState.innerDisposable = d
+				return mutableState
 			}
 
 			oldState.innerDisposable?.dispose()

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -78,10 +78,11 @@ public final class CompositeDisposable: Disposable {
 		public func remove() {
 			if let token = bagToken.swap(nil) {
 				disposable?.disposables.modify { bag in
-					guard var bag = bag else { return nil }
+					guard let immutableBag = bag else { return nil }
+					var mutableBag = immutableBag
 
-					bag.removeValueForToken(token)
-					return bag
+					mutableBag.removeValueForToken(token)
+					return mutableBag
 				}
 			}
 		}
@@ -125,12 +126,13 @@ public final class CompositeDisposable: Disposable {
 
 		var handle: DisposableHandle? = nil
 		disposables.modify { ds in
-			guard var ds = ds else { return nil }
+			guard let immutableDs = ds else { return nil }
+			var mutableDs = immutableDs
 
-			let token = ds.insert(d)
+			let token = mutableDs.insert(d)
 			handle = DisposableHandle(bagToken: token, disposable: self)
 
-			return ds
+			return mutableDs
 		}
 
 		if let handle = handle {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -119,19 +119,21 @@ public final class Signal<Value, Error: ErrorType> {
 	public func observe(observer: Observer) -> Disposable? {
 		var token: RemovalToken?
 		atomicObservers.modify { observers in
-			guard var observers = observers else { return nil }
-
-			token = observers.insert(observer)
-			return observers
+			guard let immutableObservers = observers else { return nil }
+			var mutableObservers = immutableObservers
+			
+			token = mutableObservers.insert(observer)
+			return mutableObservers
 		}
 
 		if let token = token {
 			return ActionDisposable {
 				self.atomicObservers.modify { observers in
-					guard var observers = observers else { return nil }
+					guard let immutableObservers = observers else { return nil }
+					var mutableObservers = immutableObservers
 
-					observers.removeValueForToken(token)
-					return observers
+					mutableObservers.removeValueForToken(token)
+					return mutableObservers
 				}
 			}
 		} else {


### PR DESCRIPTION
`guard var` and `{ (var x) in ... }` are being [removed from Swift](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters-patterns.md), and cause compiler errors with the Swift 2.2 preview available from [swift.org](http://swift.org).

I've replaced all usages with the ["purely mechanical migration"](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters-patterns.md#impact-on-existing-code) suggestion. It's not the best approach ever, especially stuff like:

```swift
guard let immutableBag = bag else { return nil }
var mutableBag = immutableBag
```

As a replacement for:

```swift
guard var bag = bag else { return nil }
```

So this should probably be reworked into something better. These are in calls to `.modify` - I briefly tried switching to `inout` there, but ran into many test failures and crashes, and my main goal was to make `swift build` work.

This is required for supporting the [Swift Package Manager](https://github.com/apple/swift-package-manager): https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2599.