### PR TITLE
Need to import both ReactiveCocoa and Result if using Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ ReactiveCocoa to your `Cartfile`:
 ```
 github "ReactiveCocoa/ReactiveCocoa"
 ```
-Remeber to add both ReactiveCocoa.framework and Result.framework to "Linked Frameworks and Libraries" and "copy-frameworks" Build Phases. Otherwise, it won't work.
+Make sure to add both `ReactiveCocoa.framework` and `Result.framework` to "Linked Frameworks and Libraries" and "copy-frameworks" Build Phases.
 
 If you would prefer to use [CocoaPods](https://cocoapods.org), there are some
 [unofficial podspecs](https://github.com/CocoaPods/Specs/tree/master/Specs/ReactiveCocoa)

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ ReactiveCocoa to your `Cartfile`:
 ```
 github "ReactiveCocoa/ReactiveCocoa"
 ```
+Remeber to add both ReactiveCocoa.framework and Result.framework to "Linked Frameworks and Libraries" and "copy-frameworks" Build Phases. Otherwise, it won't work.
 
 If you would prefer to use [CocoaPods](https://cocoapods.org), there are some
 [unofficial podspecs](https://github.com/CocoaPods/Specs/tree/master/Specs/ReactiveCocoa)


### PR DESCRIPTION
The README documentation is missing a important instruction for people who are using ReactiveCocoa.framework. User will need to add both ReactiveCocoa.frame work and Result.framework in order for the app to run. This apply even when ReactiveCocoa is a component of other libraries. I was using ReactiveMoya from Moya project along with some other libraries. It took me a couple hours to find out that the problem is with adding ReactiveCocoa framework. I believe we should make this clear in the ReadMe and I hope this can help other using ReactiveCocoa.