### PR TITLE
Require that Disposable is a Class

### DIFF
--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents something that can be “disposed,” usually associated with freeing
 /// resources or canceling work.
-public protocol Disposable {
+public protocol Disposable: class {
 	/// Whether this disposable has been disposed already.
 	var disposed: Bool { get }
 


### PR DESCRIPTION
I think conceptually this makes good sense, and it also enables users to treat disposables as `AnyObject` which opens up interesting possibilities like making a weak set of disposables using `NSMapTable.weakToStrongObjectsMapTable: Disposable -> NSNull` etc.