### PR TITLE
Add no-argument form of combinePrevious(), where previous value is optional

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -990,6 +990,20 @@ extension SignalType {
 		}
 	}
 
+	/// Forwards events from `self` with history, if available: values of the
+	/// returned signal are a tuple whose second value is the current value, and
+	/// whose first member is optionally the previous value. The first time `self`
+	/// sends a value, the previous value will be `nil`.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func combinePrevious() -> Signal<(Value?, Value), Error> {
+		var previous: Value?
+		return map { next in
+			let combined = (previous, next)
+			previous = next
+			return combined
+		}
+	}
+
 	/// Like `scan`, but sends only the final value and then immediately completes.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func reduce<U>(initial: U, _ combine: (U, Value) -> U) -> Signal<U, Error> {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -597,6 +597,15 @@ extension SignalProducerType {
 		return lift { $0.combinePrevious(initial) }
 	}
 
+	/// Forwards events from `self` with history, if available: values of the
+	/// returned signal are a tuple whose second value is the current value, and
+	/// whose first member is optionally the previous value. The first time `self`
+	/// sends a value, the previous value will be `nil`.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func combinePrevious() -> SignalProducer<(Value?, Value), Error> {
+		return lift { $0.combinePrevious() }
+	}
+
 	/// Like `scan`, but sends only the final value and then immediately completes.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func reduce<U>(initial: U, _ combine: (U, Value) -> U) -> SignalProducer<U, Error> {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1716,6 +1716,30 @@ class SignalSpec: QuickSpec {
 				expect(latestValues?.0).to(equal(1))
 				expect(latestValues?.1).to(equal(2))
 			}
+
+			describe("with no intitial value") {
+				var latestValues: (Int?, Int)?
+
+				beforeEach {
+					latestValues = nil
+
+					let (signal, baseObserver) = Signal<Int, NoError>.pipe()
+					observer = baseObserver
+					signal.combinePrevious().observeNext { latestValues = $0 }
+				}
+
+				it("should forward a nil previous value first time") {
+					expect(latestValues).to(beNil())
+
+					observer.sendNext(1)
+					expect(latestValues?.0).to(beNil())
+					expect(latestValues?.1).to(equal(1))
+
+					observer.sendNext(2)
+					expect(latestValues?.0).to(equal(1))
+					expect(latestValues?.1).to(equal(2))
+				}
+			}
 		}
 
 		describe("combineLatest") {


### PR DESCRIPTION
I personally found this operator useful when filtering a stream, such that the first value should always be passed through, but subsequent values should be compared to previous values. For example:

```swift
producer.combinePrevious()
  .filter { previous, next in
    guard let previous = previous else { return true }
    return previous.value != next.value
  }
  .map { $1 }
```