### PR TITLE
Replace most Signal<T, E>.Observer typealias usages with plain Observer<T, E>

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -9,7 +9,7 @@ import Foundation
 /// times concurrently will return an error.
 public final class Action<Input, Output, Error: ErrorType> {
 	private let executeClosure: Input -> SignalProducer<Output, Error>
-	private let eventsObserver: Signal<Event<Output, Error>, NoError>.Observer
+	private let eventsObserver: Observer<Event<Output, Error>, NoError>
 
 	/// A signal of all events generated from applications of the Action.
 	///

--- a/ReactiveCocoa/Swift/Flatten.swift
+++ b/ReactiveCocoa/Swift/Flatten.swift
@@ -187,7 +187,7 @@ private final class ConcatState<Value, Error: ErrorType> {
 	/// The active producer, if any, and the producers waiting to be started.
 	let queuedSignalProducers: Atomic<[SignalProducer<Value, Error>]> = Atomic([])
 
-	init(observer: Signal<Value, Error>.Observer, disposable: CompositeDisposable?) {
+	init(observer: Observer<Value, Error>, disposable: CompositeDisposable?) {
 		self.observer = observer
 		self.disposable = disposable
 	}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -75,7 +75,7 @@ public protocol MutablePropertyType: class, PropertyType {
 /// Instances of this class are thread-safe.
 public final class MutableProperty<Value>: MutablePropertyType {
 
-	private let observer: Signal<Value, NoError>.Observer
+	private let observer: Observer<Value, NoError>
 
 	/// Need a recursive lock around `value` to allow recursive access to
 	/// `value`. Note that recursive sets will still deadlock because the

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -155,7 +155,7 @@ public protocol SignalType {
 	var signal: Signal<Value, Error> { get }
 
 	/// Observes the Signal by sending any future events to the given observer.
-	func observe(observer: Signal<Value, Error>.Observer) -> Disposable?
+	func observe(observer: Observer<Value, Error>) -> Disposable?
 }
 
 extension Signal: SignalType {
@@ -167,7 +167,7 @@ extension Signal: SignalType {
 extension SignalType {
 	/// Convenience override for observe(_:) to allow trailing-closure style
 	/// invocations.
-	public func observe(action: Signal<Value, Error>.Observer.Action) -> Disposable? {
+	public func observe(action: Observer<Value, Error>.Action) -> Disposable? {
 		return observe(Observer(action))
 	}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -261,7 +261,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("skipWhile") {
 			var producer: SignalProducer<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 
 			var lastValue: Int?
 
@@ -301,8 +301,8 @@ class SignalProducerLiftingSpec: QuickSpec {
 		
 		describe("skipUntil") {
 			var producer: SignalProducer<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var triggerObserver: Signal<(), NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var triggerObserver: Observer<(), NoError>!
 			
 			var lastValue: Int? = nil
 			
@@ -500,8 +500,8 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("takeUntil") {
 			var producer: SignalProducer<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var triggerObserver: Signal<(), NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var triggerObserver: Observer<(), NoError>!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
@@ -570,8 +570,8 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("takeUntilReplacement") {
 			var producer: SignalProducer<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var replacementObserver: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var replacementObserver: Observer<Int, NoError>!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
@@ -630,7 +630,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("takeWhile") {
 			var producer: SignalProducer<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 
 			beforeEach {
 				let (baseProducer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
@@ -770,7 +770,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("throttle") {
 			var scheduler: TestScheduler!
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 			var producer: SignalProducer<Int, NoError>!
 
 			beforeEach {
@@ -852,8 +852,8 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("sampleOn") {
 			var sampledProducer: SignalProducer<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var samplerObserver: Signal<(), NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var samplerObserver: Observer<(), NoError>!
 			
 			beforeEach {
 				let (producer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
@@ -917,8 +917,8 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("combineLatestWith") {
 			var combinedProducer: SignalProducer<(Int, Double), NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var otherObserver: Signal<Double, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var otherObserver: Observer<Double, NoError>!
 			
 			beforeEach {
 				let (producer, incomingObserver) = SignalProducer<Int, NoError>.buffer()
@@ -958,8 +958,8 @@ class SignalProducerLiftingSpec: QuickSpec {
 		}
 
 		describe("zipWith") {
-			var leftObserver: Signal<Int, NoError>.Observer!
-			var rightObserver: Signal<String, NoError>.Observer!
+			var leftObserver: Observer<Int, NoError>!
+			var rightObserver: Observer<String, NoError>!
 			var zipped: SignalProducer<(Int, String), NoError>!
 
 			beforeEach {
@@ -1058,7 +1058,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 		describe("dematerialize") {
 			typealias IntEvent = Event<Int, TestError>
-			var observer: Signal<IntEvent, NoError>.Observer!
+			var observer: Observer<IntEvent, NoError>!
 			var dematerialized: SignalProducer<Int, TestError>!
 			
 			beforeEach {
@@ -1101,7 +1101,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 		}
 
 		describe("takeLast") {
-			var observer: Signal<Int, TestError>.Observer!
+			var observer: Observer<Int, TestError>!
 			var lastThree: SignalProducer<Int, TestError>!
 				
 			beforeEach {
@@ -1162,7 +1162,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 		describe("timeoutWithError") {
 			var testScheduler: TestScheduler!
 			var producer: SignalProducer<Int, TestError>!
-			var observer: Signal<Int, TestError>.Observer!
+			var observer: Observer<Int, TestError>!
 
 			beforeEach {
 				testScheduler = TestScheduler()
@@ -1294,7 +1294,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 		}
 		
 		describe("combinePrevious") {
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 			let initialValue: Int = 0
 			var latestValues: (Int, Int)?
 			

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -58,7 +58,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should dispose of added disposables upon completion") {
 				let addedDisposable = SimpleDisposable()
-				var observer: Signal<(), NoError>.Observer!
+				var observer: Observer<(), NoError>!
 
 				let producer = SignalProducer<(), NoError>() { incomingObserver, disposable in
 					disposable.addDisposable(addedDisposable)
@@ -74,7 +74,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should dispose of added disposables upon error") {
 				let addedDisposable = SimpleDisposable()
-				var observer: Signal<(), TestError>.Observer!
+				var observer: Observer<(), TestError>!
 
 				let producer = SignalProducer<(), TestError>() { incomingObserver, disposable in
 					disposable.addDisposable(addedDisposable)
@@ -90,7 +90,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should dispose of added disposables upon interruption") {
 				let addedDisposable = SimpleDisposable()
-				var observer: Signal<(), NoError>.Observer!
+				var observer: Observer<(), NoError>!
 
 				let producer = SignalProducer<(), NoError>() { incomingObserver, disposable in
 					disposable.addDisposable(addedDisposable)
@@ -122,7 +122,7 @@ class SignalProducerSpec: QuickSpec {
 
 		describe("init(signal:)") {
 			var signal: Signal<Int, TestError>!
-			var observer: Signal<Int, TestError>.Observer!
+			var observer: Observer<Int, TestError>!
 
 			beforeEach {
 				// Cannot directly assign due to compiler crash on Xcode 7.0.1
@@ -575,7 +575,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should dispose of added disposables upon completion") {
 				let addedDisposable = SimpleDisposable()
-				var observer: Signal<Int, TestError>.Observer!
+				var observer: Observer<Int, TestError>!
 
 				let producer = SignalProducer<Int, TestError>() { incomingObserver, disposable in
 					disposable.addDisposable(addedDisposable)
@@ -591,7 +591,7 @@ class SignalProducerSpec: QuickSpec {
 
 			it("should dispose of added disposables upon error") {
 				let addedDisposable = SimpleDisposable()
-				var observer: Signal<Int, TestError>.Observer!
+				var observer: Observer<Int, TestError>!
 
 				let producer = SignalProducer<Int, TestError>() { incomingObserver, disposable in
 					disposable.addDisposable(addedDisposable)
@@ -1317,8 +1317,8 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			describe("interruption") {
-				var innerObserver: Signal<(), NoError>.Observer!
-				var outerObserver: Signal<SignalProducer<(), NoError>, NoError>.Observer!
+				var innerObserver: Observer<(), NoError>!
+				var outerObserver: Observer<SignalProducer<(), NoError>, NoError>!
 				var execute: (FlattenStrategy -> Void)!
 
 				var interrupted = false

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -608,7 +608,7 @@ class SignalSpec: QuickSpec {
 
 		describe("skipWhile") {
 			var signal: Signal<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 
 			var lastValue: Int?
 
@@ -648,8 +648,8 @@ class SignalSpec: QuickSpec {
 		
 		describe("skipUntil") {
 			var signal: Signal<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var triggerObserver: Signal<(), NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var triggerObserver: Observer<(), NoError>!
 			
 			var lastValue: Int? = nil
 			
@@ -842,8 +842,8 @@ class SignalSpec: QuickSpec {
 
 		describe("takeUntil") {
 			var signal: Signal<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var triggerObserver: Signal<(), NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var triggerObserver: Observer<(), NoError>!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
@@ -912,8 +912,8 @@ class SignalSpec: QuickSpec {
 
 		describe("takeUntilReplacement") {
 			var signal: Signal<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var replacementObserver: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var replacementObserver: Observer<Int, NoError>!
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
@@ -972,7 +972,7 @@ class SignalSpec: QuickSpec {
 
 		describe("takeWhile") {
 			var signal: Signal<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 
 			beforeEach {
 				let (baseSignal, incomingObserver) = Signal<Int, NoError>.pipe()
@@ -1111,7 +1111,7 @@ class SignalSpec: QuickSpec {
 
 		describe("throttle") {
 			var scheduler: TestScheduler!
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 			var signal: Signal<Int, NoError>!
 
 			beforeEach {
@@ -1194,8 +1194,8 @@ class SignalSpec: QuickSpec {
 
 		describe("sampleOn") {
 			var sampledSignal: Signal<Int, NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var samplerObserver: Signal<(), NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var samplerObserver: Observer<(), NoError>!
 			
 			beforeEach {
 				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
@@ -1247,8 +1247,8 @@ class SignalSpec: QuickSpec {
 
 		describe("combineLatestWith") {
 			var combinedSignal: Signal<(Int, Double), NoError>!
-			var observer: Signal<Int, NoError>.Observer!
-			var otherObserver: Signal<Double, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
+			var otherObserver: Observer<Double, NoError>!
 			
 			beforeEach {
 				let (signal, incomingObserver) = Signal<Int, NoError>.pipe()
@@ -1288,8 +1288,8 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("zipWith") {
-			var leftObserver: Signal<Int, NoError>.Observer!
-			var rightObserver: Signal<String, NoError>.Observer!
+			var leftObserver: Observer<Int, NoError>!
+			var rightObserver: Observer<String, NoError>!
 			var zipped: Signal<(Int, String), NoError>!
 
 			beforeEach {
@@ -1388,7 +1388,7 @@ class SignalSpec: QuickSpec {
 
 		describe("dematerialize") {
 			typealias IntEvent = Event<Int, TestError>
-			var observer: Signal<IntEvent, NoError>.Observer!
+			var observer: Observer<IntEvent, NoError>!
 			var dematerialized: Signal<Int, TestError>!
 			
 			beforeEach {
@@ -1431,7 +1431,7 @@ class SignalSpec: QuickSpec {
 		}
 
 		describe("takeLast") {
-			var observer: Signal<Int, TestError>.Observer!
+			var observer: Observer<Int, TestError>!
 			var lastThree: Signal<Int, TestError>!
 				
 			beforeEach {
@@ -1492,7 +1492,7 @@ class SignalSpec: QuickSpec {
 		describe("timeoutWithError") {
 			var testScheduler: TestScheduler!
 			var signal: Signal<Int, TestError>!
-			var observer: Signal<Int, TestError>.Observer!
+			var observer: Observer<Int, TestError>!
 
 			beforeEach {
 				testScheduler = TestScheduler()
@@ -1624,7 +1624,7 @@ class SignalSpec: QuickSpec {
 		}
 		
 		describe("combinePrevious") {
-			var observer: Signal<Int, NoError>.Observer!
+			var observer: Observer<Int, NoError>!
 			let initialValue: Int = 0
 			var latestValues: (Int, Int)?
 			
@@ -1653,9 +1653,9 @@ class SignalSpec: QuickSpec {
 			var signalA: Signal<Int, NoError>!
 			var signalB: Signal<Int, NoError>!
 			var signalC: Signal<Int, NoError>!
-			var observerA: Signal<Int, NoError>.Observer!
-			var observerB: Signal<Int, NoError>.Observer!
-			var observerC: Signal<Int, NoError>.Observer!
+			var observerA: Observer<Int, NoError>!
+			var observerB: Observer<Int, NoError>!
+			var observerC: Observer<Int, NoError>!
 			
 			var combinedValues: [Int]?
 			var completed: Bool!
@@ -1757,9 +1757,9 @@ class SignalSpec: QuickSpec {
 			var signalA: Signal<Int, NoError>!
 			var signalB: Signal<Int, NoError>!
 			var signalC: Signal<Int, NoError>!
-			var observerA: Signal<Int, NoError>.Observer!
-			var observerB: Signal<Int, NoError>.Observer!
-			var observerC: Signal<Int, NoError>.Observer!
+			var observerA: Observer<Int, NoError>!
+			var observerB: Observer<Int, NoError>!
+			var observerC: Observer<Int, NoError>!
 
 			var zippedValues: [Int]?
 			var completed: Bool!


### PR DESCRIPTION
That was useful before #2442 is merged.