### PR TITLE
Added SignalProducer.replayLazily for multicasting

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1167,6 +1167,8 @@ extension SignalProducerType {
 
 	/// Creates a new `SignalProducer` that will multicast values emitted by
 	/// the underlying producer, up to `capacity`.
+	/// This means that all clients of this `SignalProducer` will see the same version
+	/// of the emitted values/errors.
 	///
 	/// The underlying `SignalProducer` will not be started until `self` is started
 	/// for the first time. When subscribing to this producer, all previous values
@@ -1175,6 +1177,13 @@ extension SignalProducerType {
 	/// If you find yourself needing *the current value* (the last buffered value)
 	/// you should consider using `PropertyType` instead, which, unlike this operator,
 	/// will guarantee at compile time that there's always a buffered value.
+	/// This operator is not recommended in most cases, as it will introduce an implicit
+	/// relationship between the original client and the rest, so consider alternatives
+	/// like `PropertyType`, `SignalProducer.buffer`, or representing your stream using 
+	/// a `Signal` instead.
+	///
+	/// This operator is only recommended when you absolutely need to introduce
+	/// a layer of caching in front of another `SignalProducer`.
 	///
 	/// This operator has the same semantics as `SignalProducer.buffer`.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1187,8 +1187,9 @@ extension SignalProducerType {
 		let lock = NSLock()
 		lock.name = "org.reactivecocoa.ReactiveCocoa.SignalProducer.replayLazily"
 
-		// This will go "out of scope" when the return `SignalProducer` is deallocated.
+		// This will go "out of scope" when the returned `SignalProducer` goes out of scope.
 		// This lets us know when we're supposed to dispose the underlying producer.
+		// This is necessary because `struct`s don't have `deinit`.
 		let token = NSObject()
 
 		return SignalProducer { observer, disposable in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1230,6 +1230,6 @@ private extension NSObject {
 			.mapError { error in
 				fatalError("Unexpected error: \(error)")
 				()
-		}
+			}
 	}
 }

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1861,6 +1861,244 @@ class SignalProducerSpec: QuickSpec {
 				expect(started) == false
 			}
 		}
