### PR TITLE
[Specs] Replace some Nimble matchers with equivalent operators

### DIFF
--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -55,8 +55,8 @@ class ActionSpec: QuickSpec {
 			}
 
 			it("should be disabled and not executing after initialization") {
-				expect(action.enabled.value).to(beFalsy())
-				expect(action.executing.value).to(beFalsy())
+				expect(action.enabled.value) == false
+				expect(action.executing.value) == false
 			}
 
 			it("should error if executed while disabled") {
@@ -68,18 +68,18 @@ class ActionSpec: QuickSpec {
 				expect(receivedError).notTo(beNil())
 				if let error = receivedError {
 					let expectedError = ActionError<NSError>.NotEnabled
-					expect(error == expectedError).to(beTruthy())
+					expect(error == expectedError) == true
 				}
 			}
 
 			it("should enable and disable based on the given property") {
 				enabled.value = true
-				expect(action.enabled.value).to(beTruthy())
-				expect(action.executing.value).to(beFalsy())
+				expect(action.enabled.value) == true
+				expect(action.executing.value) == false
 
 				enabled.value = false
-				expect(action.enabled.value).to(beFalsy())
-				expect(action.executing.value).to(beFalsy())
+				expect(action.enabled.value) == false
+				expect(action.executing.value) == false
 			}
 
 			describe("execution") {
@@ -95,16 +95,16 @@ class ActionSpec: QuickSpec {
 					}
 
 					expect(executionCount).to(equal(1))
-					expect(action.executing.value).to(beTruthy())
-					expect(action.enabled.value).to(beFalsy())
+					expect(action.executing.value) == true
+					expect(action.enabled.value) == false
 
 					expect(receivedValue).to(equal("00"))
 					expect(values).to(equal([ "0", "00" ]))
 					expect(errors).to(equal([]))
 
 					scheduler.run()
-					expect(action.executing.value).to(beFalsy())
-					expect(action.enabled.value).to(beTruthy())
+					expect(action.executing.value) == false
+					expect(action.enabled.value) == true
 
 					expect(values).to(equal([ "0", "00" ]))
 					expect(errors).to(equal([]))
@@ -118,17 +118,17 @@ class ActionSpec: QuickSpec {
 					}
 
 					expect(executionCount).to(equal(1))
-					expect(action.executing.value).to(beTruthy())
-					expect(action.enabled.value).to(beFalsy())
+					expect(action.executing.value) == true
+					expect(action.enabled.value) == false
 
 					scheduler.run()
-					expect(action.executing.value).to(beFalsy())
-					expect(action.enabled.value).to(beTruthy())
+					expect(action.executing.value) == false
+					expect(action.enabled.value) == true
 
 					expect(receivedError).notTo(beNil())
 					if let error = receivedError {
 						let expectedError = ActionError<NSError>.ProducerError(testError)
-						expect(error == expectedError).to(beTruthy())
+						expect(error == expectedError) == true
 					}
 
 					expect(values).to(equal([]))
@@ -142,7 +142,7 @@ class ActionSpec: QuickSpec {
 
 			beforeEach {
 				action = Action { value in SignalProducer(value: value + 1) }
-				expect(action.enabled.value).to(beTruthy())
+				expect(action.enabled.value) == true
 
 				expect(action.unsafeCocoaAction.enabled).toEventually(beTruthy())
 			}

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -94,20 +94,20 @@ class ActionSpec: QuickSpec {
 						receivedValue = $0
 					}
 
-					expect(executionCount).to(equal(1))
+					expect(executionCount) == 1
 					expect(action.executing.value) == true
 					expect(action.enabled.value) == false
 
-					expect(receivedValue).to(equal("00"))
-					expect(values).to(equal([ "0", "00" ]))
-					expect(errors).to(equal([]))
+					expect(receivedValue) == "00"
+					expect(values) == [ "0", "00" ]
+					expect(errors) == []
 
 					scheduler.run()
 					expect(action.executing.value) == false
 					expect(action.enabled.value) == true
 
-					expect(values).to(equal([ "0", "00" ]))
-					expect(errors).to(equal([]))
+					expect(values) == [ "0", "00" ]
+					expect(errors) == []
 				}
 
 				it("should execute with an error") {
@@ -117,7 +117,7 @@ class ActionSpec: QuickSpec {
 						receivedError = $0
 					}
 
-					expect(executionCount).to(equal(1))
+					expect(executionCount) == 1
 					expect(action.executing.value) == true
 					expect(action.enabled.value) == false
 
@@ -131,8 +131,8 @@ class ActionSpec: QuickSpec {
 						expect(error == expectedError) == true
 					}
 
-					expect(values).to(equal([]))
-					expect(errors).to(equal([ testError ]))
+					expect(values) == []
+					expect(errors) == [ testError ]
 				}
 			}
 		}
@@ -171,10 +171,10 @@ class ActionSpec: QuickSpec {
 					.map { $0! as! Bool }
 					.start(Observer(next: { values.append($0) }))
 
-				expect(values).to(equal([ true ]))
+				expect(values) == [ true ]
 
 				let result = action.apply(0).first()
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 				expect(values).toEventually(equal([ true, false, true ]))
 			}
 
@@ -187,10 +187,10 @@ class ActionSpec: QuickSpec {
 					.map { $0! as! Bool }
 					.start(Observer(next: { values.append($0) }))
 
-				expect(values).to(equal([ false ]))
+				expect(values) == [ false ]
 
 				let result = action.apply(0).first()
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 				expect(values).toEventually(equal([ false, true, false ]))
 			}
 		}

--- a/ReactiveCocoaTests/Swift/AtomicSpec.swift
+++ b/ReactiveCocoaTests/Swift/AtomicSpec.swift
@@ -19,33 +19,33 @@ class AtomicSpec: QuickSpec {
 		}
 
 		it("should read and write the value directly") {
-			expect(atomic.value).to(equal(1))
+			expect(atomic.value) == 1
 
 			atomic.value = 2
-			expect(atomic.value).to(equal(2))
+			expect(atomic.value) == 2
 		}
 
 		it("should swap the value atomically") {
-			expect(atomic.swap(2)).to(equal(1))
-			expect(atomic.value).to(equal(2))
+			expect(atomic.swap(2)) == 1
+			expect(atomic.value) == 2
 		}
 
 		it("should modify the value atomically") {
-			expect(atomic.modify({ $0 + 1 })).to(equal(1))
-			expect(atomic.value).to(equal(2))
+			expect(atomic.modify({ $0 + 1 })) == 1
+			expect(atomic.value) == 2
 		}
 
 		it("should modify the value and return some data") {
 			let (orig, data) = atomic.modify { ($0 + 1, "foobar") }
-			expect(orig).to(equal(1))
-			expect(data).to(equal("foobar"))
-			expect(atomic.value).to(equal(2))
+			expect(orig) == 1
+			expect(data) == "foobar"
+			expect(atomic.value) == 2
 		}
 
 		it("should perform an action with the value") {
 			let result: Bool = atomic.withValue { $0 == 1 }
 			expect(result) == true
-			expect(atomic.value).to(equal(1))
+			expect(atomic.value) == 1
 		}
 	}
 }

--- a/ReactiveCocoaTests/Swift/AtomicSpec.swift
+++ b/ReactiveCocoaTests/Swift/AtomicSpec.swift
@@ -44,7 +44,7 @@ class AtomicSpec: QuickSpec {
 
 		it("should perform an action with the value") {
 			let result: Bool = atomic.withValue { $0 == 1 }
-			expect(result).to(beTruthy())
+			expect(result) == true
 			expect(atomic.value).to(equal(1))
 		}
 	}

--- a/ReactiveCocoaTests/Swift/DisposableSpec.swift
+++ b/ReactiveCocoaTests/Swift/DisposableSpec.swift
@@ -15,10 +15,10 @@ class DisposableSpec: QuickSpec {
 		describe("SimpleDisposable") {
 			it("should set disposed to true") {
 				let disposable = SimpleDisposable()
-				expect(disposable.disposed).to(beFalsy())
+				expect(disposable.disposed) == false
 
 				disposable.dispose()
-				expect(disposable.disposed).to(beTruthy())
+				expect(disposable.disposed) == true
 			}
 		}
 
@@ -29,12 +29,12 @@ class DisposableSpec: QuickSpec {
 					didDispose = true
 				}
 
-				expect(didDispose).to(beFalsy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(didDispose) == false
+				expect(disposable.disposed) == false
 
 				disposable.dispose()
-				expect(didDispose).to(beTruthy())
-				expect(disposable.disposed).to(beTruthy())
+				expect(didDispose) == true
+				expect(disposable.disposed) == true
 			}
 		}
 
@@ -59,14 +59,14 @@ class DisposableSpec: QuickSpec {
 					didDispose = true
 				}
 
-				expect(simpleDisposable.disposed).to(beFalsy())
-				expect(didDispose).to(beFalsy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(simpleDisposable.disposed) == false
+				expect(didDispose) == false
+				expect(disposable.disposed) == false
 
 				disposable.dispose()
-				expect(simpleDisposable.disposed).to(beTruthy())
-				expect(didDispose).to(beTruthy())
-				expect(disposable.disposed).to(beTruthy())
+				expect(simpleDisposable.disposed) == true
+				expect(didDispose) == true
+				expect(disposable.disposed) == true
 			}
 
 			it("should not dispose of removed disposables") {
@@ -76,10 +76,10 @@ class DisposableSpec: QuickSpec {
 				// We should be allowed to call this any number of times.
 				handle.remove()
 				handle.remove()
-				expect(simpleDisposable.disposed).to(beFalsy())
+				expect(simpleDisposable.disposed) == false
 
 				disposable.dispose()
-				expect(simpleDisposable.disposed).to(beFalsy())
+				expect(simpleDisposable.disposed) == false
 			}
 		}
 
@@ -89,14 +89,14 @@ class DisposableSpec: QuickSpec {
 
 				func runScoped() {
 					let scopedDisposable = ScopedDisposable(simpleDisposable)
-					expect(simpleDisposable.disposed).to(beFalsy())
-					expect(scopedDisposable.disposed).to(beFalsy())
+					expect(simpleDisposable.disposed) == false
+					expect(scopedDisposable.disposed) == false
 				}
 
-				expect(simpleDisposable.disposed).to(beFalsy())
+				expect(simpleDisposable.disposed) == false
 
 				runScoped()
-				expect(simpleDisposable.disposed).to(beTruthy())
+				expect(simpleDisposable.disposed) == true
 			}
 		}
 
@@ -112,13 +112,13 @@ class DisposableSpec: QuickSpec {
 				disposable.innerDisposable = simpleDisposable
 
 				expect(disposable.innerDisposable).notTo(beNil())
-				expect(simpleDisposable.disposed).to(beFalsy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(simpleDisposable.disposed) == false
+				expect(disposable.disposed) == false
 
 				disposable.dispose()
 				expect(disposable.innerDisposable).to(beNil())
-				expect(simpleDisposable.disposed).to(beTruthy())
-				expect(disposable.disposed).to(beTruthy())
+				expect(simpleDisposable.disposed) == true
+				expect(disposable.disposed) == true
 			}
 
 			it("should dispose of the previous disposable when swapping innerDisposable") {
@@ -126,17 +126,17 @@ class DisposableSpec: QuickSpec {
 				let newDisposable = SimpleDisposable()
 
 				disposable.innerDisposable = oldDisposable
-				expect(oldDisposable.disposed).to(beFalsy())
-				expect(newDisposable.disposed).to(beFalsy())
+				expect(oldDisposable.disposed) == false
+				expect(newDisposable.disposed) == false
 
 				disposable.innerDisposable = newDisposable
-				expect(oldDisposable.disposed).to(beTruthy())
-				expect(newDisposable.disposed).to(beFalsy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(oldDisposable.disposed) == true
+				expect(newDisposable.disposed) == false
+				expect(disposable.disposed) == false
 
 				disposable.innerDisposable = nil
-				expect(newDisposable.disposed).to(beTruthy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(newDisposable.disposed) == true
+				expect(disposable.disposed) == false
 			}
 		}
 	}

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -26,7 +26,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				expect(notif).to(beNil())
 
 				center.postNotificationName("rac_notifications_test", object: nil)
-				expect(notif?.name).to(equal("rac_notifications_test"))
+				expect(notif?.name) == "rac_notifications_test"
 
 				notif = nil
 				disposable.dispose()

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -200,7 +200,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				expect(command).notTo(beNil())
 
 				command.enabled.subscribeNext { enabled = $0 as! Bool }
-				expect(enabled).to(beTruthy())
+				expect(enabled) == true
 
 				command.executionSignals.flatten().subscribeNext { results.append($0 as! Int) }
 				expect(results).to(equal([]))
@@ -209,11 +209,11 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			}
 
 			it("should reflect the enabledness of the command") {
-				expect(action.enabled.value).to(beTruthy())
+				expect(action.enabled.value) == true
 
 				enabledSubject.sendNext(false)
 				expect(enabled).toEventually(beFalsy())
-				expect(action.enabled.value).to(beFalsy())
+				expect(action.enabled.value) == false
 			}
 
 			it("should execute the command once per start()") {
@@ -255,7 +255,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					return SignalProducer(value: "\(inputNumber + 1)")
 				}
 
-				expect(action.enabled.value).to(beTruthy())
+				expect(action.enabled.value) == true
 
 				action.values.observeNext { results.append($0) }
 
@@ -263,7 +263,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				expect(command).notTo(beNil())
 
 				command.enabled.subscribeNext { enabled = $0 as! Bool }
-				expect(enabled).to(beTruthy())
+				expect(enabled) == true
 			}
 
 			it("should reflect the enabledness of the action") {

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -66,9 +66,9 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 				let producer = racSignal.toSignalProducer().map { $0 as! Int }
 
-				expect((producer.single())?.value).to(equal(0))
-				expect((producer.single())?.value).to(equal(1))
-				expect((producer.single())?.value).to(equal(2))
+				expect((producer.single())?.value) == 0
+				expect((producer.single())?.value) == 1
+				expect((producer.single())?.value) == 2
 			}
 
 			it("should forward errors")	{
@@ -78,7 +78,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				let producer = racSignal.toSignalProducer()
 				let result = producer.last()
 
-				expect(result?.error).to(equal(error))
+				expect(result?.error) == error
 			}
 		}
 
@@ -104,7 +104,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 					for number in [1, 2, 3] {
 						observer.sendNext(number)
-						expect(lastValue).to(equal(number))
+						expect(lastValue) == number
 					}
 
 					expect(didComplete) == false
@@ -125,7 +125,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					}
 
 					observer.sendFailed(expectedError)
