### PR TITLE
Use Dispatch Semaphores in Atomic Instead of Spin Locks

### DIFF
--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// An atomic variable.
 public final class Atomic<Value> {
-	private var spinLock = OS_SPINLOCK_INIT
+	private let semaphore = dispatch_semaphore_create(1)
 	private var _value: Value
 	
 	/// Atomically gets or sets the value of the variable.
@@ -30,11 +30,11 @@ public final class Atomic<Value> {
 	}
 	
 	private func lock() {
-		OSSpinLockLock(&spinLock)
+		dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
 	}
 	
 	private func unlock() {
-		OSSpinLockUnlock(&spinLock)
+		dispatch_semaphore_signal(semaphore)
 	}
 	
 	/// Atomically replaces the contents of the variable.


### PR DESCRIPTION
Resolves #2619. I chose dispatch semaphores based on the discussion in that thread, plus the following tests I did with 16 dispatch_asyncs on global concurrent queue, 100000 small arithmetic operations per block in iOS 9.2 simulator:

- OSSpinLock average: 0.153, relative standard deviation: 1.338%
- dispatch semaphore: average: 0.547, relative standard deviation: 3.032%
- NSLock: average: 4.484, relative standard deviation: 1.039%
- pthread mutex: average: 4.550, relative standard deviation: 3.291%,