### PR TITLE
Replace OSSpinLock with pthread_mutex

### DIFF
--- a/ReactiveCocoa/Objective-C/RACCompoundDisposable.m
+++ b/ReactiveCocoa/Objective-C/RACCompoundDisposable.m
@@ -78,7 +78,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 	return [[self alloc] initWithDisposables:disposables];
 }
 
-- (id)init {
+- (instancetype)init {
 	self = [super init];
 	if (self == nil) return nil;
 
@@ -88,7 +88,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 	return self;
 }
 
-- (id)initWithDisposables:(NSArray *)otherDisposables {
+- (instancetype)initWithDisposables:(NSArray *)otherDisposables {
 	self = [self init];
 	if (self == nil) return nil;
 
@@ -112,7 +112,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 	return self;
 }
 
-- (id)initWithBlock:(void (^)(void))block {
+- (instancetype)initWithBlock:(void (^)(void))block {
 	RACDisposable *disposable = [RACDisposable disposableWithBlock:block];
 	return [self initWithDisposables:@[ disposable ]];
 }

--- a/ReactiveCocoa/Objective-C/RACCompoundDisposable.m
+++ b/ReactiveCocoa/Objective-C/RACCompoundDisposable.m
@@ -8,7 +8,7 @@
 
 #import "RACCompoundDisposable.h"
 #import "RACCompoundDisposableProvider.h"
-#import <libkern/OSAtomic.h>
+#import <pthread/pthread.h>
 
 // The number of child disposables for which space will be reserved directly in
 // `RACCompoundDisposable`.
@@ -30,7 +30,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 
 @interface RACCompoundDisposable () {
 	// Used for synchronization.
-	OSSpinLock _spinLock;
+	pthread_mutex_t _mutex;
 
 	#if RACCompoundDisposableInlineCount
 	// A fast array to the first N of the receiver's disposables.
@@ -38,19 +38,19 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 	// Once this is full, `_disposables` will be created and used for additional
 	// disposables.
 	//
-	// This array should only be manipulated while _spinLock is held.
+	// This array should only be manipulated while _mutex is held.
 	RACDisposable *_inlineDisposables[RACCompoundDisposableInlineCount];
 	#endif
 
 	// Contains the receiver's disposables.
 	//
-	// This array should only be manipulated while _spinLock is held. If
+	// This array should only be manipulated while _mutex is held. If
 	// `_disposed` is YES, this may be NULL.
 	CFMutableArrayRef _disposables;
 
 	// Whether the receiver has already been disposed.
 	//
-	// This ivar should only be accessed while _spinLock is held.
+	// This ivar should only be accessed while _mutex is held.
 	BOOL _disposed;
 }
 
@@ -61,9 +61,9 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 #pragma mark Properties
 
 - (BOOL)isDisposed {
-	OSSpinLockLock(&_spinLock);
+	pthread_mutex_lock(&_mutex);
 	BOOL disposed = _disposed;
-	OSSpinLockUnlock(&_spinLock);
+	pthread_mutex_unlock(&_mutex);
 
 	return disposed;
 }
@@ -76,6 +76,16 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 
 + (instancetype)compoundDisposableWithDisposables:(NSArray *)disposables {
 	return [[self alloc] initWithDisposables:disposables];
+}
+
+- (id)init {
+	self = [super init];
+	if (self == nil) return nil;
+
+	int result = pthread_mutex_init(&_mutex, NULL);
+	NSCAssert(0 == result, @"Failed to initialize mutex with error %d.", result);
+
+	return self;
 }
 
 - (id)initWithDisposables:(NSArray *)otherDisposables {
@@ -118,6 +128,9 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 		CFRelease(_disposables);
 		_disposables = NULL;
 	}
+
+	int result = pthread_mutex_destroy(&_mutex);
+	NSCAssert(0 == result, @"Failed to destroy mutex with error %d.", result);
 }
 
 #pragma mark Addition and Removal
@@ -128,7 +141,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 
 	BOOL shouldDispose = NO;
 
-	OSSpinLockLock(&_spinLock);
+	pthread_mutex_lock(&_mutex);
 	{
 		if (_disposed) {
 			shouldDispose = YES;
@@ -154,7 +167,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 		#endif
 		}
 	}
-	OSSpinLockUnlock(&_spinLock);
+	pthread_mutex_unlock(&_mutex);
 
 	// Performed outside of the lock in case the compound disposable is used
 	// recursively.
@@ -164,7 +177,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 - (void)removeDisposable:(RACDisposable *)disposable {
 	if (disposable == nil) return;
 
-	OSSpinLockLock(&_spinLock);
+	pthread_mutex_lock(&_mutex);
 	{
 		if (!_disposed) {
 			#if RACCompoundDisposableInlineCount
@@ -188,7 +201,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 			}
 		}
 	}
-	OSSpinLockUnlock(&_spinLock);
+	pthread_mutex_unlock(&_mutex);
 }
 
 #pragma mark RACDisposable
@@ -205,7 +218,7 @@ static void disposeEach(const void *value, void *context) {
 
 	CFArrayRef remainingDisposables = NULL;
 
-	OSSpinLockLock(&_spinLock);
+	pthread_mutex_lock(&_mutex);
 	{
 		_disposed = YES;
 
@@ -219,7 +232,7 @@ static void disposeEach(const void *value, void *context) {
 		remainingDisposables = _disposables;
 		_disposables = NULL;
 	}
-	OSSpinLockUnlock(&_spinLock);
+	pthread_mutex_unlock(&_mutex);
 
 	#if RACCompoundDisposableInlineCount
 	// Dispose outside of the lock in case the compound disposable is used

--- a/ReactiveCocoa/Objective-C/RACCompoundDisposable.m
+++ b/ReactiveCocoa/Objective-C/RACCompoundDisposable.m
@@ -82,7 +82,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 	self = [super init];
 	if (self == nil) return nil;
 
-	int result = pthread_mutex_init(&_mutex, NULL);
+	const int result = pthread_mutex_init(&_mutex, NULL);
 	NSCAssert(0 == result, @"Failed to initialize mutex with error %d.", result);
 
 	return self;
@@ -129,7 +129,7 @@ static CFMutableArrayRef RACCreateDisposablesArray(void) {
 		_disposables = NULL;
 	}
 
-	int result = pthread_mutex_destroy(&_mutex);
+	const int result = pthread_mutex_destroy(&_mutex);
 	NSCAssert(0 == result, @"Failed to destroy mutex with error %d.", result);
 }
 

--- a/ReactiveCocoa/Objective-C/RACSerialDisposable.m
+++ b/ReactiveCocoa/Objective-C/RACSerialDisposable.m
@@ -14,14 +14,11 @@
 	// _mutex is held.
 	RACDisposable * _disposable;
 
-	// YES if the receiver has been disposed. This variable must only be modified
+	// YES if the receiver has been disposed. This variable must only be accessed
 	// while _mutex is held.
 	BOOL _disposed;
 
 	// A mutex to protect access to _disposable and _disposed.
-	//
-	// It must be used when _disposable is mutated or retained and when _disposed
-	// is mutated.
 	pthread_mutex_t _mutex;
 }
 
@@ -32,7 +29,11 @@
 #pragma mark Properties
 
 - (BOOL)isDisposed {
-	return _disposed;
+	pthread_mutex_lock(&_mutex);
+	BOOL disposed = _disposed;
+	pthread_mutex_unlock(&_mutex);
+
+	return disposed;
 }
 
 - (RACDisposable *)disposable {

--- a/ReactiveCocoa/Objective-C/RACSerialDisposable.m
+++ b/ReactiveCocoa/Objective-C/RACSerialDisposable.m
@@ -30,17 +30,15 @@
 
 - (BOOL)isDisposed {
 	pthread_mutex_lock(&_mutex);
-	BOOL disposed = _disposed;
+	const BOOL disposed = _disposed;
 	pthread_mutex_unlock(&_mutex);
 
 	return disposed;
 }
 
 - (RACDisposable *)disposable {
-	RACDisposable *result;
-
 	pthread_mutex_lock(&_mutex);
-	result = _disposable;
+	RACDisposable * const result = _disposable;
 	pthread_mutex_unlock(&_mutex);
 
 	return result;
@@ -62,7 +60,7 @@
 	self = [super init];
 	if (self == nil) return nil;
 
-	int result = pthread_mutex_init(&_mutex, NULL);
+	const int result = pthread_mutex_init(&_mutex, NULL);
 	NSCAssert(0 == result, @"Failed to initialize mutex with error %d", result);
 
 	return self;
@@ -78,7 +76,7 @@
 }
 
 - (void)dealloc {
-	int result = pthread_mutex_destroy(&_mutex);
+	const int result = pthread_mutex_destroy(&_mutex);
 	NSCAssert(0 == result, @"Failed to destroy mutex with error %d", result);
 }
 

--- a/ReactiveCocoa/Objective-C/RACSerialDisposable.m
+++ b/ReactiveCocoa/Objective-C/RACSerialDisposable.m
@@ -58,7 +58,7 @@
 	return serialDisposable;
 }
 
-- (id)init {
+- (instancetype)init {
 	self = [super init];
 	if (self == nil) return nil;
 
@@ -68,7 +68,7 @@
 	return self;
 }
 
-- (id)initWithBlock:(void (^)(void))block {
+- (instancetype)initWithBlock:(void (^)(void))block {
 	self = [self init];
 	if (self == nil) return nil;
 

--- a/ReactiveCocoa/Objective-C/RACSerialDisposable.m
+++ b/ReactiveCocoa/Objective-C/RACSerialDisposable.m
@@ -7,22 +7,22 @@
 //
 
 #import "RACSerialDisposable.h"
-#import <libkern/OSAtomic.h>
+#import <pthread/pthread.h>
 
 @interface RACSerialDisposable () {
 	// The receiver's `disposable`. This variable must only be referenced while
-	// _spinLock is held.
+	// _mutex is held.
 	RACDisposable * _disposable;
 
 	// YES if the receiver has been disposed. This variable must only be modified
-	// while _spinLock is held.
+	// while _mutex is held.
 	BOOL _disposed;
 
-	// A spinlock to protect access to _disposable and _disposed.
+	// A mutex to protect access to _disposable and _disposed.
 	//
 	// It must be used when _disposable is mutated or retained and when _disposed
 	// is mutated.
-	OSSpinLock _spinLock;
+	pthread_mutex_t _mutex;
 }
 
 @end
@@ -38,9 +38,9 @@
 - (RACDisposable *)disposable {
 	RACDisposable *result;
 
-	OSSpinLockLock(&_spinLock);
+	pthread_mutex_lock(&_mutex);
 	result = _disposable;
-	OSSpinLockUnlock(&_spinLock);
+	pthread_mutex_unlock(&_mutex);
 
 	return result;
 }
@@ -57,6 +57,16 @@
 	return serialDisposable;
 }
 
+- (id)init {
+	self = [super init];
+	if (self == nil) return nil;
+
+	int result = pthread_mutex_init(&_mutex, NULL);
+	NSCAssert(0 == result, @"Failed to initialize mutex with error %d", result);
+
+	return self;
+}
+
 - (id)initWithBlock:(void (^)(void))block {
 	self = [self init];
 	if (self == nil) return nil;
@@ -66,19 +76,24 @@
 	return self;
 }
 
+- (void)dealloc {
+	int result = pthread_mutex_destroy(&_mutex);
+	NSCAssert(0 == result, @"Failed to destroy mutex with error %d", result);
+}
+
 #pragma mark Inner Disposable
 
 - (RACDisposable *)swapInDisposable:(RACDisposable *)newDisposable {
 	RACDisposable *existingDisposable;
 	BOOL alreadyDisposed;
 
-	OSSpinLockLock(&_spinLock);
+	pthread_mutex_lock(&_mutex);
 	alreadyDisposed = _disposed;
 	if (!alreadyDisposed) {
 		existingDisposable = _disposable;
 		_disposable = newDisposable;
 	}
-	OSSpinLockUnlock(&_spinLock);
+	pthread_mutex_unlock(&_mutex);
 
 	if (alreadyDisposed) {
 		[newDisposable dispose];
@@ -93,13 +108,13 @@
 - (void)dispose {
 	RACDisposable *existingDisposable;
 
-	OSSpinLockLock(&_spinLock);
+	pthread_mutex_lock(&_mutex);
 	if (!_disposed) {
 		existingDisposable = _disposable;
 		_disposed = YES;
 		_disposable = nil;
 	}
-	OSSpinLockUnlock(&_spinLock);
+	pthread_mutex_unlock(&_mutex);
 	
 	[existingDisposable dispose];
 }

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -28,22 +28,22 @@ public final class Atomic<Value> {
 	public init(_ value: Value) {
 		_value = value
 		let result = pthread_mutex_init(&mutex, nil)
-		assert(0 == result, "Failed to initialize mutex with error \(result).")
+		assert(result == 0, "Failed to initialize mutex with error \(result).")
 	}
 
 	deinit {
 		let result = pthread_mutex_destroy(&mutex)
-		assert(0 == result, "Failed to destroy mutex with error \(result).")
+		assert(result == 0, "Failed to destroy mutex with error \(result).")
 	}
 
 	private func lock() {
 		let result = pthread_mutex_lock(&mutex)
-		assert(0 == result, "Failed to lock \(self) with error \(result).")
+		assert(result == 0, "Failed to lock \(self) with error \(result).")
 	}
 	
 	private func unlock() {
 		let result = pthread_mutex_unlock(&mutex)
-		assert(0 == result, "Failed to unlock \(self) with error \(result).")
+		assert(result == 0, "Failed to unlock \(self) with error \(result).")
 	}
 	
 	/// Atomically replaces the contents of the variable.

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// An atomic variable.
 public final class Atomic<Value> {
-	private var spinLock = OS_SPINLOCK_INIT
+	private var mutex = pthread_mutex_t()
 	private var _value: Value
 	
 	/// Atomically gets or sets the value of the variable.
@@ -27,14 +27,23 @@ public final class Atomic<Value> {
 	/// Initializes the variable with the given initial value.
 	public init(_ value: Value) {
 		_value = value
+		let result = pthread_mutex_init(&mutex, nil)
+		assert(0 == result, "Failed to initialize mutex with error \(result).")
 	}
-	
+
+	deinit {
+		let result = pthread_mutex_destroy(&mutex)
+		assert(0 == result, "Failed to destroy mutex with error \(result).")
+	}
+
 	private func lock() {
-		OSSpinLockLock(&spinLock)
+		let result = pthread_mutex_lock(&mutex)
+		assert(0 == result, "Failed to lock \(self) with error \(result).")
 	}
 	
 	private func unlock() {
-		OSSpinLockUnlock(&spinLock)
+		let result = pthread_mutex_unlock(&mutex)
+		assert(0 == result, "Failed to unlock \(self) with error \(result).")
 	}
 	
 	/// Atomically replaces the contents of the variable.


### PR DESCRIPTION
This supersedes #2667, resolves #2619.

Here is the performance testing I did. https://gist.github.com/Adlai-Holler/f811809e57d06a6e7a2a 16 concurrent blocks on the default-qos global queue, each running  100,000 iterations of "lock, read, increment, set, read, decrement, set, unlock".

I added assertions into `Atomic` when locking/unlocking because in optimized builds Swift assertions are not evaluated so I figure why not have the extra information available.