-					expect(error).to(equal(expectedError as NSError))
+					expect(error) == expectedError as NSError
 				}
 				
 				it("should maintain userInfo on NSError") {
@@ -142,7 +142,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					observer.sendFailed(testNSError)
 					
 					let userInfoValue = error?.userInfo[key] as? String
-					expect(userInfoValue).to(equal(userInfo[key]))
+					expect(userInfoValue) == userInfo[key]
 				}
 			}
 
@@ -155,9 +155,9 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					}
 					let racSignal = producer.toRACSignal()
 
-					expect(racSignal.first() as? NSNumber).to(equal(0))
-					expect(racSignal.first() as? NSNumber).to(equal(1))
-					expect(racSignal.first() as? NSNumber).to(equal(2))
+					expect(racSignal.first() as? NSNumber) == 0
+					expect(racSignal.first() as? NSNumber) == 1
+					expect(racSignal.first() as? NSNumber) == 2
 				}
 
 				it("should convert errors to NSError") {
@@ -165,7 +165,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					let racSignal = producer.toRACSignal().materialize()
 
 					let event = racSignal.first() as? RACEvent
-					expect(event?.error).to(equal(TestError.Error1 as NSError))
+					expect(event?.error) == TestError.Error1 as NSError
 				}
 				
 				it("should maintain userInfo on NSError") {
@@ -174,7 +174,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					
 					let event = racSignal.first() as? RACEvent
 					let userInfoValue = event?.error.userInfo[key] as? String
-					expect(userInfoValue).to(equal(userInfo[key]))
+					expect(userInfoValue) == userInfo[key]
 				}
 			}
 		}
@@ -203,7 +203,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				expect(enabled) == true
 
 				command.executionSignals.flatten().subscribeNext { results.append($0 as! Int) }
-				expect(results).to(equal([]))
+				expect(results) == []
 
 				action = command.toAction()
 			}
@@ -218,7 +218,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 			it("should execute the command once per start()") {
 				let producer = action.apply(0)
-				expect(results).to(equal([]))
+				expect(results) == []
 
 				producer.start()
 				expect(results).toEventually(equal([ 1 ]))
@@ -227,7 +227,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				expect(results).toEventually(equal([ 1, 1 ]))
 
 				let otherProducer = action.apply(2)
-				expect(results).to(equal([ 1, 1 ]))
+				expect(results) == [ 1, 1 ]
 
 				otherProducer.start()
 				expect(results).toEventually(equal([ 1, 1, 3 ]))
@@ -279,13 +279,13 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 				do {
 					try signal.asynchronouslyWaitUntilCompleted()
-					expect(results).to(equal([ "1" ]))
+					expect(results) == [ "1" ]
 
 					try signal.asynchronouslyWaitUntilCompleted()
-					expect(results).to(equal([ "1" ]))
+					expect(results) == [ "1" ]
 
 					try command.execute(2).asynchronouslyWaitUntilCompleted()
-					expect(results).to(equal([ "1", "3" ]))
+					expect(results) == [ "1", "3" ]
 				} catch {
 					XCTFail("Failed to wait for completion")
 				}

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -107,9 +107,9 @@ class ObjectiveCBridgingSpec: QuickSpec {
 						expect(lastValue).to(equal(number))
 					}
 
-					expect(didComplete).to(beFalse())
+					expect(didComplete) == false
 					observer.sendCompleted()
-					expect(didComplete).to(beTrue())
+					expect(didComplete) == true
 				}
 
 				it("should convert errors to NSError") {

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -41,7 +41,7 @@ class PropertySpec: QuickSpec {
 				}
 
 				expect(sentValue).to(equal(initialPropertyValue))
-				expect(signalCompleted).to(beTruthy())
+				expect(signalCompleted) == true
 			}
 		}
 
@@ -76,7 +76,7 @@ class PropertySpec: QuickSpec {
 				}
 
 				mutableProperty = nil
-				expect(signalCompleted).to(beTruthy())
+				expect(signalCompleted) == true
 			}
 
 			it("should not deadlock on recursive value access") {
@@ -129,7 +129,7 @@ class PropertySpec: QuickSpec {
 					}
 
 					expect(sentValue).to(equal(initialPropertyValue))
-					expect(producerCompleted).to(beTruthy())
+					expect(producerCompleted) == true
 				}
 			}
 			
@@ -232,7 +232,7 @@ class PropertySpec: QuickSpec {
 						completed = true
 					}
 
-					expect(completed).to(beFalsy())
+					expect(completed) == false
 					expect(property.value).notTo(beNil())
 					return property
 				}()
@@ -287,9 +287,9 @@ class PropertySpec: QuickSpec {
 					
 					let bindingDisposable = mutableProperty <~ signal
 					
-					expect(bindingDisposable.disposed).to(beFalsy())
+					expect(bindingDisposable.disposed) == false
 					observer.sendCompleted()
-					expect(bindingDisposable.disposed).to(beTruthy())
+					expect(bindingDisposable.disposed) == true
 				}
 				
 				it("should tear down the binding when the property deallocates") {
@@ -300,7 +300,7 @@ class PropertySpec: QuickSpec {
 					let bindingDisposable = mutableProperty! <~ signal
 
 					mutableProperty = nil
-					expect(bindingDisposable.disposed).to(beTruthy())
+					expect(bindingDisposable.disposed) == true
 				}
 			}
 
@@ -345,7 +345,7 @@ class PropertySpec: QuickSpec {
 					let disposable = mutableProperty! <~ signalProducer
 
 					mutableProperty = nil
-					expect(disposable.disposed).to(beTruthy())
+					expect(disposable.disposed) == true
 				}
 			}
 
@@ -401,7 +401,7 @@ class PropertySpec: QuickSpec {
 					let bindingDisposable = destinationProperty! <~ sourceProperty.producer
 					destinationProperty = nil
 
-					expect(bindingDisposable.disposed).to(beTruthy())
+					expect(bindingDisposable.disposed) == true
 				}
 			}
 		}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -20,7 +20,7 @@ class PropertySpec: QuickSpec {
 			it("should have the value given at initialization") {
 				let constantProperty = ConstantProperty(initialPropertyValue)
 
-				expect(constantProperty.value).to(equal(initialPropertyValue))
+				expect(constantProperty.value) == initialPropertyValue
 			}
 
 			it("should yield a producer that sends the current value then completes") {
@@ -40,7 +40,7 @@ class PropertySpec: QuickSpec {
 					}
 				}
 
-				expect(sentValue).to(equal(initialPropertyValue))
+				expect(sentValue) == initialPropertyValue
 				expect(signalCompleted) == true
 			}
 		}
@@ -49,7 +49,7 @@ class PropertySpec: QuickSpec {
 			it("should have the value given at initialization") {
 				let mutableProperty = MutableProperty(initialPropertyValue)
 
-				expect(mutableProperty.value).to(equal(initialPropertyValue))
+				expect(mutableProperty.value) == initialPropertyValue
 			}
 
 			it("should yield a producer that sends the current value then all changes") {
@@ -61,9 +61,9 @@ class PropertySpec: QuickSpec {
 					sentValue = value
 				}
 
-				expect(sentValue).to(equal(initialPropertyValue))
+				expect(sentValue) == initialPropertyValue
 				mutableProperty.value = subsequentPropertyValue
-				expect(sentValue).to(equal(subsequentPropertyValue))
+				expect(sentValue) == subsequentPropertyValue
 			}
 
 			it("should complete its producer when deallocated") {
@@ -90,7 +90,7 @@ class PropertySpec: QuickSpec {
 				}
 
 				observer.sendNext(10)
-				expect(value).to(equal(10))
+				expect(value) == 10
 			}
 
 			it("should not deadlock on recursive observation") {
@@ -101,10 +101,10 @@ class PropertySpec: QuickSpec {
 					property.producer.startWithNext { x in value = x }
 				}
 
-				expect(value).to(equal(0))
+				expect(value) == 0
 
 				property.value = 1
-				expect(value).to(equal(1))
+				expect(value) == 1
 			}
 		}
 
@@ -128,7 +128,7 @@ class PropertySpec: QuickSpec {
 						}
 					}
 
-					expect(sentValue).to(equal(initialPropertyValue))
+					expect(sentValue) == initialPropertyValue
 					expect(producerCompleted) == true
 				}
 			}
@@ -139,7 +139,7 @@ class PropertySpec: QuickSpec {
 						initialValue: initialPropertyValue,
 						producer: SignalProducer.never)
 					
-					expect(property.value).to(equal(initialPropertyValue))
+					expect(property.value) == initialPropertyValue
 				}
 				
 				it("should take on each value sent on the producer") {
@@ -147,7 +147,7 @@ class PropertySpec: QuickSpec {
 						initialValue: initialPropertyValue,
 						producer: SignalProducer(value: subsequentPropertyValue))
 					
-					expect(property.value).to(equal(subsequentPropertyValue))
+					expect(property.value) == subsequentPropertyValue
 				}
 			}
 			
@@ -159,11 +159,11 @@ class PropertySpec: QuickSpec {
 						initialValue: initialPropertyValue,
 						signal: signal)
 					
-					expect(property.value).to(equal(initialPropertyValue))
+					expect(property.value) == initialPropertyValue
 					
 					observer.sendNext(subsequentPropertyValue)
 					
-					expect(property.value).to(equal(subsequentPropertyValue))
+					expect(property.value) == subsequentPropertyValue
 				}
 			}
 		}
