### PR TITLE
Property enhancements

### DIFF
--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -63,6 +63,15 @@ class PropertySpec: QuickSpec {
 				expect(sentValue) == initialPropertyValue
 				expect(signalCompleted) == true
 			}
+
+			it("should perform an action with the value") {
+				let property = ConstantProperty(initialPropertyValue)
+
+				let result: Bool = property.withValue { $0.isEmpty }
+
+				expect(result) == false
+				expect(property.value) == initialPropertyValue
+			}
 		}
 
 		describe("MutableProperty") {
@@ -281,6 +290,10 @@ class PropertySpec: QuickSpec {
 						}
 					}
 
+					let isEmpty = property.withValue { $0.isEmpty }
+
+					expect(property.value) == initialPropertyValue
+					expect(isEmpty) == false
 					expect(sentValue) == initialPropertyValue
 					expect(signalSentValue).to(beNil())
 					expect(producerCompleted) == true
@@ -357,6 +370,51 @@ class PropertySpec: QuickSpec {
 				property.value = 1
 				expect(object.rac_value) == 1
 				expect(propertyValue()) == 1
+			}
+
+			it("should modify the value") {
+				expect(property.modify({ _ in 1 }) as? Int) == 0
+				expect(propertyValue()) == 1
+			}
+
+			it("should modify the value and subsquently send out a Next event with the new value") {
+				var value: Int!
+
+				property.producer.startWithNext {
+					value = $0 as! Int
+				}
+
+				expect(value) == 0
+				expect(property.modify({ _ in 1 }) as? Int) == 0
+
+				expect(propertyValue()) == 1
+				expect(value) == 1
+			}
+
+			it("should swap the value") {
+				expect(property.swap(1) as? Int) == 0
+				expect(propertyValue()) == 1
+			}
+
+			it("should swap the value and subsquently send out a Next event with the new value") {
+				var value: Int!
+
+				property.producer.startWithNext {
+					value = $0 as! Int
+				}
+
+				expect(value) == 0
+				expect(property.swap(1) as? Int) == 0
+
+				expect(propertyValue()) == 1
+				expect(value) == 1
+			}
+
+			it("should perform an action with the value") {
+				let isZero: Bool = property.withValue { $0 as! Int == 0 }
+
+				expect(isZero) == true
+				expect(propertyValue()) == 0
 			}
 
 			it("should yield a producer that sends the current value and then the changes for the key path of the underlying object") {


### PR DESCRIPTION
##### Non-breaking Changes (For API consumers)

1. `withValue(action:)` is now available on all `PropertyType` implementations.

2. `modify(action:)` and `swap(value:)` are now available on all `MutablePropertyType` implementations.

##### Breaking Changes (affecting only `PropertyType` and `MutablePropertyType` implementers)

1. New `PropertyType` requirement: `withValue(action:)`.
Meanwhile, `value` and `signal` are no longer required. Default implementations are provided for them instead.

2. New `MutablePropertyType` requirement: `modify(action:)`
Meanwhile, `value` is no longer required. Default implementations are provided for `value` and also `swap(value:)` instead.

-
This PR was originated from the attempt to introduce `withValue` to `PropertyType`. The only obstacle is `AnyProperty` given the current limitations of Swift's generic system. Specifically, since `@noescape` and `rethrows` are not supported in type identifier, closures cannot be used in this case.

Consequently, this PR refactored `AnyProperty` to use type erased wrappers for serving its read-only view. But more importantly, since now `withValue` is available on PropertyType, this means the atomicity of `withValue` - if enforced by an implementation, e.g. MutableProperty - is also available in the wrapping `AnyProperty` and during property composition.



For example, for `map` (https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2646), we can now instead do:
```
func map<U>(transform: Value -> U) -> AnyProperty<U> {
    return withValue { value in
        return AnyProperty(initialValue: transform(value),
            signal: signal.map(transform))
    }
}
```
and semantically it is always consistent across threads, since (if `self` is a MutableProperty) the closure that constructs the `AnyProperty` is executed before the recursive lock is released.

Note that atomicity is defined to be implementation dependent, since there is probably no way to enforce atomicity in `DynamicProperty`.