+
+		describe("replayLazily") {
+			var producer: SignalProducer<Int, TestError>!
+			var observer: SignalProducer<Int, TestError>.ProducedSignal.Observer!
+
+			var replayedProducer: SignalProducer<Int, TestError>!
+
+			beforeEach {
+				let (producerTemp, observerTemp) = SignalProducer<Int, TestError>.buffer(0)
+				producer = producerTemp
+				observer = observerTemp
+
+				replayedProducer = producer.replayLazily(2)
+			}
+
+			context("subscribing to underlying producer") {
+				it("emits new values") {
+					var last: Int?
+
+					replayedProducer.startWithNext { last = $0 }
+					expect(last).to(beNil())
+
+					observer.sendNext(1)
+					expect(last) == 1
+
+					observer.sendNext(2)
+					expect(last) == 2
+				}
+
+				it("emits errors") {
+					var error: TestError?
+
+					replayedProducer.startWithFailed { error = $0 }
+					expect(error).to(beNil())
+
+					observer.sendFailed(.Default)
+					expect(error) == TestError.Default
+				}
+			}
+
+			context("buffers past values") {
+				it("emits last value upon subscription") {
+					let disposable = replayedProducer
+						.start()
+
+					observer.sendNext(1)
+					disposable.dispose()
+
+					var last: Int?
+
+					replayedProducer
+						.startWithNext { last = $0 }
+					expect(last) == 1
+				}
+
+				it("emits previous failure upon subscription") {
+					let disposable = replayedProducer
+						.start()
+
+					observer.sendFailed(.Default)
+					disposable.dispose()
+
+					var error: TestError?
+
+					replayedProducer
+						.startWithFailed { error = $0 }
+					expect(error) == TestError.Default
+				}
+
+				it("emits last n values upon subscription") {
+					var disposable = replayedProducer
+						.start()
+
+					observer.sendNext(1)
+					observer.sendNext(2)
+					observer.sendNext(3)
+					observer.sendNext(4)
+					disposable.dispose()
+
+					var values: [Int] = []
+
+					disposable = replayedProducer
+						.startWithNext { values.append($0) }
+					expect(values) == [ 3, 4 ]
+
+					observer.sendNext(5)
+					expect(values) == [ 3, 4, 5 ]
+
+					disposable.dispose()
+					values = []
+
+					replayedProducer
+						.startWithNext { values.append($0) }
+					expect(values) == [ 4, 5 ]
+				}
+			}
+
+			context("starting underying producer") {
+				it("starts lazily") {
+					var started = false
+
+					let producer = SignalProducer<Int, NoError>(value: 0)
+						.on(started: { started = true })
+					expect(started) == false
+
+					let replayedProducer = producer
+						.replayLazily(1)
+					expect(started) == false
+
+					replayedProducer.start()
+					expect(started) == true
+				}
+
+				it("shares a single subscription") {
+					var startedTimes = 0
+
+					let producer = SignalProducer<Int, NoError>.never
+						.on(started: { startedTimes++ })
+					expect(startedTimes) == 0
+
+					let replayedProducer = producer
+						.replayLazily(1)
+					expect(startedTimes) == 0
+
+					replayedProducer.start()
+					expect(startedTimes) == 1
+
+					replayedProducer.start()
+					expect(startedTimes) == 1
+				}
+
+				it("does not start multiple times when subscribing multiple times") {
+					var startedTimes = 0
+
+					let producer = SignalProducer<Int, NoError>(value: 0)
+						.on(started: { startedTimes++ })
+
+					let replayedProducer = producer
+						.replayLazily(1)
+
+					expect(startedTimes) == 0
+					replayedProducer.start().dispose()
+					expect(startedTimes) == 1
+					replayedProducer.start().dispose()
+					expect(startedTimes) == 1
+				}
+
+				it("does not start again if it finished") {
+					var startedTimes = 0
+
+					let producer = SignalProducer<Int, NoError>.empty
+						.on(started: { startedTimes++ })
+					expect(startedTimes) == 0
+
+					let replayedProducer = producer
+						.replayLazily(1)
+					expect(startedTimes) == 0
+
+					replayedProducer.start()
+					expect(startedTimes) == 1
+
+					replayedProducer.start()
+					expect(startedTimes) == 1
+				}
+			}
+
+			context("lifetime") {
+				it("does not dispose underlying subscription if the replayed producer is still in memory") {
+					var disposed = false
+
+					let producer = SignalProducer<Int, NoError>.never
+						.on(disposed: { disposed = true })
+
+					let replayedProducer = producer
+						.replayLazily(1)
+
+					expect(disposed) == false
+					let disposable = replayedProducer.start()
+					expect(disposed) == false
+
+					disposable.dispose()
+					expect(disposed) == false
+				}
+
+				it("disposes underlying producer when the producer is deallocated") {
+					var disposed = false
+
+					let producer = SignalProducer<Int, NoError>.never
+						.on(disposed: { disposed = true })
+
+					var replayedProducer = ImplicitlyUnwrappedOptional(producer.replayLazily(1))
+
+					expect(disposed) == false
+					let disposable = replayedProducer.start()
+					expect(disposed) == false
+
+					disposable.dispose()
+					expect(disposed) == false
+
+					replayedProducer = nil
+					expect(disposed) == true
+				}
+
+				it("does not leak buffered values") {
+					final class Value {
+						private let deinitBlock: () -> ()
+
+						init(deinitBlock: () -> ()) {
+							self.deinitBlock = deinitBlock
+						}
+
+						deinit {
+							self.deinitBlock()
+						}
+					}
+
+					var deinitValues = 0
+
+					var producer: SignalProducer<Value, NoError>! = SignalProducer(value: Value { deinitValues++ })
+					expect(deinitValues) == 0
+
+					var replayedProducer: SignalProducer<Value, NoError>! = producer
+						.replayLazily(1)
+					
+					let disposable = replayedProducer
+						.start()
+					
+					disposable.dispose()
+					expect(deinitValues) == 0
+					
+					producer = nil
+					expect(deinitValues) == 0
+					
+					replayedProducer = nil
+					expect(deinitValues) == 1
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Motivation
====================

I expect this to be a controversial one, so let me provide some context: multicasting has always been an important feature.
Notably, *Rx* contains multiple operators ([replay and cache](http://reactivex.io/documentation/operators/replay.html), [multicast](http://reactivex.io/documentation/operators/publish.html), etc) for this. However, we've always been very cautious about including this in *ReactiveCocoa* **because it's very easy to misuse**. Specifically, the most common pattern that I see is this:
```java
final BehaviorSubject<Integer> subject = BehaviorSubject.create();
final Observable<Integer> observable = subject.getObservable();

// ... somewhere else in the code:

// This is safe because it's backed by a `BehaviorSubject`.
final int lastNumber = observable.toBlocking().first();
```

I've seen this **so many times**. It seems fine at first, but it's very important to realize that the comment "this is safe" is actually a lie: we have no compile time guarantees that it will not deadlock, or block the current thread for several seconds.
This is precisely why `PropertyType` was born: not only does it make this pattern a lot easier, but it provides compile-time guarantees and better semantics to implement this sort of thing.

This is exactly why I and others have felt that A: we don't need multicasting, and B: if we did add it, it would be used instead of using `PropertyType`.
However, I've ran into several scenarios where *replaying* was necessary. To accomplish it, I've been using `MutableProperty` (I even [suggested this in StackOverflow](http://stackoverflow.com/questions/33946571/how-do-i-observe-a-signal-and-immediately-receive-a-next-event-if-it-has-alrea/34010425#34010425)), so I thought it was time to provide a first-party solution to this.

Details
====================

I've been putting a lot of thought into this, whether it really belongs in RAC's codebase, the semantics that it should have, etc. And this is the result!
First let me explain what the semantics are (all of this is tested in this commit):

- Invoking the operator has no side effects, i.e. it's *lazy*. This is important to maintain consistency with the rest of `SignalProducer` semantics: only `start` can have side effects.
- Upon the first call to `start`, the underlying `SignalProducer* is started.
- Values are buffered to all subsequent subscribers, from that point on.
- This is slightly weird because the `SignalProducer` no longer has *value semantics* (its buffered values are shared). But this is already how things like `SignalProducer.buffer` or `PropertyType.producer` work: they also have reference semantics, so I think it's fine. It just means that starting the producer *can* have side effects, but most importantly, different observers will see different versions of the producer depending on when they `start` it.
- When the producer *fails*, the `error` is automatically forwarded to any subsequent observer.
- When the producer *completes*, new observers will see the last `n` values emitted, and then complete.
- The subscription to the underlying `SignalProducer` will stay alive even if the last observer disposes of it. This is important, because there might be new observers later on.
- If there are no more subscriptions to the replayed `SignalProducer`, and it goes out of scope, the underlying producer is disposed.
- The result of this operator **is another `SignalProducer`**: this is important because, as explained above, each observer will see a different version of the truth.
- This operator **is only implemented for `SignalProducer`**: this is also very important (and something that Rx can't do). it wouldn't make sense to multicast a `Signal`!

So notice that this is exactly the same semantics as `SignalProducer.buffer`. It allows you to multicast elements from a single source.
Thanks to this, its implementation is actually 100% based on `SignalProducer.buffer`!

I tried explaining these points as concisely as possible as part of the *dosctring*, but let me know if it could be improved.

Use cases
====================

- As an optimization: one can use this operator to avoid doing the same work multiple times. I needed this myself to get these semantics [in my rendering framework](https://github.com/NachoSoto/AsyncImageView/blob/master/AsyncImageView/Renderers/MulticastedRenderer.swift), and using an operator would be a lot easier.
- In cases where the same producer is needed multiple times as part of a complicated operator chain. For example, being able to do things like `combineLatest(p.filter(f1), p.filter(f2))` without incurring in 2 subscriptions to the same `SignalProducer`.

Questions
====================

- I'd like @jspahrsummers to take a look at this if possible. He actually taught me a lot of what I explained here regarding the common cases that lead to misusing *multicasting*. **I think** I've managed to come up with an implementation that minimizes the room for errors, and the *docstring* explains when `PropertyType` would be preferred, but I'd like to hear his thoughts, and anybody else's, regarding this controversial operator.
- I'm also interested in hearing other people's ideas for cases where they wished *multicasting* were easier, and make sure that these are the right semantics we want.