@@ -182,7 +182,7 @@ class PropertySpec: QuickSpec {
 
 			beforeEach {
 				object = ObservableObject()
-				expect(object.rac_value).to(equal(0))
+				expect(object.rac_value) == 0
 
 				property = DynamicProperty(object: object, keyPath: "rac_value")
 			}
@@ -192,16 +192,16 @@ class PropertySpec: QuickSpec {
 			}
 
 			it("should read the underlying object") {
-				expect(propertyValue()).to(equal(0))
+				expect(propertyValue()) == 0
 
 				object.rac_value = 1
-				expect(propertyValue()).to(equal(1))
+				expect(propertyValue()) == 1
 			}
 
 			it("should write the underlying object") {
 				property.value = 1
-				expect(object.rac_value).to(equal(1))
-				expect(propertyValue()).to(equal(1))
+				expect(object.rac_value) == 1
+				expect(propertyValue()) == 1
 			}
 
 			it("should observe changes to the property and underlying object") {
@@ -211,13 +211,13 @@ class PropertySpec: QuickSpec {
 					values.append((value as? Int) ?? -1)
 				}
 
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				property.value = 1
-				expect(values).to(equal([ 0, 1 ]))
+				expect(values) == [ 0, 1 ]
 
 				object.rac_value = 2
-				expect(values).to(equal([ 0, 1, 2 ]))
+				expect(values) == [ 0, 1, 2 ]
 			}
 
 			it("should complete when the underlying object deallocates") {
@@ -262,10 +262,10 @@ class PropertySpec: QuickSpec {
 					mutableProperty <~ signal
 
 					// Verify that the binding hasn't changed the property value:
-					expect(mutableProperty.value).to(equal(initialPropertyValue))
+					expect(mutableProperty.value) == initialPropertyValue
 
 					observer.sendNext(subsequentPropertyValue)
-					expect(mutableProperty.value).to(equal(subsequentPropertyValue))
+					expect(mutableProperty.value) == subsequentPropertyValue
 				}
 
 				it("should tear down the binding when disposed") {
@@ -277,7 +277,7 @@ class PropertySpec: QuickSpec {
 					bindingDisposable.dispose()
 
 					observer.sendNext(subsequentPropertyValue)
-					expect(mutableProperty.value).to(equal(initialPropertyValue))
+					expect(mutableProperty.value) == initialPropertyValue
 				}
 				
 				it("should tear down the binding when bound signal is completed") {
@@ -313,7 +313,7 @@ class PropertySpec: QuickSpec {
 
 					mutableProperty <~ signalProducer
 
-					expect(mutableProperty.value).to(equal(signalValues.last!))
+					expect(mutableProperty.value) == signalValues.last!
 				}
 
 				it("should tear down the binding when disposed") {
@@ -357,7 +357,7 @@ class PropertySpec: QuickSpec {
 
 					destinationProperty <~ sourceProperty.producer
 
-					expect(destinationProperty.value).to(equal(initialPropertyValue))
+					expect(destinationProperty.value) == initialPropertyValue
 				}
 
 				it("should update with changes to the source property's value") {
@@ -368,7 +368,7 @@ class PropertySpec: QuickSpec {
 					destinationProperty <~ sourceProperty.producer
 
 					sourceProperty.value = subsequentPropertyValue
-					expect(destinationProperty.value).to(equal(subsequentPropertyValue))
+					expect(destinationProperty.value) == subsequentPropertyValue
 				}
 
 				it("should tear down the binding when disposed") {
@@ -381,7 +381,7 @@ class PropertySpec: QuickSpec {
 
 					sourceProperty.value = subsequentPropertyValue
 
-					expect(destinationProperty.value).to(equal(initialPropertyValue))
+					expect(destinationProperty.value) == initialPropertyValue
 				}
 
 				it("should tear down the binding when the source property deallocates") {

--- a/ReactiveCocoaTests/Swift/SchedulerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SchedulerSpec.swift
@@ -21,7 +21,7 @@ class SchedulerSpec: QuickSpec {
 					didRun = true
 				}
 
-				expect(didRun).to(beTruthy())
+				expect(didRun) == true
 			}
 		}
 
@@ -35,7 +35,7 @@ class SchedulerSpec: QuickSpec {
 			it("should run actions immediately when on the main thread") {
 				let scheduler = UIScheduler()
 				var values: [Int] = []
-				expect(NSThread.isMainThread()).to(beTruthy())
+				expect(NSThread.isMainThread()) == true
 
 				scheduler.schedule {
 					values.append(0)
@@ -60,7 +60,7 @@ class SchedulerSpec: QuickSpec {
 
 				dispatchSyncInBackground {
 					scheduler.schedule {
-						expect(NSThread.isMainThread()).to(beTruthy())
+						expect(NSThread.isMainThread()) == true
 						values.append(0)
 					}
 
@@ -72,12 +72,12 @@ class SchedulerSpec: QuickSpec {
 
 				dispatchSyncInBackground {
 					scheduler.schedule {
-						expect(NSThread.isMainThread()).to(beTruthy())
+						expect(NSThread.isMainThread()) == true
 						values.append(1)
 					}
 
 					scheduler.schedule {
-						expect(NSThread.isMainThread()).to(beTruthy())
+						expect(NSThread.isMainThread()) == true
 						values.append(2)
 					}
 
@@ -94,7 +94,7 @@ class SchedulerSpec: QuickSpec {
 
 				dispatchSyncInBackground {
 					scheduler.schedule {
-						expect(NSThread.isMainThread()).to(beTruthy())
+						expect(NSThread.isMainThread()) == true
 						values.append(0)
 					}
 
@@ -102,12 +102,12 @@ class SchedulerSpec: QuickSpec {
 				}
 
 				scheduler.schedule {
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 					values.append(1)
 				}
 
 				scheduler.schedule {
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 					values.append(2)
 				}
 
@@ -127,7 +127,7 @@ class SchedulerSpec: QuickSpec {
 				}
 				scheduler.schedule {
 					didRun = true
-					expect(NSThread.isMainThread()).to(beFalsy())
+					expect(NSThread.isMainThread()) == false
 				}
 
 				expect{didRun}.toEventually(beTruthy())
@@ -150,7 +150,7 @@ class SchedulerSpec: QuickSpec {
 
 					for _ in 0..<5 {
 						scheduler.schedule {
-							expect(NSThread.isMainThread()).to(beFalsy())
+							expect(NSThread.isMainThread()) == false
 							value++
 						}
 					}
@@ -165,10 +165,10 @@ class SchedulerSpec: QuickSpec {
 					var didRun = false
 					scheduler.scheduleAfter(NSDate()) {
 						didRun = true
-						expect(NSThread.isMainThread()).to(beFalsy())
+						expect(NSThread.isMainThread()) == false
 					}
 
-					expect(didRun).to(beFalsy())
+					expect(didRun) == false
 
 					dispatch_resume(scheduler.queue)
 					expect{didRun}.toEventually(beTruthy())
@@ -181,7 +181,7 @@ class SchedulerSpec: QuickSpec {
 					let timesToRun = 3
 
 					disposable.innerDisposable = scheduler.scheduleAfter(NSDate(), repeatingEvery: 0.01, withLeeway: 0) {
-						expect(NSThread.isMainThread()).to(beFalsy())
+						expect(NSThread.isMainThread()) == false
 
 						if ++count == timesToRun {
 							disposable.dispose()
@@ -215,12 +215,12 @@ class SchedulerSpec: QuickSpec {
 
 				scheduler.schedule {
 					string += "foo"
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 				}
 
 				scheduler.schedule {
 					string += "bar"
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 				}
 
 				expect(string).to(equal(""))
@@ -236,12 +236,12 @@ class SchedulerSpec: QuickSpec {
 
 				scheduler.scheduleAfter(15) {
 					string += "bar"
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 				}
 
 				scheduler.scheduleAfter(5) {
 					string += "foo"
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 				}
 
 				expect(string).to(equal(""))
@@ -260,17 +260,17 @@ class SchedulerSpec: QuickSpec {
 
 				scheduler.scheduleAfter(15) {
 					string += "bar"
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 				}
 
 				scheduler.scheduleAfter(5) {
 					string += "foo"
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 				}
 
 				scheduler.schedule {
 					string += "fuzzbuzz"
-					expect(NSThread.isMainThread()).to(beTruthy())
+					expect(NSThread.isMainThread()) == true
 				}
 
 				expect(string).to(equal(""))

--- a/ReactiveCocoaTests/Swift/SchedulerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SchedulerSpec.swift
@@ -41,7 +41,7 @@ class SchedulerSpec: QuickSpec {
 					values.append(0)
 				}
 
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				scheduler.schedule {
 					values.append(1)
@@ -51,7 +51,7 @@ class SchedulerSpec: QuickSpec {
 					values.append(2)
 				}
 
-				expect(values).to(equal([ 0, 1, 2 ]))
+				expect(values) == [ 0, 1, 2 ]
 			}
 
 			it("should enqueue actions scheduled from the background") {
@@ -67,7 +67,7 @@ class SchedulerSpec: QuickSpec {
 					return
 				}
 
-				expect(values).to(equal([]))
+				expect(values) == []
 				expect(values).toEventually(equal([ 0 ]))
 
 				dispatchSyncInBackground {
@@ -84,7 +84,7 @@ class SchedulerSpec: QuickSpec {
 					return
 				}
 
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 				expect(values).toEventually(equal([ 0, 1, 2 ]))
 			}
 
@@ -111,7 +111,7 @@ class SchedulerSpec: QuickSpec {
 					values.append(2)
 				}
 
-				expect(values).to(equal([]))
+				expect(values) == []
 				expect(values).toEventually(equal([ 0, 1, 2 ]))
 			}
 		}
@@ -155,7 +155,7 @@ class SchedulerSpec: QuickSpec {
 						}
 					}
 
-					expect(value).to(equal(0))
+					expect(value) == 0
 
 					dispatch_resume(scheduler.queue)
 					expect{value}.toEventually(equal(5))
@@ -188,7 +188,7 @@ class SchedulerSpec: QuickSpec {
 						}
 					}
 
-					expect(count).to(equal(0))
+					expect(count) == 0
 
 					dispatch_resume(scheduler.queue)
 					expect{count}.toEventually(equal(timesToRun))
@@ -207,7 +207,7 @@ class SchedulerSpec: QuickSpec {
 				startDate = NSDate()
 
 				scheduler = TestScheduler(startDate: startDate)
-				expect(scheduler.currentDate).to(equal(startDate))
+				expect(scheduler.currentDate) == startDate
 			}
 
 			it("should run immediately enqueued actions upon advancement") {
@@ -223,12 +223,12 @@ class SchedulerSpec: QuickSpec {
 					expect(NSThread.isMainThread()) == true
 				}
 
-				expect(string).to(equal(""))
+				expect(string) == ""
 
 				scheduler.advance()
 				expect(scheduler.currentDate).to(beCloseTo(startDate))
 
-				expect(string).to(equal("foobar"))
+				expect(string) == "foobar"
 			}
 
 			it("should run actions when advanced past the target date") {
@@ -244,15 +244,15 @@ class SchedulerSpec: QuickSpec {
 					expect(NSThread.isMainThread()) == true
 				}
 
-				expect(string).to(equal(""))
+				expect(string) == ""
 
 				scheduler.advanceByInterval(10)
 				expect(scheduler.currentDate).to(beCloseTo(startDate.dateByAddingTimeInterval(10), within: dateComparisonDelta))
-				expect(string).to(equal("foo"))
+				expect(string) == "foo"
 
 				scheduler.advanceByInterval(10)
 				expect(scheduler.currentDate).to(beCloseTo(startDate.dateByAddingTimeInterval(20), within: dateComparisonDelta))
-				expect(string).to(equal("foobar"))
+				expect(string) == "foobar"
 			}
 
 			it("should run all remaining actions in order") {
@@ -273,11 +273,11 @@ class SchedulerSpec: QuickSpec {
 					expect(NSThread.isMainThread()) == true
 				}
 
-				expect(string).to(equal(""))
+				expect(string) == ""
 
 				scheduler.run()
-				expect(scheduler.currentDate).to(equal(NSDate.distantFuture()))
-				expect(string).to(equal("fuzzbuzzfoobar"))
+				expect(scheduler.currentDate) == NSDate.distantFuture()
+				expect(string) == "fuzzbuzzfoobar"
 			}
 		}
 	}

--- a/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
@@ -58,12 +58,12 @@ class SignalLifetimeSpec: QuickSpec {
 
 				signal?.observeFailed { _ in errored = true }
 
-				expect(errored).to(beFalsy())
+				expect(errored) == false
 				expect(signal).toNot(beNil())
 
 				testScheduler.run()
 
-				expect(errored).to(beTruthy())
+				expect(errored) == true
 				expect(signal).to(beNil())
 			}
 
@@ -79,12 +79,12 @@ class SignalLifetimeSpec: QuickSpec {
 
 				signal?.observeCompleted { completed = true }
 
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				expect(signal).toNot(beNil())
 
 				testScheduler.run()
 
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 				expect(signal).to(beNil())
 			}
 
@@ -102,12 +102,12 @@ class SignalLifetimeSpec: QuickSpec {
 					interrupted = true
 				}
 
-				expect(interrupted).to(beFalsy())
+				expect(interrupted) == false
 				expect(signal).toNot(beNil())
 
 				testScheduler.run()
 
-				expect(interrupted).to(beTruthy())
+				expect(interrupted) == true
 				expect(signal).to(beNil())
 			}
 		}

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -406,9 +406,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 					.take(numbers.count)
 					.startWithCompleted { completed = true }
 				
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				testScheduler.run()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should interrupt when 0") {
@@ -442,7 +442,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 
-				expect(interrupted).to(beTruthy())
+				expect(interrupted) == true
 
 				testScheduler.run()
 				expect(result).to(beEmpty())
@@ -739,11 +739,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
 				expect(result).to(equal([ 1 ]))
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
 				expect(result).to(equal([ 1, 2 ]))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should schedule errors immediately") {
@@ -764,7 +764,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					.startWithFailed { _ in errored = true }
 				
 				testScheduler.advance()
-				expect(errored).to(beTruthy())
+				expect(errored) == true
 			}
 		}
 
@@ -842,11 +842,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				observer.sendNext(1)
 				observer.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 
 				scheduler.run()
 				expect(values).to(equal([ 0 ]))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -896,10 +896,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				sampledProducer.startWithCompleted { completed = true }
 				
 				observer.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				
 				samplerObserver.sendCompleted()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should emit an initial value if the sampler is a synchronous SignalProducer") {
@@ -950,10 +950,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				combinedProducer.startWithCompleted { completed = true }
 				
 				observer.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				
 				otherObserver.sendCompleted()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -1011,15 +1011,15 @@ class SignalProducerLiftingSpec: QuickSpec {
 					}
 				}
 
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 
 				leftObserver.sendNext(0)
 				leftObserver.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				expect(result).to(equal([]))
 
 				rightObserver.sendNext("foo")
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 				expect(result).to(equal([ "0foo" ]))
 			}
 		}
@@ -1084,19 +1084,19 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var errored = false
 				dematerialized.startWithFailed { _ in errored = true }
 				
-				expect(errored).to(beFalsy())
+				expect(errored) == false
 				
 				observer.sendNext(.Failed(TestError.Default))
-				expect(errored).to(beTruthy())
+				expect(errored) == true
 			}
 
 			it("should complete early for Completed events") {
 				var completed = false
 				dematerialized.startWithCompleted { completed = true }
 				
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				observer.sendNext(IntEvent.Completed)
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -1151,10 +1151,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(1)
 				observer.sendNext(2)
 				observer.sendNext(3)
-				expect(errored).to(beFalsy())
+				expect(errored) == false
 				
 				observer.sendFailed(TestError.Default)
-				expect(errored).to(beTruthy())
+				expect(errored) == true
 				expect(result).to(beEmpty())
 			}
 		}
@@ -1189,12 +1189,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 					observer.sendCompleted()
 				}
 
-				expect(completed).to(beFalsy())
-				expect(errored).to(beFalsy())
+				expect(completed) == false
+				expect(errored) == false
 
 				testScheduler.run()
-				expect(completed).to(beTruthy())
-				expect(errored).to(beFalsy())
+				expect(completed) == true
+				expect(errored) == false
 			}
 
 			it("should error if not completed before the interval has elapsed") {
@@ -1215,12 +1215,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 					observer.sendCompleted()
 				}
 
-				expect(completed).to(beFalsy())
-				expect(errored).to(beFalsy())
+				expect(completed) == false
+				expect(errored) == false
 
 				testScheduler.run()
-				expect(completed).to(beFalsy())
-				expect(errored).to(beTruthy())
+				expect(completed) == false
+				expect(errored) == true
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -28,10 +28,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(0)
-				expect(lastValue).to(equal("1"))
+				expect(lastValue) == "1"
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal("2"))
+				expect(lastValue) == "2"
 			}
 		}
 		
@@ -48,7 +48,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(error).to(beNil())
 
 				observer.sendFailed(TestError.Default)
-				expect(error).to(equal(producerError))
+				expect(error) == producerError
 			}
 		}
 
@@ -64,13 +64,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 		}
 
@@ -88,13 +88,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(nil)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 		}
 
@@ -110,10 +110,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext("a")
-				expect(lastValue).to(equal("a"))
+				expect(lastValue) == "a"
 
 				observer.sendNext("bb")
-				expect(lastValue).to(equal("abb"))
+				expect(lastValue) == "abb"
 			}
 		}
 
@@ -148,7 +148,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendCompleted()
 				expect(completed) == true
 
-				expect(lastValue).to(equal(4))
+				expect(lastValue) == 4
 			}
 
 			it("should send the initial value if none are received") {
@@ -174,7 +174,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				observer.sendCompleted()
 
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 				expect(completed) == true
 			}
 		}
@@ -193,7 +193,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 
 			it("should not skip any values when 0") {
@@ -206,10 +206,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 		}
 
@@ -221,19 +221,19 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var values: [Bool] = []
 				producer.startWithNext { values.append($0) }
 
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				observer.sendNext(true)
-				expect(values).to(equal([ true ]))
+				expect(values) == [ true ]
 
 				observer.sendNext(true)
-				expect(values).to(equal([ true ]))
+				expect(values) == [ true ]
 
 				observer.sendNext(false)
-				expect(values).to(equal([ true, false ]))
+				expect(values) == [ true, false ]
 
 				observer.sendNext(true)
-				expect(values).to(equal([ true, false, true ]))
+				expect(values) == [ true, false, true ]
 			}
 
 			it("should skip values according to a predicate") {
@@ -243,19 +243,19 @@ class SignalProducerLiftingSpec: QuickSpec {
 				var values: [String] = []
 				producer.startWithNext { values.append($0) }
 
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				observer.sendNext("a")
-				expect(values).to(equal([ "a" ]))
+				expect(values) == [ "a" ]
 
 				observer.sendNext("b")
-				expect(values).to(equal([ "a" ]))
+				expect(values) == [ "a" ]
 
 				observer.sendNext("cc")
-				expect(values).to(equal([ "a", "cc" ]))
+				expect(values) == [ "a", "cc" ]
 
 				observer.sendNext("d")
-				expect(values).to(equal([ "a", "cc", "d" ]))
+				expect(values) == [ "a", "cc", "d" ]
 			}
 		}
 
@@ -282,20 +282,20 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 			}
 
 			it("should not skip any values when the predicate starts false") {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(3)
-				expect(lastValue).to(equal(3))
+				expect(lastValue) == 3
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 			}
 		}
 		
@@ -337,7 +337,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				triggerObserver.sendNext(())
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 			}
 			
 			it("should skip values until the trigger completes") {
@@ -351,7 +351,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				triggerObserver.sendCompleted()
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 			}
 		}
 
@@ -377,11 +377,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == false
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 				expect(completed) == false
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 				expect(completed) == true
 			}
 			
@@ -468,7 +468,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(result).to(beNil())
 				observer.sendCompleted()
-				expect(result).to(equal(expectedResult))
+				expect(result) == expectedResult
 			}
 
 			it("should complete with an empty array if there are no values") {
@@ -481,7 +481,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(result).to(beNil())
 				observer.sendCompleted()
-				expect(result).to(equal([]))
+				expect(result) == []
 			}
 
 			it("should forward errors") {
@@ -494,7 +494,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(error).to(beNil())
 				observer.sendFailed(.Default)
-				expect(error).to(equal(TestError.Default))
+				expect(error) == TestError.Default
 			}
 		}
 
