### PR TITLE
Update Nimble to v3.1.0

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
 github "Quick/Quick" ~> 0.8
-github "Quick/Nimble" ~> 3.0
+github "Quick/Nimble" ~> 3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v3.0.0"
+github "Quick/Nimble" "v3.1.0"
 github "Quick/Quick" "v0.8.0"
 github "antitypical/Result" "1.0.1"
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"

--- a/ReactiveCocoaTests/Objective-C/RACCommandSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACCommandSpec.m
@@ -214,7 +214,7 @@ qck_it(@"should send on executionSignals in order of execution", ^{
 	expect(@([[command execute:first] asynchronouslyWaitUntilCompleted:NULL])).to(beTruthy());
 
 	RACSequence *second = @[ @"buzz", @"baz" ].rac_sequence;
-	expect(@([[command execute:second] asynchronouslyWaitUntilCompleted:NULL])).toEventually(beTruthy());
+	expect(@([[command execute:second] asynchronouslyWaitUntilCompleted:NULL])).to(beTruthy());
 
 	NSArray *expectedValues = @[ @"foo", @"bar", @"buzz", @"baz" ];
 	expect(valuesReceived).to(equal(expectedValues));


### PR DESCRIPTION
https://github.com/Quick/Nimble/releases/tag/v3.1.0

> Async expectations have been rewritten to reduce flakiness. The public API remains the same but uses lower-level features to avoid complex interactions with common run loop features.