### PR TITLE
Actually fix tvOS headers

### DIFF
--- a/ReactiveCocoa/ReactiveCocoa.h
+++ b/ReactiveCocoa/ReactiveCocoa.h
@@ -62,28 +62,30 @@ FOUNDATION_EXPORT const unsigned char ReactiveCocoaVersionString[];
 #import <ReactiveCocoa/RACUnit.h>
 
 #if TARGET_OS_WATCH
-#elif TARGET_OS_TV
-#elif TARGET_OS_IPHONE
-	#import <ReactiveCocoa/MKAnnotationView+RACSignalSupport.h>
-	#import <ReactiveCocoa/UIActionSheet+RACSignalSupport.h>
-	#import <ReactiveCocoa/UIAlertView+RACSignalSupport.h>
-	#import <ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h>
+#elif TARGET_OS_IOS || TARGET_OS_TV
 	#import <ReactiveCocoa/UIButton+RACCommandSupport.h>
 	#import <ReactiveCocoa/UICollectionReusableView+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIControl+RACSignalSupport.h>
-	#import <ReactiveCocoa/UIDatePicker+RACSignalSupport.h>
 	#import <ReactiveCocoa/UIGestureRecognizer+RACSignalSupport.h>
-	#import <ReactiveCocoa/UIImagePickerController+RACSignalSupport.h>
-	#import <ReactiveCocoa/UIRefreshControl+RACCommandSupport.h>
 	#import <ReactiveCocoa/UISegmentedControl+RACSignalSupport.h>
-	#import <ReactiveCocoa/UISlider+RACSignalSupport.h>
-	#import <ReactiveCocoa/UIStepper+RACSignalSupport.h>
-	#import <ReactiveCocoa/UISwitch+RACSignalSupport.h>
 	#import <ReactiveCocoa/UITableViewCell+RACSignalSupport.h>
 	#import <ReactiveCocoa/UITableViewHeaderFooterView+RACSignalSupport.h>
 	#import <ReactiveCocoa/UITextField+RACSignalSupport.h>
 	#import <ReactiveCocoa/UITextView+RACSignalSupport.h>
-	#import <ReactiveCocoa/NSURLConnection+RACSupport.h>
+
+	#if TARGET_OS_IOS
+		#import <ReactiveCocoa/NSURLConnection+RACSupport.h>
+		#import <ReactiveCocoa/UIStepper+RACSignalSupport.h>
+		#import <ReactiveCocoa/UIDatePicker+RACSignalSupport.h>
+		#import <ReactiveCocoa/UIBarButtonItem+RACCommandSupport.h>
+		#import <ReactiveCocoa/UIAlertView+RACSignalSupport.h>
+		#import <ReactiveCocoa/UIActionSheet+RACSignalSupport.h>
+		#import <ReactiveCocoa/MKAnnotationView+RACSignalSupport.h>
+		#import <ReactiveCocoa/UIImagePickerController+RACSignalSupport.h>
+		#import <ReactiveCocoa/UIRefreshControl+RACCommandSupport.h>
+		#import <ReactiveCocoa/UISlider+RACSignalSupport.h>
+		#import <ReactiveCocoa/UISwitch+RACSignalSupport.h>
+	#endif
 #elif TARGET_OS_MAC
 	#import <ReactiveCocoa/NSControl+RACCommandSupport.h>
 	#import <ReactiveCocoa/NSControl+RACTextSignalSupport.h>


### PR DESCRIPTION
Follow up to #2651 and #2673. I forgot to actually update `ReactiveCocoa.h`... why is this in THREE places, [Xcode](https://twitter.com/NachoSoto/status/692785182525382656)?

The hilarious part is that `TARGET_OS_IPHONE` is defined for `tvOS`, which [Apple closed as "works as intended"](http://www.openradar.me/22639221). I changed that to `TARGET_OS_IOS`. Because it makes sense that `tvOS` is an iPhone.