@@ -533,10 +533,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 
 				expect(completed) == false
 				triggerObserver.sendNext(())
@@ -547,10 +547,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 				
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 				
 				expect(completed) == false
 				triggerObserver.sendCompleted()
@@ -604,23 +604,23 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == false
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 
 				replacementObserver.sendNext(3)
 
-				expect(lastValue).to(equal(3))
+				expect(lastValue) == 3
 				expect(completed) == false
 
 				observer.sendNext(4)
 
-				expect(lastValue).to(equal(3))
+				expect(lastValue) == 3
 				expect(completed) == false
 
 				replacementObserver.sendNext(5)
-				expect(lastValue).to(equal(5))
+				expect(lastValue) == 5
 
 				expect(completed) == false
 				replacementObserver.sendCompleted()
@@ -655,12 +655,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				for value in -1...4 {
 					observer.sendNext(value)
-					expect(latestValue).to(equal(value))
+					expect(latestValue) == value
 					expect(completed) == false
 				}
 
 				observer.sendNext(5)
-				expect(latestValue).to(equal(4))
+				expect(latestValue) == 4
 				expect(completed) == true
 			}
 
@@ -701,7 +701,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				testScheduler.run()
-				expect(result).to(equal([ 1, 2 ]))
+				expect(result) == [ 1, 2 ]
 			}
 		}
 
@@ -738,11 +738,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
-				expect(result).to(equal([ 1 ]))
+				expect(result) == [ 1 ]
 				expect(completed) == false
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
-				expect(result).to(equal([ 1, 2 ]))
+				expect(result) == [ 1, 2 ]
 				expect(completed) == true
 			}
 
@@ -788,37 +788,37 @@ class SignalProducerLiftingSpec: QuickSpec {
 					values.append(value)
 				}
 
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				observer.sendNext(0)
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				scheduler.advance()
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				observer.sendNext(1)
 				observer.sendNext(2)
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				scheduler.advanceByInterval(1.5)
-				expect(values).to(equal([ 0, 2 ]))
+				expect(values) == [ 0, 2 ]
 
 				scheduler.advanceByInterval(3)
-				expect(values).to(equal([ 0, 2 ]))
+				expect(values) == [ 0, 2 ]
 
 				observer.sendNext(3)
-				expect(values).to(equal([ 0, 2 ]))
+				expect(values) == [ 0, 2 ]
 
 				scheduler.advance()
-				expect(values).to(equal([ 0, 2, 3 ]))
+				expect(values) == [ 0, 2, 3 ]
 
 				observer.sendNext(4)
 				observer.sendNext(5)
 				scheduler.advance()
-				expect(values).to(equal([ 0, 2, 3 ]))
+				expect(values) == [ 0, 2, 3 ]
 
 				scheduler.run()
-				expect(values).to(equal([ 0, 2, 3, 5 ]))
+				expect(values) == [ 0, 2, 3, 5 ]
 			}
 
 			it("should schedule completion immediately") {
@@ -838,14 +838,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				observer.sendNext(0)
 				scheduler.advance()
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				observer.sendNext(1)
 				observer.sendCompleted()
 				expect(completed) == false
 
 				scheduler.run()
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 				expect(completed) == true
 			}
 		}
@@ -870,7 +870,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(1)
 				observer.sendNext(2)
 				samplerObserver.sendNext(())
-				expect(result).to(equal([ 2 ]))
+				expect(result) == [ 2 ]
 			}
 			
 			it("should do nothing if sampler fires before signal receives value") {
@@ -888,7 +888,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(1)
 				samplerObserver.sendNext(())
 				samplerObserver.sendNext(())
-				expect(result).to(equal([ 1, 1 ]))
+				expect(result) == [ 1, 1 ]
 			}
 
 			it("should complete when both inputs have completed") {
@@ -937,12 +937,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				// is there a better way to test tuples?
 				otherObserver.sendNext(1.5)
-				expect(latest?.0).to(equal(1))
-				expect(latest?.1).to(equal(1.5))
+				expect(latest?.0) == 1
+				expect(latest?.1) == 1.5
 				
 				observer.sendNext(2)
-				expect(latest?.0).to(equal(2))
-				expect(latest?.1).to(equal(1.5))
+				expect(latest?.0) == 2
+				expect(latest?.1) == 1.5
 			}
 
 			it("should complete when both inputs have completed") {
@@ -977,23 +977,23 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				leftObserver.sendNext(1)
 				leftObserver.sendNext(2)
-				expect(result).to(equal([]))
+				expect(result) == []
 
 				rightObserver.sendNext("foo")
-				expect(result).to(equal([ "1foo" ]))
+				expect(result) == [ "1foo" ]
 
 				leftObserver.sendNext(3)
 				rightObserver.sendNext("bar")
-				expect(result).to(equal([ "1foo", "2bar" ]))
+				expect(result) == [ "1foo", "2bar" ]
 
 				rightObserver.sendNext("buzz")
-				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
+				expect(result) == [ "1foo", "2bar", "3buzz" ]
 
 				rightObserver.sendNext("fuzz")
-				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
+				expect(result) == [ "1foo", "2bar", "3buzz" ]
 
 				leftObserver.sendNext(4)
-				expect(result).to(equal([ "1foo", "2bar", "3buzz", "4fuzz" ]))
+				expect(result) == [ "1foo", "2bar", "3buzz", "4fuzz" ]
 			}
 
 			it("should complete when the shorter signal has completed") {
@@ -1016,11 +1016,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				leftObserver.sendNext(0)
 				leftObserver.sendCompleted()
 				expect(completed) == false
-				expect(result).to(equal([]))
+				expect(result) == []
 
 				rightObserver.sendNext("foo")
 				expect(completed) == true
-				expect(result).to(equal([ "0foo" ]))
+				expect(result) == [ "0foo" ]
 			}
 		}
 
@@ -1038,7 +1038,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				if let latestEvent = latestEvent {
 					switch latestEvent {
 					case let .Next(value):
-						expect(value).to(equal(2))
+						expect(value) == 2
 					default:
 						fail()
 					}
@@ -1074,10 +1074,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				observer.sendNext(.Next(2))
-				expect(result).to(equal([ 2 ]))
+				expect(result) == [ 2 ]
 				
 				observer.sendNext(.Next(4))
-				expect(result).to(equal([ 2, 4 ]))
+				expect(result) == [ 2, 4 ]
 			}
 
 			it("should error out for Error events") {
@@ -1121,7 +1121,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				observer.sendCompleted()
-				expect(result).to(equal([ 2, 3, 4 ]))
+				expect(result) == [ 2, 3, 4 ]
 			}
 
 			it("should send less than N values if not enough were received") {
@@ -1131,7 +1131,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(1)
 				observer.sendNext(2)
 				observer.sendCompleted()
-				expect(result).to(equal([ 1, 2 ]))
+				expect(result) == [ 1, 2 ]
 			}
 			
 			it("should send nothing when errors") {
@@ -1238,7 +1238,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				
 				for value in 1...5 {
 					observer.sendNext(value)
-					expect(current).to(equal(value))
+					expect(current) == value
 				}
 			}
 			
@@ -1254,7 +1254,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				observer.sendNext(42)
-				expect(error).to(equal(TestError.Default))
+				expect(error) == TestError.Default
 			}
 		}
 		
@@ -1271,10 +1271,10 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				observer.sendNext(1)
-				expect(even).to(equal(false))
+				expect(even) == false
 				
 				observer.sendNext(2)
-				expect(even).to(equal(true))
+				expect(even) == true
 			}
 			
 			it("should error if a mapping fails") {
@@ -1289,7 +1289,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				observer.sendNext(42)
-				expect(error).to(equal(TestError.Default))
+				expect(error) == TestError.Default
 			}
 		}
 		
@@ -1310,12 +1310,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(latestValues).to(beNil())
 				
 				observer.sendNext(1)
-				expect(latestValues?.0).to(equal(initialValue))
-				expect(latestValues?.1).to(equal(1))
+				expect(latestValues?.0) == initialValue
+				expect(latestValues?.1) == 1
 				
 				observer.sendNext(2)
-				expect(latestValues?.0).to(equal(1))
-				expect(latestValues?.1).to(equal(2))
+				expect(latestValues?.0) == 1
+				expect(latestValues?.1) == 2
 			}
 		}
 	}

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -144,9 +144,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(2)
 				expect(lastValue).to(beNil())
 
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				observer.sendCompleted()
-				expect(completed).to(beTrue())
+				expect(completed) == true
 
 				expect(lastValue).to(equal(4))
 			}
@@ -170,12 +170,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendCompleted()
 
 				expect(lastValue).to(equal(1))
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 		}
 
@@ -374,15 +374,15 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 			
 			it("should complete immediately after taking given number of values") {
@@ -538,9 +538,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				triggerObserver.sendNext(())
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 
 			it("should take values until the trigger completes") {
@@ -552,18 +552,18 @@ class SignalProducerLiftingSpec: QuickSpec {
 				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 				
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				triggerObserver.sendCompleted()
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 
 			it("should complete if the trigger fires immediately") {
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				triggerObserver.sendNext(())
 
-				expect(completed).to(beTrue())
+				expect(completed) == true
 				expect(lastValue).to(beNil())
 			}
 		}
@@ -601,7 +601,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should take values from the original then the replacement") {
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
@@ -612,19 +612,19 @@ class SignalProducerLiftingSpec: QuickSpec {
 				replacementObserver.sendNext(3)
 
 				expect(lastValue).to(equal(3))
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(4)
 
 				expect(lastValue).to(equal(3))
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				replacementObserver.sendNext(5)
 				expect(lastValue).to(equal(5))
 
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				replacementObserver.sendCompleted()
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 		}
 
@@ -656,12 +656,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 				for value in -1...4 {
 					observer.sendNext(value)
 					expect(latestValue).to(equal(value))
-					expect(completed).to(beFalse())
+					expect(completed) == false
 				}
 
 				observer.sendNext(5)
 				expect(latestValue).to(equal(4))
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 
 			it("should complete if the predicate starts false") {
@@ -681,7 +681,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				observer.sendNext(5)
 				expect(latestValue).to(beNil())
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -66,10 +66,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				producer.start()
-				expect(addedDisposable.disposed).to(beFalsy())
+				expect(addedDisposable.disposed) == false
 
 				observer.sendCompleted()
-				expect(addedDisposable.disposed).to(beTruthy())
+				expect(addedDisposable.disposed) == true
 			}
 
 			it("should dispose of added disposables upon error") {
@@ -82,10 +82,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				producer.start()
-				expect(addedDisposable.disposed).to(beFalsy())
+				expect(addedDisposable.disposed) == false
 
 				observer.sendFailed(.Default)
-				expect(addedDisposable.disposed).to(beTruthy())
+				expect(addedDisposable.disposed) == true
 			}
 
 			it("should dispose of added disposables upon interruption") {
@@ -98,10 +98,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				producer.start()
-				expect(addedDisposable.disposed).to(beFalsy())
+				expect(addedDisposable.disposed) == false
 
 				observer.sendInterrupted()
-				expect(addedDisposable.disposed).to(beTruthy())
+				expect(addedDisposable.disposed) == true
 			}
 
 			it("should dispose of added disposables upon start() disposal") {
@@ -113,10 +113,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				let startDisposable = producer.start()
-				expect(addedDisposable.disposed).to(beFalsy())
+				expect(addedDisposable.disposed) == false
 
 				startDisposable.dispose()
-				expect(addedDisposable.disposed).to(beTruthy())
+				expect(addedDisposable.disposed) == true
 			}
 		}
 
@@ -269,18 +269,18 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				expect(values).to(equal([1, 2, 3]))
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 
 				observer.sendNext(4)
 				observer.sendNext(5)
 
 				expect(values).to(equal([1, 2, 3, 4, 5]))
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 
 				observer.sendCompleted()
 
 				expect(values).to(equal([1, 2, 3, 4, 5]))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should drop earliest events to maintain the capacity") {
@@ -327,7 +327,7 @@ class SignalProducerSpec: QuickSpec {
 					completed = true
 				}
 				
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 			
 			it("should replay values after being terminated") {
@@ -350,7 +350,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 				
 				expect(value).to(equal(123))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should not deadlock when started while sending") {
@@ -470,11 +470,11 @@ class SignalProducerSpec: QuickSpec {
 						value = $0
 					})
 					.startWithSignal { _ in
-						expect(started).to(beFalsy())
+						expect(started) == false
 						expect(value).to(beNil())
 					}
 
-				expect(started).to(beTruthy())
+				expect(started) == true
 				expect(value).to(equal(42))
 			}
 
@@ -491,10 +491,10 @@ class SignalProducerSpec: QuickSpec {
 					disposable = innerDisposable
 				}
 
-				expect(addedDisposable.disposed).to(beFalsy())
+				expect(addedDisposable.disposed) == false
 
 				disposable.dispose()
-				expect(addedDisposable.disposed).to(beTruthy())
+				expect(addedDisposable.disposed) == true
 			}
 
 			it("should send interrupted if disposed") {
@@ -511,10 +511,10 @@ class SignalProducerSpec: QuickSpec {
 						disposable = innerDisposable
 					}
 
-				expect(interrupted).to(beFalsy())
+				expect(interrupted) == false
 
 				disposable.dispose()
-				expect(interrupted).to(beTruthy())
+				expect(interrupted) == true
 			}
 
 			it("should release signal observers if disposed") {
@@ -546,13 +546,13 @@ class SignalProducerSpec: QuickSpec {
 						value = $0
 					})
 					.startWithSignal { _, disposable in
-						expect(started).to(beFalsy())
+						expect(started) == false
 						expect(value).to(beNil())
 
 						disposable.dispose()
 					}
 
-				expect(started).to(beFalsy())
+				expect(started) == false
 				expect(value).to(beNil())
 			}
 
