### PR TITLE
Implement `PropertyType.signal`.

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -10,6 +10,9 @@ public protocol PropertyType {
 	/// A producer for Signals that will send the property's current value,
 	/// followed by all changes over time.
 	var producer: SignalProducer<Value, NoError> { get }
+
+	/// A signal that will send the property's changes over time.
+	var signal: Signal<Value, NoError> { get }
 }
 
 /// A read-only property that allows observation of its changes.
@@ -17,6 +20,8 @@ public struct AnyProperty<Value>: PropertyType {
 
 	private let _value: () -> Value
 	private let _producer: () -> SignalProducer<Value, NoError>
+	private let _signal: () -> Signal<Value, NoError>
+
 
 	public var value: Value {
 		return _value()
@@ -25,11 +30,16 @@ public struct AnyProperty<Value>: PropertyType {
 	public var producer: SignalProducer<Value, NoError> {
 		return _producer()
 	}
+
+	public var signal: Signal<Value, NoError> {
+		return _signal()
+	}
 	
 	/// Initializes a property as a read-only view of the given property.
 	public init<P: PropertyType where P.Value == Value>(_ property: P) {
 		_value = { property.value }
 		_producer = { property.producer }
+		_signal = { property.signal }
 	}
 	
 	/// Initializes a property that first takes on `initialValue`, then each value
@@ -54,11 +64,13 @@ public struct ConstantProperty<Value>: PropertyType {
 
 	public let value: Value
 	public let producer: SignalProducer<Value, NoError>
+	public let signal: Signal<Value, NoError>
 
 	/// Initializes the property to have the given value.
 	public init(_ value: Value) {
 		self.value = value
 		self.producer = SignalProducer(value: value)
+		self.signal = .empty
 	}
 }
 
@@ -80,7 +92,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// Need a recursive lock around `value` to allow recursive access to
 	/// `value`. Note that recursive sets will still deadlock because the
 	/// underlying producer prevents sending recursive events.
-	private let lock = NSRecursiveLock()
+	private let lock: NSRecursiveLock
 	private var _value: Value
 
 	/// The current value of the property.
@@ -97,6 +109,10 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		}
 	}
 
+	/// A signal that will send the property's changes over time,
+	/// then complete when the property has deinitialized.
+	public let signal: Signal<Value, NoError>
+
 	/// A producer for Signals that will send the property's current value,
 	/// followed by all changes over time, then complete when the property has
 	/// deinitialized.
@@ -104,11 +120,18 @@ public final class MutableProperty<Value>: MutablePropertyType {
 
 	/// Initializes the property with the given value to start.
 	public init(_ initialValue: Value) {
-		lock.name = "org.reactivecocoa.ReactiveCocoa.MutableProperty"
-
-		(producer, observer) = SignalProducer<Value, NoError>.buffer(1)
-
 		_value = initialValue
+
+		lock = NSRecursiveLock()
+		lock.name = "org.reactivecocoa.ReactiveCocoa.MutableProperty"
+		(producer, observer) = SignalProducer.buffer(1)
+
+		var extractedSignal: Signal<Value, NoError>?
+		producer.startWithSignal { signal, _ in
+			extractedSignal = signal
+		}
+		signal = extractedSignal!
+
 		observer.sendNext(initialValue)
 	}
 
@@ -160,6 +183,8 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	private weak var object: NSObject?
 	private let keyPath: String
 
+	private var _property: MutableProperty<AnyObject?>?
+
 	/// The current value of the property, as read and written using Key-Value
 	/// Coding.
 	public var value: AnyObject? {
@@ -179,16 +204,11 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// By definition, this only works if the object given to init() is
 	/// KVO-compliant. Most UI controls are not!
 	public var producer: SignalProducer<AnyObject?, NoError> {
-		if let object = object {
-			return object.rac_valuesForKeyPath(keyPath, observer: nil).toSignalProducer()
-				// Errors aren't possible, but the compiler doesn't know that.
-				.flatMapError { error in
-					0 // suppresses implicit return error on fatalError
-					fatalError("Received unexpected error from KVO signal: \(error)")
-				}
-		} else {
-			return .empty
-		}
+		return _property?.producer ?? .empty
+	}
+
+	public var signal: Signal<AnyObject?, NoError> {
+		return _property?.signal ?? .empty
 	}
 
 	/// Initializes a property that will observe and set the given key path of
@@ -196,11 +216,24 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	public init(object: NSObject?, keyPath: String) {
 		self.object = object
 		self.keyPath = keyPath
-		
+		self._property = MutableProperty(nil)
+
 		/// DynamicProperty stay alive as long as object is alive.
 		/// This is made possible by strong reference cycles.
 		super.init()
-		object?.rac_willDeallocSignal()?.toSignalProducer().startWithCompleted { self }
+
+		object?.rac_valuesForKeyPath(keyPath, observer: nil)?
+			.toSignalProducer()
+			.start {
+				switch $0 {
+				case let .Next(newValue):
+					self._property?.value = newValue
+				case let .Failed(error):
+					fatalError("Received unexpected error from KVO signal: \(error)")
+				case .Interrupted, .Completed:
+					self._property = nil
+				}
+			}
 	}
 }
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -87,6 +87,14 @@ public final class Signal<Value, Error: ErrorType> {
 		return self.init { _ in nil }
 	}
 
+	/// A Signal that completes immediately without emitting any value.
+	public static var empty: Signal {
+		return self.init { observer in
+			observer.sendCompleted()
+			return nil
+		}
+	}
+
 	/// Creates a Signal that will be controlled by sending events to the given
 	/// observer.
 	///

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -27,28 +27,20 @@ class PropertySpec: QuickSpec {
 			it("should yield a signal that interrupts observers without emitting any value.") {
 				let constantProperty = ConstantProperty(initialPropertyValue)
 
-				var sentValue: String?
-				var signalFailed = false
 				var signalInterrupted = false
-				var signalCompleted = false
+				var hasUnexpectedEventsEmitted = false
 
 				constantProperty.signal.observe { event in
 					switch event {
-					case let .Next(value):
-						sentValue = value
-					case .Failed(_):
-						signalFailed = true
 					case .Interrupted:
 						signalInterrupted = true
-					case .Completed:
-						signalCompleted = true
+					case .Next(_), .Failed(_), .Completed:
+						hasUnexpectedEventsEmitted = true
 					}
 				}
 
-				expect(sentValue).to(beNil())
 				expect(signalInterrupted) == true
-				expect(signalCompleted) == false
-				expect(signalFailed) == false
+				expect(hasUnexpectedEventsEmitted) == false
 			}
 
 			it("should yield a producer that sends the current value then completes") {

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -34,7 +34,7 @@ class PropertySpec: QuickSpec {
 					switch event {
 					case .Interrupted:
 						signalInterrupted = true
-					case .Next(_), .Failed(_), .Completed:
+					case .Next, .Failed, .Completed:
 						hasUnexpectedEventsEmitted = true
 					}
 				}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -467,7 +467,7 @@ class PropertySpec: QuickSpec {
 					expect(completed) == false
 					expect(property.value).notTo(beNil())
 					return property
-					}()
+				}()
 
 				expect(completed).toEventually(beTruthy())
 				expect(property.value).to(beNil())

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -137,6 +137,27 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("Signal.empty") {
+			it("should interrupt its observers without emitting any value") {
+				let signal = Signal<(), NoError>.empty
+
+				var hasUnexpectedEventsEmitted = false
+				var signalInterrupted = false
+
+				signal.observe { event in
+					switch event {
+					case .Next(_), .Failed(_), .Completed:
+						hasUnexpectedEventsEmitted = false
+					case .Interrupted:
+						signalInterrupted = true
+					}
+				}
+
+				expect(hasUnexpectedEventsEmitted) == false
+				expect(signalInterrupted) == true
+			}
+		}
+
 		describe("Signal.pipe") {
 			it("should forward events to observers") {
 				let (signal, observer) = Signal<Int, NoError>.pipe()

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -146,7 +146,7 @@ class SignalSpec: QuickSpec {
 
 				signal.observe { event in
 					switch event {
-					case .Next(_), .Failed(_), .Completed:
+					case .Next, .Failed, .Completed:
 						hasUnexpectedEventsEmitted = false
 					case .Interrupted:
 						signalInterrupted = true
@@ -1398,7 +1398,7 @@ class SignalSpec: QuickSpec {
 				observer.sendFailed(TestError.Default)
 				if let latestEvent = latestEvent {
 					switch latestEvent {
-					case .Failed(_):
+					case .Failed:
 						()
 					default:
 						fail()
@@ -1492,7 +1492,7 @@ class SignalSpec: QuickSpec {
 					switch event {
 					case let .Next(value):
 						result.append(value)
-					case .Failed(_):
+					case .Failed:
 						errored = true
 					default:
 						break
@@ -1529,7 +1529,7 @@ class SignalSpec: QuickSpec {
 					switch event {
 					case .Completed:
 						completed = true
-					case .Failed(_):
+					case .Failed:
 						errored = true
 					default:
 						break
@@ -1555,7 +1555,7 @@ class SignalSpec: QuickSpec {
 					switch event {
 					case .Completed:
 						completed = true
-					case .Failed(_):
+					case .Failed:
 						errored = true
 					default:
 						break


### PR DESCRIPTION
Fixes: #2543 

#### Signal.empty
It is a signal that completes immediately without emitting any value. Future observation to this signal would only result in an `Interrupted` event per the `Signal.observe` implementation.

#### ConstantProperty
`ConstantProperty.signal` is just a `Signal.empty`, since there is never a change anyway.

#### MutableProperty
`MutableProperty.signal` is a signal started from the buffering producer at the time the property is initialised.

#### DynamicProperty
`DynamicProperty.signal` and `DynamicProperty.producer` are backed by an underlying `MutableProperty`. The implementation is not thread-safe (as usual...?).
