### PR TITLE
Add Foundation imports to files that use Foundation

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents an action that will do some work when executed with a value of
 /// type `Input`, then return zero or more values of type `Output` and/or fail
 /// with an error of type `Error`. If no failure should be possible, NoError can

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2014 GitHub. All rights reserved.
 //
 
+import Foundation
+
 /// An atomic variable.
 public final class Atomic<Value> {
 	private var spinLock = OS_SPINLOCK_INIT

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents a property that allows observation of its changes.
 public protocol PropertyType {
 	typealias Value

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Result
 
 /// A push-driven stream that sends Events over time, parameterized by the type

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Result
 
 /// A SignalProducer creates Signals that can produce values of type `Value` and/or


### PR DESCRIPTION
ReactiveCocoa inherits the Foundation types from the Objective-C headers, I think. However, if those aren't included when building, those files will generate compiler errors for the missing types.

This is required to support the [Swift Package Manager](https://github.com/apple/swift-package-manager): https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2599.