@@ -561,7 +561,7 @@ class SignalProducerSpec: QuickSpec {
 
 				SignalProducer<Int, NoError>(value: 42)
 					.startWithSignal { signal, disposable in
-						expect(interrupted).to(beFalsy())
+						expect(interrupted) == false
 
 						signal.observeInterrupted {
 							interrupted = true
@@ -570,7 +570,7 @@ class SignalProducerSpec: QuickSpec {
 						disposable.dispose()
 					}
 
-				expect(interrupted).to(beTruthy())
+				expect(interrupted) == true
 			}
 
 			it("should dispose of added disposables upon completion") {
@@ -583,10 +583,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				producer.startWithSignal { _ in }
-				expect(addedDisposable.disposed).to(beFalsy())
+				expect(addedDisposable.disposed) == false
 
 				observer.sendCompleted()
-				expect(addedDisposable.disposed).to(beTruthy())
+				expect(addedDisposable.disposed) == true
 			}
 
 			it("should dispose of added disposables upon error") {
@@ -599,10 +599,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				producer.startWithSignal { _ in }
-				expect(addedDisposable.disposed).to(beFalsy())
+				expect(addedDisposable.disposed) == false
 
 				observer.sendFailed(.Default)
-				expect(addedDisposable.disposed).to(beTruthy())
+				expect(addedDisposable.disposed) == true
 			}
 		}
 
@@ -624,7 +624,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				expect(values).to(equal([1, 2]))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should send interrupted if disposed") {
@@ -635,10 +635,10 @@ class SignalProducerSpec: QuickSpec {
 					interrupted = true
 				}
 
-				expect(interrupted).to(beFalsy())
+				expect(interrupted) == false
 
 				disposable.dispose()
-				expect(interrupted).to(beTruthy())
+				expect(interrupted) == true
 			}
 
 			it("should release observer when disposed") {
@@ -945,10 +945,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				producer.startOn(scheduler).start()
-				expect(invoked).to(beFalsy())
+				expect(invoked) == false
 
 				scheduler.advance()
-				expect(invoked).to(beTruthy())
+				expect(invoked) == true
 			}
 
 			it("should forward events on their original scheduler") {
@@ -1002,7 +1002,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 
 				expect(values).to(equal([1, 2]))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should interrupt the replaced producer on disposal") {
@@ -1020,8 +1020,8 @@ class SignalProducerSpec: QuickSpec {
 				baseObserver.sendFailed(.Default)
 				disposable.dispose()
 
-				expect(interrupted).to(beTruthy())
-				expect(disposed).to(beTruthy())
+				expect(interrupted) == true
+				expect(disposed) == true
 			}
 		}
 
@@ -1054,25 +1054,25 @@ class SignalProducerSpec: QuickSpec {
 					it("should immediately start subsequent inner producer if previous inner producer has already completed") {
 						completePrevious()
 						sendSubsequent()
-						expect(subsequentStarted).to(beTruthy())
+						expect(subsequentStarted) == true
 					}
 
 					context("with queued producers") {
 						beforeEach {
 							// Place the subsequent producer into `concat`'s queue.
 							sendSubsequent()
-							expect(subsequentStarted).to(beFalsy())
+							expect(subsequentStarted) == false
 						}
 
 						it("should start subsequent inner producer upon completion of previous inner producer") {
 							completePrevious()
-							expect(subsequentStarted).to(beTruthy())
+							expect(subsequentStarted) == true
 						}
 
 						it("should start subsequent inner producer upon completion of previous inner producer and completion of outer producer") {
 							completeOuter()
 							completePrevious()
-							expect(subsequentStarted).to(beTruthy())
+							expect(subsequentStarted) == true
 						}
 					}
 				}
@@ -1124,18 +1124,18 @@ class SignalProducerSpec: QuickSpec {
 
 					it("should complete when inner producers complete, then outer producer completes") {
 						completeInner()
-						expect(completed).to(beFalsy())
+						expect(completed) == false
 
 						completeOuter()
-						expect(completed).to(beTruthy())
+						expect(completed) == true
 					}
 
 					it("should complete when outer producers completes, then inner producers complete") {
 						completeOuter()
-						expect(completed).to(beFalsy())
+						expect(completed) == false
 
 						completeInner()
-						expect(completed).to(beTruthy())
+						expect(completed) == true
 					}
 				}
 			}
@@ -1193,9 +1193,9 @@ class SignalProducerSpec: QuickSpec {
 
 					it("should complete when all signals have completed") {
 						completeA()
-						expect(outerCompleted).to(beFalsy())
+						expect(outerCompleted) == false
 						completeB()
-						expect(outerCompleted).to(beTruthy())
+						expect(outerCompleted) == true
 					}
 				}
 
@@ -1256,8 +1256,8 @@ class SignalProducerSpec: QuickSpec {
 					outerObserver.sendCompleted()
 
 					expect(receivedValues).to(equal([ 0, 1, 2 ]))
-					expect(errored).to(beFalsy())
-					expect(completed).to(beFalsy())
+					expect(errored) == false
+					expect(completed) == false
 
 					firstInnerObserver.sendNext(3)
 					firstInnerObserver.sendCompleted()
@@ -1265,8 +1265,8 @@ class SignalProducerSpec: QuickSpec {
 					secondInnerObserver.sendCompleted()
 
 					expect(receivedValues).to(equal([ 0, 1, 2, 4 ]))
-					expect(errored).to(beFalsy())
-					expect(completed).to(beTruthy())
+					expect(errored) == false
+					expect(completed) == true
 				}
 
 				it("should forward an error from an inner signal") {
@@ -1293,7 +1293,7 @@ class SignalProducerSpec: QuickSpec {
 						completed = true
 					}
 
-					expect(completed).to(beTruthy())
+					expect(completed) == true
 				}
 
 				it("should complete when the outer signal completes before sending any signals") {
@@ -1304,7 +1304,7 @@ class SignalProducerSpec: QuickSpec {
 						completed = true
 					}
 
-					expect(completed).to(beTruthy())
+					expect(completed) == true
 				}
 
 				it("should not deadlock") {
@@ -1357,17 +1357,17 @@ class SignalProducerSpec: QuickSpec {
 						execute(.Concat)
 
 						innerObserver.sendInterrupted()
-						expect(interrupted).to(beFalsy())
-						expect(completed).to(beFalsy())
+						expect(interrupted) == false
+						expect(completed) == false
 
 						outerObserver.sendCompleted()
-						expect(completed).to(beTruthy())
+						expect(completed) == true
 					}
 
 					it("should forward interrupted from the outer producer") {
 						execute(.Concat)
 						outerObserver.sendInterrupted()
-						expect(interrupted).to(beTruthy())
+						expect(interrupted) == true
 					}
 				}
 
@@ -1376,17 +1376,17 @@ class SignalProducerSpec: QuickSpec {
 						execute(.Latest)
 
 						innerObserver.sendInterrupted()
-						expect(interrupted).to(beFalsy())
-						expect(completed).to(beFalsy())
+						expect(interrupted) == false
+						expect(completed) == false
 
 						outerObserver.sendCompleted()
-						expect(completed).to(beTruthy())
+						expect(completed) == true
 					}
 
 					it("should forward interrupted from the outer producer") {
 						execute(.Latest)
 						outerObserver.sendInterrupted()
-						expect(interrupted).to(beTruthy())
+						expect(interrupted) == true
 					}
 				}
 
@@ -1395,17 +1395,17 @@ class SignalProducerSpec: QuickSpec {
 						execute(.Merge)
 
 						innerObserver.sendInterrupted()
-						expect(interrupted).to(beFalsy())
-						expect(completed).to(beFalsy())
+						expect(interrupted) == false
+						expect(completed) == false
 
 						outerObserver.sendCompleted()
-						expect(completed).to(beTruthy())
+						expect(completed) == true
 					}
 
 					it("should forward interrupted from the outer producer") {
 						execute(.Merge)
 						outerObserver.sendInterrupted()
-						expect(interrupted).to(beTruthy())
+						expect(interrupted) == true
 					}
 				}
 			}
@@ -1441,12 +1441,12 @@ class SignalProducerSpec: QuickSpec {
 					it("should cancel inner work when disposed before the outer producer completes") {
 						execute(.Concat)
 
-						expect(innerDisposable.disposed).to(beFalsy())
-						expect(interrupted).to(beFalsy())
+						expect(innerDisposable.disposed) == false
+						expect(interrupted) == false
 						disposeOuter()
 
-						expect(innerDisposable.disposed).to(beTruthy())
-						expect(interrupted).to(beTruthy())
+						expect(innerDisposable.disposed) == true
+						expect(interrupted) == true
 					}
 
 					it("should cancel inner work when disposed after the outer producer completes") {
@@ -1454,12 +1454,12 @@ class SignalProducerSpec: QuickSpec {
 
 						completeOuter()
 
-						expect(innerDisposable.disposed).to(beFalsy())
-						expect(interrupted).to(beFalsy())
+						expect(innerDisposable.disposed) == false
+						expect(interrupted) == false
 						disposeOuter()
 
-						expect(innerDisposable.disposed).to(beTruthy())
-						expect(interrupted).to(beTruthy())
+						expect(innerDisposable.disposed) == true
+						expect(interrupted) == true
 					}
 				}
 
@@ -1467,12 +1467,12 @@ class SignalProducerSpec: QuickSpec {
 					it("should cancel inner work when disposed before the outer producer completes") {
 						execute(.Latest)
 
-						expect(innerDisposable.disposed).to(beFalsy())
-						expect(interrupted).to(beFalsy())
+						expect(innerDisposable.disposed) == false
+						expect(interrupted) == false
 						disposeOuter()
 
-						expect(innerDisposable.disposed).to(beTruthy())
-						expect(interrupted).to(beTruthy())
+						expect(innerDisposable.disposed) == true
+						expect(interrupted) == true
 					}
 
 					it("should cancel inner work when disposed after the outer producer completes") {
@@ -1480,12 +1480,12 @@ class SignalProducerSpec: QuickSpec {
 
 						completeOuter()
 
-						expect(innerDisposable.disposed).to(beFalsy())
-						expect(interrupted).to(beFalsy())
+						expect(innerDisposable.disposed) == false
+						expect(interrupted) == false
 						disposeOuter()
 
-						expect(innerDisposable.disposed).to(beTruthy())
-						expect(interrupted).to(beTruthy())
+						expect(innerDisposable.disposed) == true
+						expect(interrupted) == true
 					}
 				}
 
@@ -1493,12 +1493,12 @@ class SignalProducerSpec: QuickSpec {
 					it("should cancel inner work when disposed before the outer producer completes") {
 						execute(.Merge)
 
-						expect(innerDisposable.disposed).to(beFalsy())
-						expect(interrupted).to(beFalsy())
+						expect(innerDisposable.disposed) == false
+						expect(interrupted) == false
 						disposeOuter()
 
-						expect(innerDisposable.disposed).to(beTruthy())
-						expect(interrupted).to(beTruthy())
+						expect(innerDisposable.disposed) == true
+						expect(interrupted) == true
 					}
 
 					it("should cancel inner work when disposed after the outer producer completes") {
@@ -1506,12 +1506,12 @@ class SignalProducerSpec: QuickSpec {
 
 						completeOuter()
 
-						expect(innerDisposable.disposed).to(beFalsy())
-						expect(interrupted).to(beFalsy())
+						expect(innerDisposable.disposed) == false
+						expect(interrupted) == false
 						disposeOuter()
 
-						expect(innerDisposable.disposed).to(beTruthy())
-						expect(interrupted).to(beTruthy())
+						expect(innerDisposable.disposed) == true
+						expect(interrupted) == true
 					}
 				}
 			}
@@ -1570,9 +1570,9 @@ class SignalProducerSpec: QuickSpec {
 				} else {
 					// Can't test for equality because Array<T> is not Equatable,
 					// and neither is Event<Value, Error>.
-					expect(result![0] == expectedEvents[0]).to(beTruthy())
-					expect(result![1] == expectedEvents[1]).to(beTruthy())
-					expect(result![2] == expectedEvents[2]).to(beTruthy())
+					expect(result![0] == expectedEvents[0]) == true
+					expect(result![1] == expectedEvents[1]) == true
+					expect(result![2] == expectedEvents[2]) == true
 				}
 			}
 
@@ -1642,10 +1642,10 @@ class SignalProducerSpec: QuickSpec {
 
 				let producer = original.then(subsequent)
 				producer.start()
-				expect(subsequentStarted).to(beFalsy())
+				expect(subsequentStarted) == false
 
 				observer.sendCompleted()
-				expect(subsequentStarted).to(beTruthy())
+				expect(subsequentStarted) == true
 			}
 
 			it("should forward errors from the original producer") {
@@ -1676,10 +1676,10 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				originalObserver.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 
 				subsequentObserver.sendCompleted()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -1826,10 +1826,10 @@ class SignalProducerSpec: QuickSpec {
 						downstreamDisposable = innerDisposable
 					}
 				
-				expect(upstreamDisposable.disposed).to(beFalsy())
+				expect(upstreamDisposable.disposed) == false
 				
 				downstreamDisposable.dispose()
-				expect(upstreamDisposable.disposed).to(beTruthy())
+				expect(upstreamDisposable.disposed) == true
 			}
 		}
 
@@ -1858,7 +1858,7 @@ class SignalProducerSpec: QuickSpec {
 				let result = producer1.concat(producer2).take(1).collect().first()
 
 				expect(result?.value).to(equal([1]))
-				expect(started).to(beFalsy())
+				expect(started) == false
 			}
 		}
 	}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -27,7 +27,7 @@ class SignalProducerSpec: QuickSpec {
 				signalProducer.start()
 				signalProducer.start()
 
-				expect(handlerCalledTimes).to(equal(2))
+				expect(handlerCalledTimes) == 2
 			}
 
 			it("should release signal observers when given disposable is disposed") {
@@ -268,18 +268,18 @@ class SignalProducerSpec: QuickSpec {
 					}
 				}
 
-				expect(values).to(equal([1, 2, 3]))
+				expect(values) == [1, 2, 3]
 				expect(completed) == false
 
 				observer.sendNext(4)
 				observer.sendNext(5)
 
-				expect(values).to(equal([1, 2, 3, 4, 5]))
+				expect(values) == [1, 2, 3, 4, 5]
 				expect(completed) == false
 
 				observer.sendCompleted()
 
-				expect(values).to(equal([1, 2, 3, 4, 5]))
+				expect(values) == [1, 2, 3, 4, 5]
 				expect(completed) == true
 			}
 
@@ -302,19 +302,19 @@ class SignalProducerSpec: QuickSpec {
 					}
 				}
 				
-				expect(values).to(equal([2]))
+				expect(values) == [2]
 				expect(error).to(beNil())
 
 				observer.sendNext(3)
 				observer.sendNext(4)
 
-				expect(values).to(equal([2, 3, 4]))
+				expect(values) == [2, 3, 4]
 				expect(error).to(beNil())
 
 				observer.sendFailed(.Default)
 
-				expect(values).to(equal([2, 3, 4]))
-				expect(error).to(equal(TestError.Default))
+				expect(values) == [2, 3, 4]
+				expect(error) == TestError.Default
 			}
 			
 			it("should always replay termination event") {
@@ -349,7 +349,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 				}
 				
-				expect(value).to(equal(123))
+				expect(value) == 123
 				expect(completed) == true
 			}
 
