### PR TITLE
Fix leak of signal with deallocated generator observer

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02D2602A1C1D6DAF003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
+		02D2602B1C1D6DB8003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
 		579504331BB8A34200A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
@@ -766,6 +768,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalLifetimeSpec.swift; sourceTree = "<group>"; };
 		314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1647,6 +1650,7 @@
 				D0A226101A72F30B00D33B74 /* ObjectiveCBridgingSpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */,
 				D0C312F219EF2A7700984962 /* SchedulerSpec.swift */,
+				02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */,
 				D0A2260A1A72E6C500D33B74 /* SignalProducerSpec.swift */,
 				D8024DB11B2E1BB0005E6B9A /* SignalProducerLiftingSpec.swift */,
 				D0A226071A72E0E900D33B74 /* SignalSpec.swift */,
@@ -2439,6 +2443,7 @@
 				D037670519EDA60000A782A9 /* RACSubscriberExamples.m in Sources */,
 				D0A226081A72E0E900D33B74 /* SignalSpec.swift in Sources */,
 				D0C3132219EF2D9700984962 /* RACTestSchedulerSpec.m in Sources */,
+				02D2602B1C1D6DB8003ACC61 /* SignalLifetimeSpec.swift in Sources */,
 				D0C3130C19EF2B1F00984962 /* DisposableSpec.swift in Sources */,
 				D03766D719EDA60000A782A9 /* RACBlockTrampolineSpec.m in Sources */,
 				D0A2260B1A72E6C500D33B74 /* SignalProducerSpec.swift in Sources */,
@@ -2639,6 +2644,7 @@
 				D037671A19EDA60000A782A9 /* UIActionSheetRACSupportSpec.m in Sources */,
 				D03766DA19EDA60000A782A9 /* RACChannelExamples.m in Sources */,
 				D03766F619EDA60000A782A9 /* RACSequenceExamples.m in Sources */,
