### PR TITLE
Introduce Atomic's `modify`, `swap` and `withValue` to MutableProperty.

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -90,16 +90,13 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	public var value: Value {
 		get {
 			lock.lock()
-			let value = _value
-			lock.unlock()
-			return value
+			defer { lock.unlock() }
+
+			return _value
 		}
 
 		set {
-			lock.lock()
-			_value = newValue
-			observer.sendNext(newValue)
-			lock.unlock()
+			modify { _ in newValue }
 		}
 	}
 
@@ -116,6 +113,37 @@ public final class MutableProperty<Value>: MutablePropertyType {
 
 		_value = initialValue
 		observer.sendNext(initialValue)
+	}
+
+	/// Atomically replaces the contents of the variable.
+	///
+	/// Returns the old value.
+	public func swap(newValue: Value) -> Value {
+		return modify { _ in newValue }
+	}
+
+	/// Atomically modifies the variable.
+	///
+	/// Returns the old value.
+	public func modify(@noescape action: (Value) throws -> Value) rethrows -> Value {
+		lock.lock()
+		defer { lock.unlock() }
+
+		let oldValue = _value
+		_value = try action(_value)
+		observer.sendNext(_value)
+		return oldValue
+	}
+
+	/// Atomically performs an arbitrary action using the current value of the
+	/// variable.
+	///
+	/// Returns the result of the action.
+	public func withValue<Result>(@noescape action: (Value) throws -> Result) rethrows -> Result {
+		lock.lock()
+		defer { lock.unlock() }
+
+		return try action(_value)
 	}
 
 	deinit {

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -89,10 +89,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// created from the `values` producer.
 	public var value: Value {
 		get {
-			lock.lock()
-			defer { lock.unlock() }
-
-			return _value
+			return withValue { $0 }
 		}
 
 		set {

--- a/ReactiveCocoaTests/Swift/AtomicSpec.swift
+++ b/ReactiveCocoaTests/Swift/AtomicSpec.swift
@@ -35,13 +35,6 @@ class AtomicSpec: QuickSpec {
 			expect(atomic.value) == 2
 		}
 
-		it("should modify the value and return some data") {
-			let (orig, data) = atomic.modify { ($0 + 1, "foobar") }
-			expect(orig) == 1
-			expect(data) == "foobar"
-			expect(atomic.value) == 2
-		}
-
 		it("should perform an action with the value") {
 			let result: Bool = atomic.withValue { $0 == 1 }
 			expect(result) == true


### PR DESCRIPTION
Related Issue: #2615 

In a nutshell, this PR:

1. introduced `modify(action:)`, `swap(newValue:)` and `withValue(action:)` to `MutableProperty`;
2. new test cases for these new methods;
3. a stylish refactor of `value.getter`;
4. makes `value.setter` use the new `modify(action:)` method; and
5. removed an invalid test case from AtomicSpec (the related overload was removed in https://github.com/ReactiveCocoa/ReactiveCocoa/commit/d83b219cd61d27b9a0e8402ac864de42e85bf657 as mentioned by @ikesyo).