@@ -370,7 +370,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				observer.sendCompleted()
-				expect(values).to(equal([ 1, 2, 3 ]))
+				expect(values) == [ 1, 2, 3 ]
 			}
 
 			it("should buffer values before sending recursively to new observers") {
@@ -388,21 +388,21 @@ class SignalProducerSpec: QuickSpec {
 						bufferedValues.append(bufferedValue)
 					}
 
-					expect(bufferedValues).to(equal(values))
+					expect(bufferedValues) == values
 					lastBufferedValues = bufferedValues
 				}
 
 				observer.sendNext(1)
-				expect(values).to(equal([ 1 ]))
-				expect(lastBufferedValues).to(equal(values))
+				expect(values) == [ 1 ]
+				expect(lastBufferedValues) == values
 
 				observer.sendNext(2)
-				expect(values).to(equal([ 1, 2 ]))
-				expect(lastBufferedValues).to(equal(values))
+				expect(values) == [ 1, 2 ]
+				expect(lastBufferedValues) == values
 
 				observer.sendNext(3)
-				expect(values).to(equal([ 1, 2, 3 ]))
-				expect(lastBufferedValues).to(equal(values))
+				expect(values) == [ 1, 2, 3 ]
+				expect(lastBufferedValues) == values
 			}
 		}
 
@@ -416,7 +416,7 @@ class SignalProducerSpec: QuickSpec {
 					values.append(next)
 				}
 
-				expect(values).to(equal([1]))
+				expect(values) == [1]
 			}
 		}
 
@@ -432,7 +432,7 @@ class SignalProducerSpec: QuickSpec {
 				SignalProducer.attempt(operation).start()
 				SignalProducer.attempt(operation).start()
 
-				expect(operationRunTimes).to(equal(2))
+				expect(operationRunTimes) == 2
 			}
 
 			it("should send the value then complete") {
@@ -475,7 +475,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 
 				expect(started) == true
-				expect(value).to(equal(42))
+				expect(value) == 42
 			}
 
 			it("should dispose of added disposables if disposed") {
@@ -623,7 +623,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 				}
 
-				expect(values).to(equal([1, 2]))
+				expect(values) == [1, 2]
 				expect(completed) == true
 			}
 
@@ -673,7 +673,7 @@ class SignalProducerSpec: QuickSpec {
 
 					observer.sendCompleted()
 
-					expect(values).to(equal([1, 2, 3]))
+					expect(values) == [1, 2, 3]
 				}
 			}
 		}
@@ -690,13 +690,13 @@ class SignalProducerSpec: QuickSpec {
 					}
 
 					let producer = baseProducer.lift(transform)
-					expect(counter).to(equal(0))
+					expect(counter) == 0
 
 					producer.start()
-					expect(counter).to(equal(1))
+					expect(counter) == 1
 
 					producer.start()
-					expect(counter).to(equal(2))
+					expect(counter) == 2
 				}
 
 				it("should not miss any events") {
@@ -707,7 +707,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 					let result = producer.collect().single()
 
-					expect(result?.value).to(equal([1, 4, 9, 16]))
+					expect(result?.value) == [1, 4, 9, 16]
 				}
 			}
 
@@ -725,13 +725,13 @@ class SignalProducerSpec: QuickSpec {
 					}
 
 					let producer = baseProducer.lift(transform)(otherProducer)
-					expect(counter).to(equal(0))
+					expect(counter) == 0
 
 					producer.start()
-					expect(counter).to(equal(1))
+					expect(counter) == 1
 
 					producer.start()
-					expect(counter).to(equal(2))
+					expect(counter) == 2
 				}
 
 				it("should not miss any events") {
@@ -747,7 +747,7 @@ class SignalProducerSpec: QuickSpec {
 					let producer = baseProducer.lift(transform)(otherProducer)
 					let result = producer.collect().single()
 
-					expect(result?.value).to(equal([5, 7, 9]))
+					expect(result?.value) == [5, 7, 9]
 				}
 			}
 
@@ -765,7 +765,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 
 					let producer = baseProducer.lift(transform)(otherSignal)
-					expect(counter).to(equal(0))
+					expect(counter) == 0
 
 					producer.start()
 					otherSignalObserver.sendNext(1)
@@ -824,14 +824,14 @@ class SignalProducerSpec: QuickSpec {
 				let producer = combineLatest([producerA, producerB])
 				let result = producer.collect().single()
 				
-				expect(result?.value).to(equal([[1, 4], [2, 4]]))
+				expect(result?.value) == [[1, 4], [2, 4]]
 			}
 			
 			it("should zip the events to one array") {
 				let producer = zip([producerA, producerB])
 				let result = producer.collect().single()
 				
-				expect(result?.value).to(equal([[1, 3], [2, 4]]))
+				expect(result?.value) == [[1, 3], [2, 4]]
 			}
 		}
 
@@ -844,21 +844,21 @@ class SignalProducerSpec: QuickSpec {
 				producer.startWithNext { dates.append($0) }
 
 				scheduler.advanceByInterval(0.9)
-				expect(dates).to(equal([]))
+				expect(dates) == []
 
 				scheduler.advanceByInterval(1)
 				let firstTick = scheduler.currentDate
-				expect(dates).to(equal([firstTick]))
+				expect(dates) == [firstTick]
 
 				scheduler.advance()
-				expect(dates).to(equal([firstTick]))
+				expect(dates) == [firstTick]
 
 				scheduler.advanceByInterval(0.2)
 				let secondTick = scheduler.currentDate
-				expect(dates).to(equal([firstTick, secondTick]))
+				expect(dates) == [firstTick, secondTick]
 
 				scheduler.advanceByInterval(1)
-				expect(dates).to(equal([firstTick, secondTick, scheduler.currentDate]))
+				expect(dates) == [firstTick, secondTick, scheduler.currentDate]
 			}
 
 			it("should release the signal when disposed") {
@@ -904,19 +904,19 @@ class SignalProducerSpec: QuickSpec {
 					})
 
 				producer.start()
-				expect(started).to(equal(1))
+				expect(started) == 1
 
 				producer.start()
-				expect(started).to(equal(2))
+				expect(started) == 2
 
 				observer.sendNext(1)
-				expect(event).to(equal(2))
-				expect(next).to(equal(2))
+				expect(event) == 2
+				expect(next) == 2
 
 				observer.sendCompleted()
-				expect(event).to(equal(4))
-				expect(completed).to(equal(2))
-				expect(terminated).to(equal(2))
+				expect(event) == 4
+				expect(completed) == 2
+				expect(terminated) == 2
 			}
 
 			it("should attach event handlers for disposal") {
@@ -967,7 +967,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(next).to(beNil())
 
 				testScheduler.advanceByInterval(1)
-				expect(next).to(equal(testScheduler.currentDate))
+				expect(next) == testScheduler.currentDate
 			}
 		}
 
@@ -982,8 +982,8 @@ class SignalProducerSpec: QuickSpec {
 
 				baseProducer
 					.flatMapError { (error: TestError) -> SignalProducer<Int, TestError> in
-						expect(error).to(equal(TestError.Default))
-						expect(values).to(equal([1]))
+						expect(error) == TestError.Default
+						expect(values) == [1]
 
 						let (innerProducer, innerObserver) = SignalProducer<Int, TestError>.buffer()
 						innerObserver.sendNext(2)
@@ -1001,7 +1001,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 					}
 
-				expect(values).to(equal([1, 2]))
+				expect(values) == [1, 2]
 				expect(completed) == true
 			}
 
@@ -1086,7 +1086,7 @@ class SignalProducerSpec: QuickSpec {
 						error = e
 					}
 
-					expect(error).to(equal(TestError.Default))
+					expect(error) == TestError.Default
 				}
 
 				it("should forward an error from the outer producer") {
@@ -1098,7 +1098,7 @@ class SignalProducerSpec: QuickSpec {
 					}
 
 					outerObserver.sendFailed(TestError.Default)
-					expect(error).to(equal(TestError.Default))
+					expect(error) == TestError.Default
 				}
 
 				describe("completion") {
@@ -1188,7 +1188,7 @@ class SignalProducerSpec: QuickSpec {
 						sendB()
 						sendA()
 						sendB()
-						expect(recv).to(equal([0, 1, 100, 2, 101]))
+						expect(recv) == [0, 1, 100, 2, 101]
 					}
 
 					it("should complete when all signals have completed") {
@@ -1208,7 +1208,7 @@ class SignalProducerSpec: QuickSpec {
 						outerProducer.flatten(.Merge).startWithFailed { e in
 							error = e
 						}
-						expect(error).to(equal(TestError.Default))
+						expect(error) == TestError.Default
 					}
 
 					it("should forward an error from the outer signal") {
@@ -1220,7 +1220,7 @@ class SignalProducerSpec: QuickSpec {
 						}
 
 						outerObserver.sendFailed(TestError.Default)
-						expect(error).to(equal(TestError.Default))
+						expect(error) == TestError.Default
 					}
 				}
 			}
@@ -1255,7 +1255,7 @@ class SignalProducerSpec: QuickSpec {
 					outerObserver.sendNext(secondInner)
 					outerObserver.sendCompleted()
 
-					expect(receivedValues).to(equal([ 0, 1, 2 ]))
+					expect(receivedValues) == [ 0, 1, 2 ]
 					expect(errored) == false
 					expect(completed) == false
 
@@ -1264,7 +1264,7 @@ class SignalProducerSpec: QuickSpec {
 					secondInnerObserver.sendNext(4)
 					secondInnerObserver.sendCompleted()
 
-					expect(receivedValues).to(equal([ 0, 1, 2, 4 ]))
+					expect(receivedValues) == [ 0, 1, 2, 4 ]
 					expect(errored) == false
 					expect(completed) == true
 				}
@@ -1274,14 +1274,14 @@ class SignalProducerSpec: QuickSpec {
 					let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(value: inner)
 
 					let result = outer.flatten(.Latest).first()
-					expect(result?.error).to(equal(TestError.Default))
+					expect(result?.error) == TestError.Default
 				}
 
 				it("should forward an error from the outer signal") {
 					let outer = SignalProducer<SignalProducer<Int, TestError>, TestError>(error: .Default)
 
 					let result = outer.flatten(.Latest).first()
-					expect(result?.error).to(equal(TestError.Default))
+					expect(result?.error) == TestError.Default
 				}
 
 				it("should complete when the original and latest signals have completed") {
@@ -1312,7 +1312,7 @@ class SignalProducerSpec: QuickSpec {
 						.flatMap(.Latest) { _ in SignalProducer(value: 10) }
 
 					let result = producer.take(1).last()
-					expect(result?.value).to(equal(10))
+					expect(result?.value) == 10
 				}
 			}
 
@@ -1523,7 +1523,7 @@ class SignalProducerSpec: QuickSpec {
 				let producer = original.times(3)
 
 				let result = producer.collect().single()
-				expect(result?.value).to(equal([ 1, 2, 3, 1, 2, 3, 1, 2, 3 ]))
+				expect(result?.value) == [ 1, 2, 3, 1, 2, 3, 1, 2, 3 ]
 			}
 
 			it("should produce an equivalent signal producer if count is 1") {
@@ -1531,7 +1531,7 @@ class SignalProducerSpec: QuickSpec {
 				let producer = original.times(1)
 
 				let result = producer.collect().single()
-				expect(result?.value).to(equal([ 1 ]))
+				expect(result?.value) == [ 1 ]
 			}
 
 			it("should produce an empty signal if count is 0") {
@@ -1581,7 +1581,7 @@ class SignalProducerSpec: QuickSpec {
 				let producer = original.times(Int.max)
 
 				let result = producer.take(1).single()
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 			}
 		}
 
@@ -1598,7 +1598,7 @@ class SignalProducerSpec: QuickSpec {
 
 				let result = producer.single()
 
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 			}
 
 			it("should forward errors that occur after all retries") {
@@ -1613,7 +1613,7 @@ class SignalProducerSpec: QuickSpec {
 
 				let result = producer.single()
 
-				expect(result?.error).to(equal(TestError.Error2))
+				expect(result?.error) == TestError.Error2
 			}
 
 			it("should not retry upon completion") {
@@ -1627,7 +1627,7 @@ class SignalProducerSpec: QuickSpec {
 				let producer = original.retry(2)
 
 				let result = producer.single()
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 			}
 		}
 
@@ -1653,7 +1653,7 @@ class SignalProducerSpec: QuickSpec {
 				let subsequent = SignalProducer<Int, TestError>.empty
 
 				let result = original.then(subsequent).first()
-				expect(result?.error).to(equal(TestError.Default))
+				expect(result?.error) == TestError.Default
 			}
 
 			it("should forward errors from the subsequent producer") {
@@ -1661,7 +1661,7 @@ class SignalProducerSpec: QuickSpec {
 				let subsequent = SignalProducer<Int, TestError>(error: .Default)
 
 				let result = original.then(subsequent).first()
-				expect(result?.error).to(equal(TestError.Default))
+				expect(result?.error) == TestError.Default
 			}
 
 			it("should complete when both inputs have completed") {
@@ -1697,7 +1697,7 @@ class SignalProducerSpec: QuickSpec {
 
 				observer.sendNext(1)
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 			}
 
 			it("should return a nil result if no values are sent before completion") {
@@ -1707,12 +1707,12 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should return the first value if more than one value is sent") {
 				let result = SignalProducer<Int, NoError>(values: [ 1, 2 ]).first()
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 			}
 
 			it("should return an error if one occurs before the first value") {
 				let result = SignalProducer<Int, TestError>(error: .Default).first()
-				expect(result?.error).to(equal(TestError.Default))
+				expect(result?.error) == TestError.Default
 			}
 		}
 
@@ -1733,7 +1733,7 @@ class SignalProducerSpec: QuickSpec {
 
 				observer.sendCompleted()
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
-				expect(result?.value).to(equal(1))
+				expect(result?.value) == 1
 			}
 
 			it("should return a nil result if no values are sent before completion") {
@@ -1748,7 +1748,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should return an error if one occurs") {
 				let result = SignalProducer<Int, TestError>(error: .Default).single()
-				expect(result?.error).to(equal(TestError.Default))
+				expect(result?.error) == TestError.Default
 			}
 		}
 
@@ -1770,7 +1770,7 @@ class SignalProducerSpec: QuickSpec {
 
 				observer.sendCompleted()
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
-				expect(result?.value).to(equal(2))
+				expect(result?.value) == 2
 			}
 
 			it("should return a nil result if no values are sent before completion") {
@@ -1780,12 +1780,12 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should return the last value if more than one value is sent") {
 				let result = SignalProducer<Int, NoError>(values: [ 1, 2 ]).last()
-				expect(result?.value).to(equal(2))
+				expect(result?.value) == 2
 			}
 
 			it("should return an error if one occurs") {
 				let result = SignalProducer<Int, TestError>(error: .Default).last()
-				expect(result?.error).to(equal(TestError.Default))
+				expect(result?.error) == TestError.Default
 			}
 		}
 
@@ -1808,7 +1808,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should return an error if one occurs") {
 				let result = SignalProducer<Int, TestError>(error: .Default).wait()
-				expect(result.error).to(equal(TestError.Default))
+				expect(result.error) == TestError.Default
 			}
 		}
 