+				02D2602A1C1D6DAF003ACC61 /* SignalLifetimeSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -128,8 +128,8 @@ public final class Signal<Value, Error: ErrorType> {
 		}
 
 		if let token = token {
-			return ActionDisposable {
-				self.atomicObservers.modify { observers in
+			return ActionDisposable { [weak self] in
+				self?.atomicObservers.modify { observers in
 					guard let immutableObservers = observers else { return nil }
 					var mutableObservers = immutableObservers
 

--- a/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
@@ -1,0 +1,214 @@
+//
+//  SignalLifetimeSpec.swift
+//  ReactiveCocoa
+//
+//  Created by Vadim Yelagin on 2015-12-13.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+import Result
+import Nimble
+import Quick
+import ReactiveCocoa
+
+class SignalLifetimeSpec: QuickSpec {
+	override func spec() {
+		describe("init") {
+			var testScheduler: TestScheduler!
+
+			beforeEach {
+				testScheduler = TestScheduler()
+			}
+
+			it("should deallocate") {
+				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }
+
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate even if it has an observer") {
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
+					return signal
+				}()
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate even if it has an observer with retained disposable") {
+				var disposable: Disposable? = nil
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
+					disposable = signal.observe(Observer())
+					return signal
+				}()
+				expect(signal).to(beNil())
+				disposable?.dispose()
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate after erroring") {
+				weak var signal: Signal<AnyObject, TestError>? = Signal { observer in
+					testScheduler.schedule {
+						observer.sendFailed(TestError.Default)
+					}
+					return nil
+				}
+
+				var errored = false
+
+				signal?.observeFailed { _ in errored = true }
+
+				expect(errored).to(beFalsy())
+				expect(signal).toNot(beNil())
+
+				testScheduler.run()
+
+				expect(errored).to(beTruthy())
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate after completing") {
+				weak var signal: Signal<AnyObject, NoError>? = Signal { observer in
+					testScheduler.schedule {
+						observer.sendCompleted()
+					}
+					return nil
+				}
+
+				var completed = false
+
+				signal?.observeCompleted { completed = true }
+
+				expect(completed).to(beFalsy())
+				expect(signal).toNot(beNil())
+
+				testScheduler.run()
+
+				expect(completed).to(beTruthy())
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate after interrupting") {
+				weak var signal: Signal<AnyObject, NoError>? = Signal { observer in
+					testScheduler.schedule {
+						observer.sendInterrupted()
+					}
+
+					return nil
+				}
+
+				var interrupted = false
+				signal?.observeInterrupted {
+					interrupted = true
+				}
+
+				expect(interrupted).to(beFalsy())
+				expect(signal).toNot(beNil())
+
+				testScheduler.run()
+
+				expect(interrupted).to(beTruthy())
+				expect(signal).to(beNil())
+			}
+		}
+
+		describe("Signal.pipe") {
+			it("should deallocate") {
+				weak var signal = Signal<(), NoError>.pipe().0
+
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate after erroring") {
+				let testScheduler = TestScheduler()
+				weak var weakSignal: Signal<(), TestError>?
+
+				// Use an inner closure to help ARC deallocate things as we
+				// expect.
+				let test: () -> () = {
+					let (signal, observer) = Signal<(), TestError>.pipe()
+					weakSignal = signal
+					testScheduler.schedule {
+						observer.sendFailed(TestError.Default)
+					}
+				}
+				test()
+
+				expect(weakSignal).toNot(beNil())
+
+				testScheduler.run()
+				expect(weakSignal).to(beNil())
+			}
+
+			it("should deallocate after completing") {
+				let testScheduler = TestScheduler()
+				weak var weakSignal: Signal<(), TestError>?
+
+				// Use an inner closure to help ARC deallocate things as we
+				// expect.
+				let test: () -> () = {
+					let (signal, observer) = Signal<(), TestError>.pipe()
+					weakSignal = signal
+					testScheduler.schedule {
+						observer.sendCompleted()
+					}
+				}
+				test()
+
+				expect(weakSignal).toNot(beNil())
+
+				testScheduler.run()
+				expect(weakSignal).to(beNil())
+			}
+
+			it("should deallocate after interrupting") {
+				let testScheduler = TestScheduler()
+				weak var weakSignal: Signal<(), NoError>?
+
+				let test: () -> () = {
+					let (signal, observer) = Signal<(), NoError>.pipe()
+					weakSignal = signal
+
+					testScheduler.schedule {
+						observer.sendInterrupted()
+					}
+				}
+
+				test()
+				expect(weakSignal).toNot(beNil())
+
+				testScheduler.run()
+				expect(weakSignal).to(beNil())
+			}
+		}
+
+		describe("map") {
+			it("should deallocate") {
+				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }.map { $0 }
+
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate even if it has an observer") {
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
+					signal.observe(Observer())
+					return signal
+				}()
+				expect(signal).to(beNil())
+			}
+
+			it("should deallocate even if it has an observer with retained disposable") {
+				var disposable: Disposable? = nil
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
+					disposable = signal.observe(Observer())
+					return signal
+				}()
+				expect(signal).to(beNil())
+				disposable?.dispose()
+				expect(signal).to(beNil())
+			}
+		}
+	}
+}

--- a/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
@@ -182,16 +182,16 @@ class SignalLifetimeSpec: QuickSpec {
 			}
 		}
 
-		describe("map") {
+		describe("testTransform") {
 			it("should deallocate") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }.map { $0 }
+				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }.testTransform()
 
 				expect(signal).to(beNil())
 			}
 
 			it("should deallocate even if it has an observer") {
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.testTransform()
 					signal.observe(Observer())
 					return signal
 				}()
@@ -201,7 +201,7 @@ class SignalLifetimeSpec: QuickSpec {
 			it("should deallocate even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.testTransform()
 					disposable = signal.observe(Observer())
 					return signal
 				}()
@@ -211,4 +211,14 @@ class SignalLifetimeSpec: QuickSpec {
 			}
 		}
 	}
+}
+
+private extension SignalType {
+
+	func testTransform() -> Signal<Value, Error> {
+		return Signal { observer in
+			self.observe(observer.action)
+		}
+	}
+
 }

--- a/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
@@ -214,11 +214,9 @@ class SignalLifetimeSpec: QuickSpec {
 }
 
 private extension SignalType {
-
 	func testTransform() -> Signal<Value, Error> {
 		return Signal { observer in
-			self.observe(observer.action)
+			return self.observe(observer.action)
 		}
 	}
-
 }

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -31,14 +31,14 @@ class SignalSpec: QuickSpec {
 			}
 
 			it("should deallocate") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal.never
+				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }
 				
 				expect(signal).to(beNil())
 			}
 
 			it("should deallocate even if it has an observer") {
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal.never
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
 					return signal
 				}()
 				expect(signal).to(beNil())
@@ -47,7 +47,7 @@ class SignalSpec: QuickSpec {
 			it("should deallocate even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal.never
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
 					disposable = signal.observe(Observer())
 					return signal
 				}()
@@ -475,14 +475,14 @@ class SignalSpec: QuickSpec {
 			}
 
 			it("should deallocate") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal.never.map { $0 }
+				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }.map { $0 }
 
 				expect(signal).to(beNil())
 			}
 
 			it("should deallocate even if it has an observer") {
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
 					signal.observe(Observer())
 					return signal
 				}()
@@ -492,7 +492,7 @@ class SignalSpec: QuickSpec {
 			it("should deallocate even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }
+					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
 					disposable = signal.observe(Observer())
 					return signal
 				}()

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -453,6 +453,12 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(1)
 				expect(lastValue).to(equal("2"))
 			}
+
+			it("should not keep resulting signal alive indefinitely") {
+				weak var signal: Signal<AnyObject, NoError>? = Signal.never.map { $0 }
+
+				expect(signal).to(beNil())
+			}
 		}
 		
 		

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -30,97 +30,6 @@ class SignalSpec: QuickSpec {
 				expect(didRunGenerator).to(beTruthy())
 			}
 
-			it("should deallocate") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }
-				
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate even if it has an observer") {
-				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
-					return signal
-				}()
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate even if it has an observer with retained disposable") {
-				var disposable: Disposable? = nil
-				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
-					disposable = signal.observe(Observer())
-					return signal
-				}()
-				expect(signal).to(beNil())
-				disposable?.dispose()
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate after erroring") {
-				weak var signal: Signal<AnyObject, TestError>? = Signal { observer in
-					testScheduler.schedule {
-						observer.sendFailed(TestError.Default)
-					}
-					return nil
-				}
-				
-				var errored = false
-				
-				signal?.observeFailed { _ in errored = true }
-				
-				expect(errored).to(beFalsy())
-				expect(signal).toNot(beNil())
-				
-				testScheduler.run()
-				
-				expect(errored).to(beTruthy())
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate after completing") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal { observer in
-					testScheduler.schedule {
-						observer.sendCompleted()
-					}
-					return nil
-				}
-				
-				var completed = false
-				
-				signal?.observeCompleted { completed = true }
-				
-				expect(completed).to(beFalsy())
-				expect(signal).toNot(beNil())
-				
-				testScheduler.run()
-				
-				expect(completed).to(beTruthy())
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate after interrupting") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal { observer in
-					testScheduler.schedule {
-						observer.sendInterrupted()
-					}
-
-					return nil
-				}
-
-				var interrupted = false
-				signal?.observeInterrupted {
-					interrupted = true
-				}
-
-				expect(interrupted).to(beFalsy())
-				expect(signal).toNot(beNil())
-
-				testScheduler.run()
-
-				expect(interrupted).to(beTruthy())
-				expect(signal).to(beNil())
-			}
-
 			it("should forward events to observers") {
 				let numbers = [ 1, 2, 5 ]
 				
@@ -229,74 +138,6 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("Signal.pipe") {
-			it("should not keep signal alive indefinitely") {
-				weak var signal = Signal<(), NoError>.pipe().0
-				
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate after erroring") {
-				let testScheduler = TestScheduler()
-				weak var weakSignal: Signal<(), TestError>?
-				
-				// Use an inner closure to help ARC deallocate things as we
-				// expect.
-				let test: () -> () = {
-					let (signal, observer) = Signal<(), TestError>.pipe()
-					weakSignal = signal
-					testScheduler.schedule {
-						observer.sendFailed(TestError.Default)
-					}
-				}
-				test()
-				
-				expect(weakSignal).toNot(beNil())
-				
-				testScheduler.run()
-				expect(weakSignal).to(beNil())
-			}
-
-			it("should deallocate after completing") {
-				let testScheduler = TestScheduler()
-				weak var weakSignal: Signal<(), TestError>?
-				
-				// Use an inner closure to help ARC deallocate things as we
-				// expect.
-				let test: () -> () = {
-					let (signal, observer) = Signal<(), TestError>.pipe()
-					weakSignal = signal
-					testScheduler.schedule {
-						observer.sendCompleted()
-					}
-				}
-				test()
-				
-				expect(weakSignal).toNot(beNil())
-
-				testScheduler.run()
-				expect(weakSignal).to(beNil())
-			}
-
-			it("should deallocate after interrupting") {
-				let testScheduler = TestScheduler()
-				weak var weakSignal: Signal<(), NoError>?
-
-				let test: () -> () = {
-					let (signal, observer) = Signal<(), NoError>.pipe()
-					weakSignal = signal
-
-					testScheduler.schedule {
-						observer.sendInterrupted()
-					}
-				}
-
-				test()
-				expect(weakSignal).toNot(beNil())
-
-				testScheduler.run()
-				expect(weakSignal).to(beNil())
-			}
-
 			it("should forward events to observers") {
 				let (signal, observer) = Signal<Int, NoError>.pipe()
 				
@@ -472,33 +313,6 @@ class SignalSpec: QuickSpec {
 
 				observer.sendNext(1)
 				expect(lastValue).to(equal("2"))
-			}
-
-			it("should deallocate") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }.map { $0 }
-
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate even if it has an observer") {
-				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
-					signal.observe(Observer())
-					return signal
-				}()
-				expect(signal).to(beNil())
-			}
-
-			it("should deallocate even if it has an observer with retained disposable") {
-				var disposable: Disposable? = nil
-				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.map { $0 }
-					disposable = signal.observe(Observer())
-					return signal
-				}()
-				expect(signal).to(beNil())
-				disposable?.dispose()
-				expect(signal).to(beNil())
 			}
 		}
 		

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -459,6 +459,18 @@ class SignalSpec: QuickSpec {
 
 				expect(signal).to(beNil())
 			}
+
+			it("should not keep resulting signal alive indefinitely after observing and disposing") {
+				var disposable: Disposable? = nil
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }
+					disposable = signal.observe(Observer())
+					return signal
+				}()
+				expect(signal).toNot(beNil())
+				disposable?.dispose()
+				expect(signal).to(beNil())
+			}
 		}
 		
 		

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -30,13 +30,13 @@ class SignalSpec: QuickSpec {
 				expect(didRunGenerator).to(beTruthy())
 			}
 
-			it("should not keep signal alive indefinitely") {
+			it("should deallocate") {
 				weak var signal: Signal<AnyObject, NoError>? = Signal.never
 				
 				expect(signal).to(beNil())
 			}
 
-			it("should not keep signal alive indefinitely even if it has an observer") {
+			it("should deallocate even if it has an observer") {
 				weak var signal: Signal<AnyObject, NoError>? = {
 					let signal: Signal<AnyObject, NoError> = Signal.never
 					return signal
@@ -44,7 +44,7 @@ class SignalSpec: QuickSpec {
 				expect(signal).to(beNil())
 			}
 
-			it("should not keep signal alive indefinitely even if it has an observer with retained disposable") {
+			it("should deallocate even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
 					let signal: Signal<AnyObject, NoError> = Signal.never
@@ -474,13 +474,13 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(equal("2"))
 			}
 
-			it("should not keep resulting signal alive indefinitely") {
+			it("should deallocate") {
 				weak var signal: Signal<AnyObject, NoError>? = Signal.never.map { $0 }
 
 				expect(signal).to(beNil())
 			}
 
-			it("should not keep resulting signal alive indefinitely even if it has an observer") {
+			it("should deallocate even if it has an observer") {
 				weak var signal: Signal<AnyObject, NoError>? = {
 					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }
 					signal.observe(Observer())
@@ -489,7 +489,7 @@ class SignalSpec: QuickSpec {
 				expect(signal).to(beNil())
 			}
 
-			it("should not keep resulting signal alive indefinitely even if it has an observer with retained disposable") {
+			it("should deallocate even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
 					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -36,6 +36,26 @@ class SignalSpec: QuickSpec {
 				expect(signal).to(beNil())
 			}
 
+			it("should not keep signal alive indefinitely even if it has an observer") {
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal.never
+					return signal
+				}()
+				expect(signal).to(beNil())
+			}
+
+			it("should not keep signal alive indefinitely even if it has an observer with retained disposable") {
+				var disposable: Disposable? = nil
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal.never
+					disposable = signal.observe(Observer())
+					return signal
+				}()
+				expect(signal).to(beNil())
+				disposable?.dispose()
+				expect(signal).to(beNil())
+			}
+
 			it("should deallocate after erroring") {
 				weak var signal: Signal<AnyObject, TestError>? = Signal { observer in
 					testScheduler.schedule {
@@ -460,14 +480,23 @@ class SignalSpec: QuickSpec {
 				expect(signal).to(beNil())
 			}
 
-			it("should not keep resulting signal alive indefinitely after observing and disposing") {
+			it("should not keep resulting signal alive indefinitely even if it has an observer") {
+				weak var signal: Signal<AnyObject, NoError>? = {
+					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }
+					signal.observe(Observer())
+					return signal
+				}()
+				expect(signal).to(beNil())
+			}
+
+			it("should not keep resulting signal alive indefinitely even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
 					let signal: Signal<AnyObject, NoError> = Signal.never.map { $0 }
 					disposable = signal.observe(Observer())
 					return signal
 				}()
-				expect(signal).toNot(beNil())
+				expect(signal).to(beNil())
 				disposable?.dispose()
 				expect(signal).to(beNil())
 			}


### PR DESCRIPTION
Fix leak of signal with deallocated generator observer by capturing self weakly in disposable from `Signal.observe`.
Fixes https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2586 , test cases included, all pass.