@@ -1857,7 +1857,7 @@ class SignalProducerSpec: QuickSpec {
 
 				let result = producer1.concat(producer2).take(1).collect().first()
 
-				expect(result?.value).to(equal([1]))
+				expect(result?.value) == [1]
 				expect(started) == false
 			}
 		}

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -27,7 +27,7 @@ class SignalSpec: QuickSpec {
 					return nil
 				}
 				
-				expect(didRunGenerator).to(beTruthy())
+				expect(didRunGenerator) == true
 			}
 
 			it("should forward events to observers") {
@@ -57,12 +57,12 @@ class SignalSpec: QuickSpec {
 					}
 				}
 				
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				expect(fromSignal).to(beEmpty())
 				
 				testScheduler.run()
 				
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 				expect(fromSignal).to(equal(numbers))
 			}
 
@@ -80,13 +80,13 @@ class SignalSpec: QuickSpec {
 				
 				signal.observeFailed { _ in errored = true }
 				
-				expect(errored).to(beFalsy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(errored) == false
+				expect(disposable.disposed) == false
 				
 				testScheduler.run()
 				
-				expect(errored).to(beTruthy())
-				expect(disposable.disposed).to(beTruthy())
+				expect(errored) == true
+				expect(disposable.disposed) == true
 			}
 
 			it("should dispose of returned disposable upon completion") {
@@ -103,13 +103,13 @@ class SignalSpec: QuickSpec {
 				
 				signal.observeCompleted { completed = true }
 				
-				expect(completed).to(beFalsy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(completed) == false
+				expect(disposable.disposed) == false
 				
 				testScheduler.run()
 				
-				expect(completed).to(beTruthy())
-				expect(disposable.disposed).to(beTruthy())
+				expect(completed) == true
+				expect(disposable.disposed) == true
 			}
 
 			it("should dispose of returned disposable upon interrupted") {
@@ -127,13 +127,13 @@ class SignalSpec: QuickSpec {
 					interrupted = true
 				}
 
-				expect(interrupted).to(beFalsy())
-				expect(disposable.disposed).to(beFalsy())
+				expect(interrupted) == false
+				expect(disposable.disposed) == false
 
 				testScheduler.run()
 
-				expect(interrupted).to(beTruthy())
-				expect(disposable.disposed).to(beTruthy())
+				expect(interrupted) == true
+				expect(disposable.disposed) == true
 			}
 		}
 
@@ -156,7 +156,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				expect(fromSignal).to(beEmpty())
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				
 				observer.sendNext(1)
 				expect(fromSignal).to(equal([ 1 ]))
@@ -164,9 +164,9 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(2)
 				expect(fromSignal).to(equal([ 1, 2 ]))
 				
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				observer.sendCompleted()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			context("memory") {
@@ -210,12 +210,12 @@ class SignalSpec: QuickSpec {
 					fromSignal.append(number)
 				}
 				
-				expect(disposable.disposed).to(beFalsy())
+				expect(disposable.disposed) == false
 				expect(fromSignal).to(beEmpty())
 				
 				testScheduler.run()
 				
-				expect(disposable.disposed).to(beTruthy())
+				expect(disposable.disposed) == true
 				expect(fromSignal).to(equal([ 1, 2 ]))
 			}
 
@@ -750,9 +750,9 @@ class SignalSpec: QuickSpec {
 				signal = signal.take(numbers.count)
 				signal.observeCompleted { completed = true }
 				
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				testScheduler.run()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should interrupt when 0") {
@@ -784,7 +784,7 @@ class SignalSpec: QuickSpec {
 					}
 				}
 
-				expect(interrupted).to(beTruthy())
+				expect(interrupted) == true
 
 				testScheduler.run()
 				expect(result).to(beEmpty())
@@ -1082,11 +1082,11 @@ class SignalSpec: QuickSpec {
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
 				expect(result).to(equal([ 1 ]))
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
 				expect(result).to(equal([ 1, 2 ]))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 
 			it("should schedule errors immediately") {
@@ -1105,7 +1105,7 @@ class SignalSpec: QuickSpec {
 					.observeFailed { _ in errored = true }
 				
 				testScheduler.advance()
-				expect(errored).to(beTruthy())
+				expect(errored) == true
 			}
 		}
 
@@ -1184,11 +1184,11 @@ class SignalSpec: QuickSpec {
 
 				observer.sendNext(1)
 				observer.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 
 				scheduler.run()
 				expect(values).to(equal([ 0 ]))
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -1238,10 +1238,10 @@ class SignalSpec: QuickSpec {
 				sampledSignal.observeCompleted { completed = true }
 				
 				observer.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				
 				samplerObserver.sendCompleted()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -1280,10 +1280,10 @@ class SignalSpec: QuickSpec {
 				combinedSignal.observeCompleted { completed = true }
 				
 				observer.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				
 				otherObserver.sendCompleted()
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -1341,15 +1341,15 @@ class SignalSpec: QuickSpec {
 					}
 				}
 
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 
 				leftObserver.sendNext(0)
 				leftObserver.sendCompleted()
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				expect(result).to(equal([]))
 
 				rightObserver.sendNext("foo")
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 				expect(result).to(equal([ "0foo" ]))
 			}
 		}
@@ -1414,19 +1414,19 @@ class SignalSpec: QuickSpec {
 				var errored = false
 				dematerialized.observeFailed { _ in errored = true }
 				
-				expect(errored).to(beFalsy())
+				expect(errored) == false
 				
 				observer.sendNext(.Failed(TestError.Default))
-				expect(errored).to(beTruthy())
+				expect(errored) == true
 			}
 
 			it("should complete early for Completed events") {
 				var completed = false
 				dematerialized.observeCompleted { completed = true }
 				
-				expect(completed).to(beFalsy())
+				expect(completed) == false
 				observer.sendNext(IntEvent.Completed)
-				expect(completed).to(beTruthy())
+				expect(completed) == true
 			}
 		}
 
@@ -1481,10 +1481,10 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(1)
 				observer.sendNext(2)
 				observer.sendNext(3)
-				expect(errored).to(beFalsy())
+				expect(errored) == false
 				
 				observer.sendFailed(TestError.Default)
-				expect(errored).to(beTruthy())
+				expect(errored) == true
 				expect(result).to(beEmpty())
 			}
 		}
@@ -1519,12 +1519,12 @@ class SignalSpec: QuickSpec {
 					observer.sendCompleted()
 				}
 
-				expect(completed).to(beFalsy())
-				expect(errored).to(beFalsy())
+				expect(completed) == false
+				expect(errored) == false
 
 				testScheduler.run()
-				expect(completed).to(beTruthy())
-				expect(errored).to(beFalsy())
+				expect(completed) == true
+				expect(errored) == false
 			}
 
 			it("should error if not completed before the interval has elapsed") {
@@ -1545,12 +1545,12 @@ class SignalSpec: QuickSpec {
 					observer.sendCompleted()
 				}
 
-				expect(completed).to(beFalsy())
-				expect(errored).to(beFalsy())
+				expect(completed) == false
+				expect(errored) == false
 
 				testScheduler.run()
-				expect(completed).to(beFalsy())
-				expect(errored).to(beTruthy())
+				expect(completed) == false
+				expect(errored) == true
 			}
 		}
 
@@ -1705,14 +1705,14 @@ class SignalSpec: QuickSpec {
 				}
 				
 				it("should complete when all inputs have completed"){
-					expect(completed).to(beFalsy())
+					expect(completed) == false
 					
 					observerA.sendCompleted()
 					observerB.sendCompleted()
-					expect(completed).to(beFalsy())
+					expect(completed) == false
 					
 					observerC.sendCompleted()
-					expect(completed).to(beTruthy())
+					expect(completed) == true
 				}
 			}
 			
@@ -1809,16 +1809,16 @@ class SignalSpec: QuickSpec {
 				}
 				
 				it("should complete when the shorter signal has completed"){
-					expect(completed).to(beFalsy())
+					expect(completed) == false
 					
 					observerB.sendNext(1)
 					observerC.sendNext(2)
 					observerB.sendCompleted()
 					observerC.sendCompleted()
-					expect(completed).to(beFalsy())
+					expect(completed) == false
 					
 					observerA.sendNext(0)
-					expect(completed).to(beTruthy())
+					expect(completed) == true
 				}
 			}
 			

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -491,9 +491,9 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(2)
 				expect(lastValue).to(beNil())
 
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				observer.sendCompleted()
-				expect(completed).to(beTrue())
+				expect(completed) == true
 
 				expect(lastValue).to(equal(4))
 			}
@@ -517,12 +517,12 @@ class SignalSpec: QuickSpec {
 				}
 
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendCompleted()
 
 				expect(lastValue).to(equal(1))
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 		}
 
@@ -721,15 +721,15 @@ class SignalSpec: QuickSpec {
 				}
 
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 			
 			it("should complete immediately after taking given number of values") {
@@ -880,9 +880,9 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				triggerObserver.sendNext(())
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 			
 			it("should take values until the trigger completes") {
@@ -894,18 +894,18 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(2)
 				expect(lastValue).to(equal(2))
 				
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				triggerObserver.sendCompleted()
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 
 			it("should complete if the trigger fires immediately") {
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				triggerObserver.sendNext(())
 
-				expect(completed).to(beTrue())
+				expect(completed) == true
 				expect(lastValue).to(beNil())
 			}
 		}
@@ -943,7 +943,7 @@ class SignalSpec: QuickSpec {
 
 			it("should take values from the original then the replacement") {
 				expect(lastValue).to(beNil())
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(1)
 				expect(lastValue).to(equal(1))
@@ -954,19 +954,19 @@ class SignalSpec: QuickSpec {
 				replacementObserver.sendNext(3)
 
 				expect(lastValue).to(equal(3))
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				observer.sendNext(4)
 
 				expect(lastValue).to(equal(3))
-				expect(completed).to(beFalse())
+				expect(completed) == false
 
 				replacementObserver.sendNext(5)
 				expect(lastValue).to(equal(5))
 
-				expect(completed).to(beFalse())
+				expect(completed) == false
 				replacementObserver.sendCompleted()
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 		}
 
@@ -998,12 +998,12 @@ class SignalSpec: QuickSpec {
 				for value in -1...4 {
 					observer.sendNext(value)
 					expect(latestValue).to(equal(value))
-					expect(completed).to(beFalse())
+					expect(completed) == false
 				}
 
 				observer.sendNext(5)
 				expect(latestValue).to(equal(4))
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 
 			it("should complete if the predicate starts false") {
@@ -1023,7 +1023,7 @@ class SignalSpec: QuickSpec {
 
 				observer.sendNext(5)
 				expect(latestValue).to(beNil())
-				expect(completed).to(beTrue())
+				expect(completed) == true
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -63,7 +63,7 @@ class SignalSpec: QuickSpec {
 				testScheduler.run()
 				
 				expect(completed) == true
-				expect(fromSignal).to(equal(numbers))
+				expect(fromSignal) == numbers
 			}
 
 			it("should dispose of returned disposable upon error") {
@@ -159,10 +159,10 @@ class SignalSpec: QuickSpec {
 				expect(completed) == false
 				
 				observer.sendNext(1)
-				expect(fromSignal).to(equal([ 1 ]))
+				expect(fromSignal) == [ 1 ]
 				
 				observer.sendNext(2)
-				expect(fromSignal).to(equal([ 1, 2 ]))
+				expect(fromSignal) == [ 1, 2 ]
 				
 				expect(completed) == false
 				observer.sendCompleted()
@@ -216,7 +216,7 @@ class SignalSpec: QuickSpec {
 				testScheduler.run()
 				
 				expect(disposable.disposed) == true
-				expect(fromSignal).to(equal([ 1, 2 ]))
+				expect(fromSignal) == [ 1, 2 ]
 			}
 
 			it("should not trigger side effects") {
@@ -226,10 +226,10 @@ class SignalSpec: QuickSpec {
 					return nil
 				}
 				
-				expect(runCount).to(equal(1))
+				expect(runCount) == 1
 				
 				signal.observe(Observer<(), NoError>())
-				expect(runCount).to(equal(1))
+				expect(runCount) == 1
 			}
 
 			it("should release observer after termination") {
@@ -246,9 +246,9 @@ class SignalSpec: QuickSpec {
 				test()
 
 				observer.sendNext(1)
-				expect(testStr).to(equal("1"))
+				expect(testStr) == "1"
 				observer.sendNext(2)
-				expect(testStr).to(equal("12"))
+				expect(testStr) == "12"
 
 				observer.sendCompleted()
 				expect(testStr).to(beNil())
@@ -270,10 +270,10 @@ class SignalSpec: QuickSpec {
 				test()
 
 				observer.sendNext(1)
-				expect(testStr).to(equal("1"))
+				expect(testStr) == "1"
 
 				observer.sendNext(2)
-				expect(testStr).to(equal("12"))
+				expect(testStr) == "12"
 
 				observer.sendInterrupted()
 				expect(testStr).to(beNil())
@@ -290,7 +290,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				observer.sendNext(1)
-				expect(values).to(equal([1]))
+				expect(values) == [1]
 			}
 		}
 
@@ -309,10 +309,10 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(0)
-				expect(lastValue).to(equal("1"))
+				expect(lastValue) == "1"
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal("2"))
+				expect(lastValue) == "2"
 			}
 		}
 		
@@ -330,7 +330,7 @@ class SignalSpec: QuickSpec {
 				expect(error).to(beNil())
 
 				observer.sendFailed(TestError.Default)
-				expect(error).to(equal(producerError))
+				expect(error) == producerError
 			}
 		}
 
@@ -346,13 +346,13 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 		}
 
@@ -435,13 +435,13 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(nil)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 		}
 
@@ -457,10 +457,10 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext("a")
-				expect(lastValue).to(equal("a"))
+				expect(lastValue) == "a"
 
 				observer.sendNext("bb")
-				expect(lastValue).to(equal("abb"))
+				expect(lastValue) == "abb"
 			}
 		}
 
@@ -495,7 +495,7 @@ class SignalSpec: QuickSpec {
 				observer.sendCompleted()
 				expect(completed) == true
 
-				expect(lastValue).to(equal(4))
+				expect(lastValue) == 4
 			}
 
 			it("should send the initial value if none are received") {
@@ -521,7 +521,7 @@ class SignalSpec: QuickSpec {
 
 				observer.sendCompleted()
 
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 				expect(completed) == true
 			}
 		}
@@ -540,7 +540,7 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 
 			it("should not skip any values when 0") {
@@ -553,10 +553,10 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 			}
 		}
 
@@ -568,19 +568,19 @@ class SignalSpec: QuickSpec {
 				var values: [Bool] = []
 				signal.observeNext { values.append($0) }
 
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				observer.sendNext(true)
-				expect(values).to(equal([ true ]))
+				expect(values) == [ true ]
 
 				observer.sendNext(true)
-				expect(values).to(equal([ true ]))
+				expect(values) == [ true ]
 
 				observer.sendNext(false)
-				expect(values).to(equal([ true, false ]))
+				expect(values) == [ true, false ]
 
 				observer.sendNext(true)
-				expect(values).to(equal([ true, false, true ]))
+				expect(values) == [ true, false, true ]
 			}
 
 			it("should skip values according to a predicate") {
@@ -590,19 +590,19 @@ class SignalSpec: QuickSpec {
 				var values: [String] = []
 				signal.observeNext { values.append($0) }
 
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				observer.sendNext("a")
-				expect(values).to(equal([ "a" ]))
+				expect(values) == [ "a" ]
 
 				observer.sendNext("b")
-				expect(values).to(equal([ "a" ]))
+				expect(values) == [ "a" ]
 
 				observer.sendNext("cc")
-				expect(values).to(equal([ "a", "cc" ]))
+				expect(values) == [ "a", "cc" ]
 
 				observer.sendNext("d")
-				expect(values).to(equal([ "a", "cc", "d" ]))
+				expect(values) == [ "a", "cc", "d" ]
 			}
 		}
 
@@ -629,20 +629,20 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 			}
 
 			it("should not skip any values when the predicate starts false") {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(3)
-				expect(lastValue).to(equal(3))
+				expect(lastValue) == 3
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 			}
 		}
 		
@@ -684,7 +684,7 @@ class SignalSpec: QuickSpec {
 
 				triggerObserver.sendNext(())
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 			}
 			
 			it("should skip values until the trigger completes") {
@@ -698,7 +698,7 @@ class SignalSpec: QuickSpec {
 				
 				triggerObserver.sendCompleted()
 				observer.sendNext(0)
-				expect(lastValue).to(equal(0))
+				expect(lastValue) == 0
 			}
 		}
 
@@ -724,11 +724,11 @@ class SignalSpec: QuickSpec {
 				expect(completed) == false
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 				expect(completed) == false
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 				expect(completed) == true
 			}
 			
@@ -810,7 +810,7 @@ class SignalSpec: QuickSpec {
 
 				expect(result).to(beNil())
 				observer.sendCompleted()
-				expect(result).to(equal(expectedResult))
+				expect(result) == expectedResult
 			}
 
 			it("should complete with an empty array if there are no values") {
@@ -823,7 +823,7 @@ class SignalSpec: QuickSpec {
 
 				expect(result).to(beNil())
 				observer.sendCompleted()
-				expect(result).to(equal([]))
+				expect(result) == []
 			}
 
 			it("should forward errors") {
@@ -836,7 +836,7 @@ class SignalSpec: QuickSpec {
 
 				expect(error).to(beNil())
 				observer.sendFailed(.Default)
-				expect(error).to(equal(TestError.Default))
+				expect(error) == TestError.Default
 			}
 		}
 
@@ -875,10 +875,10 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 
 				expect(completed) == false
 				triggerObserver.sendNext(())
@@ -889,10 +889,10 @@ class SignalSpec: QuickSpec {
 				expect(lastValue).to(beNil())
 				
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 				
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 				
 				expect(completed) == false
 				triggerObserver.sendCompleted()
@@ -946,23 +946,23 @@ class SignalSpec: QuickSpec {
 				expect(completed) == false
 
 				observer.sendNext(1)
-				expect(lastValue).to(equal(1))
+				expect(lastValue) == 1
 
 				observer.sendNext(2)
-				expect(lastValue).to(equal(2))
+				expect(lastValue) == 2
 
 				replacementObserver.sendNext(3)
 
-				expect(lastValue).to(equal(3))
+				expect(lastValue) == 3
 				expect(completed) == false
 
 				observer.sendNext(4)
 
-				expect(lastValue).to(equal(3))
+				expect(lastValue) == 3
 				expect(completed) == false
 
 				replacementObserver.sendNext(5)
-				expect(lastValue).to(equal(5))
+				expect(lastValue) == 5
 
 				expect(completed) == false
 				replacementObserver.sendCompleted()
@@ -997,12 +997,12 @@ class SignalSpec: QuickSpec {
 
 				for value in -1...4 {
 					observer.sendNext(value)
-					expect(latestValue).to(equal(value))
+					expect(latestValue) == value
 					expect(completed) == false
 				}
 
 				observer.sendNext(5)
-				expect(latestValue).to(equal(4))
+				expect(latestValue) == 4
 				expect(completed) == true
 			}
 
@@ -1043,7 +1043,7 @@ class SignalSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				testScheduler.run()
-				expect(result).to(equal([ 1, 2 ]))
+				expect(result) == [ 1, 2 ]
 			}
 		}
 
@@ -1081,11 +1081,11 @@ class SignalSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
-				expect(result).to(equal([ 1 ]))
+				expect(result) == [ 1 ]
 				expect(completed) == false
 				
 				testScheduler.advanceByInterval(10) // send second value and receive first
-				expect(result).to(equal([ 1, 2 ]))
+				expect(result) == [ 1, 2 ]
 				expect(completed) == true
 			}
 
@@ -1130,37 +1130,37 @@ class SignalSpec: QuickSpec {
 					values.append(value)
 				}
 
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				observer.sendNext(0)
-				expect(values).to(equal([]))
+				expect(values) == []
 
 				scheduler.advance()
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				observer.sendNext(1)
 				observer.sendNext(2)
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				scheduler.advanceByInterval(1.5)
-				expect(values).to(equal([ 0, 2 ]))
+				expect(values) == [ 0, 2 ]
 
 				scheduler.advanceByInterval(3)
-				expect(values).to(equal([ 0, 2 ]))
+				expect(values) == [ 0, 2 ]
 
 				observer.sendNext(3)
-				expect(values).to(equal([ 0, 2 ]))
+				expect(values) == [ 0, 2 ]
 
 				scheduler.advance()
-				expect(values).to(equal([ 0, 2, 3 ]))
+				expect(values) == [ 0, 2, 3 ]
 
 				observer.sendNext(4)
 				observer.sendNext(5)
 				scheduler.advance()
-				expect(values).to(equal([ 0, 2, 3 ]))
+				expect(values) == [ 0, 2, 3 ]
 
 				scheduler.run()
-				expect(values).to(equal([ 0, 2, 3, 5 ]))
+				expect(values) == [ 0, 2, 3, 5 ]
 			}
 
 			it("should schedule completion immediately") {
@@ -1180,14 +1180,14 @@ class SignalSpec: QuickSpec {
 
 				observer.sendNext(0)
 				scheduler.advance()
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 
 				observer.sendNext(1)
 				observer.sendCompleted()
 				expect(completed) == false
 
 				scheduler.run()
-				expect(values).to(equal([ 0 ]))
+				expect(values) == [ 0 ]
 				expect(completed) == true
 			}
 		}
@@ -1212,7 +1212,7 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(1)
 				observer.sendNext(2)
 				samplerObserver.sendNext(())
-				expect(result).to(equal([ 2 ]))
+				expect(result) == [ 2 ]
 			}
 			
 			it("should do nothing if sampler fires before signal receives value") {
@@ -1230,7 +1230,7 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(1)
 				samplerObserver.sendNext(())
 				samplerObserver.sendNext(())
-				expect(result).to(equal([ 1, 1 ]))
+				expect(result) == [ 1, 1 ]
 			}
 
 			it("should complete when both inputs have completed") {
@@ -1267,12 +1267,12 @@ class SignalSpec: QuickSpec {
 				
 				// is there a better way to test tuples?
 				otherObserver.sendNext(1.5)
-				expect(latest?.0).to(equal(1))
-				expect(latest?.1).to(equal(1.5))
+				expect(latest?.0) == 1
+				expect(latest?.1) == 1.5
 				
 				observer.sendNext(2)
-				expect(latest?.0).to(equal(2))
-				expect(latest?.1).to(equal(1.5))
+				expect(latest?.0) == 2
+				expect(latest?.1) == 1.5
 			}
 
 			it("should complete when both inputs have completed") {
@@ -1307,23 +1307,23 @@ class SignalSpec: QuickSpec {
 
 				leftObserver.sendNext(1)
 				leftObserver.sendNext(2)
-				expect(result).to(equal([]))
+				expect(result) == []
 
 				rightObserver.sendNext("foo")
-				expect(result).to(equal([ "1foo" ]))
+				expect(result) == [ "1foo" ]
 
 				leftObserver.sendNext(3)
 				rightObserver.sendNext("bar")
-				expect(result).to(equal([ "1foo", "2bar" ]))
+				expect(result) == [ "1foo", "2bar" ]
 
 				rightObserver.sendNext("buzz")
-				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
+				expect(result) == [ "1foo", "2bar", "3buzz" ]
 
 				rightObserver.sendNext("fuzz")
-				expect(result).to(equal([ "1foo", "2bar", "3buzz" ]))
+				expect(result) == [ "1foo", "2bar", "3buzz" ]
 
 				leftObserver.sendNext(4)
-				expect(result).to(equal([ "1foo", "2bar", "3buzz", "4fuzz" ]))
+				expect(result) == [ "1foo", "2bar", "3buzz", "4fuzz" ]
 			}
 
 			it("should complete when the shorter signal has completed") {
@@ -1346,11 +1346,11 @@ class SignalSpec: QuickSpec {
 				leftObserver.sendNext(0)
 				leftObserver.sendCompleted()
 				expect(completed) == false
-				expect(result).to(equal([]))
+				expect(result) == []
 
 				rightObserver.sendNext("foo")
 				expect(completed) == true
-				expect(result).to(equal([ "0foo" ]))
+				expect(result) == [ "0foo" ]
 			}
 		}
 
@@ -1368,7 +1368,7 @@ class SignalSpec: QuickSpec {
 				if let latestEvent = latestEvent {
 					switch latestEvent {
 					case let .Next(value):
-						expect(value).to(equal(2))
+						expect(value) == 2
 					default:
 						fail()
 					}
@@ -1404,10 +1404,10 @@ class SignalSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				observer.sendNext(.Next(2))
-				expect(result).to(equal([ 2 ]))
+				expect(result) == [ 2 ]
 				
 				observer.sendNext(.Next(4))
-				expect(result).to(equal([ 2, 4 ]))
+				expect(result) == [ 2, 4 ]
 			}
 
 			it("should error out for Error events") {
@@ -1451,7 +1451,7 @@ class SignalSpec: QuickSpec {
 				expect(result).to(beEmpty())
 				
 				observer.sendCompleted()
-				expect(result).to(equal([ 2, 3, 4 ]))
+				expect(result) == [ 2, 3, 4 ]
 			}
 
 			it("should send less than N values if not enough were received") {
@@ -1461,7 +1461,7 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(1)
 				observer.sendNext(2)
 				observer.sendCompleted()
-				expect(result).to(equal([ 1, 2 ]))
+				expect(result) == [ 1, 2 ]
 			}
 			
 			it("should send nothing when errors") {
@@ -1568,7 +1568,7 @@ class SignalSpec: QuickSpec {
 				
 				for value in 1...5 {
 					observer.sendNext(value)
-					expect(current).to(equal(value))
+					expect(current) == value
 				}
 			}
 			
@@ -1584,7 +1584,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				observer.sendNext(42)
-				expect(error).to(equal(TestError.Default))
+				expect(error) == TestError.Default
 			}
 		}
 		
@@ -1601,10 +1601,10 @@ class SignalSpec: QuickSpec {
 				}
 				
 				observer.sendNext(1)
-				expect(even).to(equal(false))
+				expect(even) == false
 				
 				observer.sendNext(2)
-				expect(even).to(equal(true))
+				expect(even) == true
 			}
 			
 			it("should error if a mapping fails") {
@@ -1619,7 +1619,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				observer.sendNext(42)
-				expect(error).to(equal(TestError.Default))
+				expect(error) == TestError.Default
 			}
 		}
 		
@@ -1640,12 +1640,12 @@ class SignalSpec: QuickSpec {
 				expect(latestValues).to(beNil())
 				
 				observer.sendNext(1)
-				expect(latestValues?.0).to(equal(initialValue))
-				expect(latestValues?.1).to(equal(1))
+				expect(latestValues?.0) == initialValue
+				expect(latestValues?.1) == 1
 				
 				observer.sendNext(2)
-				expect(latestValues?.0).to(equal(1))
-				expect(latestValues?.1).to(equal(2))
+				expect(latestValues?.0) == 1
+				expect(latestValues?.1) == 2
 			}
 		}
 
@@ -1685,10 +1685,10 @@ class SignalSpec: QuickSpec {
 					observerA.sendNext(0)
 					observerB.sendNext(1)
 					observerC.sendNext(2)
-					expect(combinedValues).to(equal([0, 1, 2]))
+					expect(combinedValues) == [0, 1, 2]
 					
 					observerA.sendNext(10)
-					expect(combinedValues).to(equal([10, 1, 2]))
+					expect(combinedValues) == [10, 1, 2]
 				}
 				
 				it("should not forward the latest values before all inputs"){
@@ -1701,7 +1701,7 @@ class SignalSpec: QuickSpec {
 					expect(combinedValues).to(beNil())
 					
 					observerC.sendNext(2)
-					expect(combinedValues).to(equal([0, 1, 2]))
+					expect(combinedValues) == [0, 1, 2]
 				}
 				
 				it("should complete when all inputs have completed"){
@@ -1793,19 +1793,19 @@ class SignalSpec: QuickSpec {
 					expect(zippedValues).to(beNil())
 					
 					observerC.sendNext(2)
-					expect(zippedValues).to(equal([0, 1, 2]))
+					expect(zippedValues) == [0, 1, 2]
 					
 					observerA.sendNext(10)
-					expect(zippedValues).to(equal([0, 1, 2]))
+					expect(zippedValues) == [0, 1, 2]
 					
 					observerA.sendNext(20)
-					expect(zippedValues).to(equal([0, 1, 2]))
+					expect(zippedValues) == [0, 1, 2]
 					
 					observerB.sendNext(11)
-					expect(zippedValues).to(equal([0, 1, 2]))
+					expect(zippedValues) == [0, 1, 2]
 					
 					observerC.sendNext(12)
-					expect(zippedValues).to(equal([10, 11, 12]))
+					expect(zippedValues) == [10, 11, 12]
 				}
 				
 				it("should complete when the shorter signal has completed"){


### PR DESCRIPTION
As per the suggestions at https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2582#discussion_r47448849 and others.