### PR TITLE
Allow RACCommand to specify generic input type

### DIFF
--- a/ReactiveCocoa/Objective-C/NSControl+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/NSControl+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-#import "RACCommand.h"
+@class RACCommand<__contravariant InputType>;
 
 @interface NSControl (RACCommandSupport)
 

--- a/ReactiveCocoa/Objective-C/NSControl+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/NSControl+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-@class RACCommand;
+#import "RACCommand.h"
 
 @interface NSControl (RACCommandSupport)
 
@@ -17,6 +17,6 @@
 /// to the command's `canExecute`.
 ///
 /// Note: this will reset the control's target and action.
-@property (nonatomic, strong) RACCommand *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof NSControl *> *rac_command;
 
 @end

--- a/ReactiveCocoa/Objective-C/RACCommand.h
+++ b/ReactiveCocoa/Objective-C/RACCommand.h
@@ -24,7 +24,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 
 /// A command is a signal triggered in response to some action, typically
 /// UI-related.
-@interface RACCommand<__covariant InputType> : NSObject
+@interface RACCommand<__contravariant InputType> : NSObject
 
 /// A signal of the signals returned by successful invocations of -execute:
 /// (i.e., while the receiver is `enabled`).

--- a/ReactiveCocoa/Objective-C/RACCommand.h
+++ b/ReactiveCocoa/Objective-C/RACCommand.h
@@ -24,7 +24,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 
 /// A command is a signal triggered in response to some action, typically
 /// UI-related.
-@interface RACCommand : NSObject
+@interface RACCommand<__covariant InputType> : NSObject
 
 /// A signal of the signals returned by successful invocations of -execute:
 /// (i.e., while the receiver is `enabled`).
@@ -77,7 +77,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 @property (atomic, assign) BOOL allowsConcurrentExecution;
 
 /// Invokes -initWithEnabled:signalBlock: with a nil `enabledSignal`.
-- (id)initWithSignalBlock:(RACSignal * (^)(id input))signalBlock;
+- (id)initWithSignalBlock:(RACSignal * (^)(InputType input))signalBlock;
 
 /// Initializes a command that is conditionally enabled.
 ///
@@ -92,7 +92,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 ///                 to a replay subject, sent on `executionSignals`, then
 ///                 subscribed to synchronously. Neither the block nor the
 ///                 returned signal may be nil.
-- (id)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(id input))signalBlock;
+- (id)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(InputType input))signalBlock;
 
 /// If the receiver is enabled, this method will:
 ///
@@ -107,7 +107,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 /// Returns the multicasted signal, after subscription. If the receiver is not
 /// enabled, returns a signal that will send an error with code
 /// RACCommandErrorNotEnabled.
-- (RACSignal *)execute:(id)input;
+- (RACSignal *)execute:(InputType)input;
 
 @end
 

--- a/ReactiveCocoa/Objective-C/UIBarButtonItem+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/UIBarButtonItem+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACCommand;
+#import "RACCommand.h"
 
 @interface UIBarButtonItem (RACCommandSupport)
 
@@ -17,6 +17,6 @@
 /// to the command's `canExecute`.
 ///
 /// Note: this will reset the control's target and action.
-@property (nonatomic, strong) RACCommand *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof UIBarButtonItem *> *rac_command;
 
 @end

--- a/ReactiveCocoa/Objective-C/UIBarButtonItem+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/UIBarButtonItem+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "RACCommand.h"
+@class RACCommand<__contravariant InputType>;
 
 @interface UIBarButtonItem (RACCommandSupport)
 

--- a/ReactiveCocoa/Objective-C/UIButton+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/UIButton+RACCommandSupport.h
@@ -8,13 +8,13 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACCommand;
+#import "RACCommand.h"
 
 @interface UIButton (RACCommandSupport)
 
 /// Sets the button's command. When the button is clicked, the command is
 /// executed with the sender of the event. The button's enabledness is bound
 /// to the command's `canExecute`.
-@property (nonatomic, strong) RACCommand *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof UIButton *> *rac_command;
 
 @end

--- a/ReactiveCocoa/Objective-C/UIButton+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/UIButton+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "RACCommand.h"
+@class RACCommand<__contravariant InputType>;
 
 @interface UIButton (RACCommandSupport)
 

--- a/ReactiveCocoa/Objective-C/UIRefreshControl+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/UIRefreshControl+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import "RACCommand.h"
+@class RACCommand<__contravariant InputType>;
 
 @interface UIRefreshControl (RACCommandSupport)
 

--- a/ReactiveCocoa/Objective-C/UIRefreshControl+RACCommandSupport.h
+++ b/ReactiveCocoa/Objective-C/UIRefreshControl+RACCommandSupport.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@class RACCommand;
+#import "RACCommand.h"
 
 @interface UIRefreshControl (RACCommandSupport)
 
@@ -17,6 +17,6 @@
 /// When this refresh control is activated by the user, the command will be
 /// executed. Upon completion or error of the execution signal, -endRefreshing
 /// will be invoked.
-@property (nonatomic, strong) RACCommand *rac_command;
+@property (nonatomic, strong) RACCommand<__kindof UIRefreshControl *> *rac_command;
 
 @end

--- a/ReactiveCocoaTests/Objective-C/RACCommandSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACCommandSpec.m
@@ -199,7 +199,7 @@ qck_it(@"should invoke the signalBlock once per execution", ^{
 });
 
 qck_it(@"should send on executionSignals in order of execution", ^{
-	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSequence *seq) {
+	RACCommand<RACSequence *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSequence *seq) {
 		return [seq signalWithScheduler:RACScheduler.immediateScheduler];
 	}];
 
@@ -221,7 +221,7 @@ qck_it(@"should send on executionSignals in order of execution", ^{
 });
 
 qck_it(@"should wait for all signals to complete or error before executing sends NO", ^{
-	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
+	RACCommand<RACSignal *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
 		return signal;
 	}];
 
@@ -336,7 +336,7 @@ qck_it(@"should deliver errors from -execute:", ^{
 });
 
 qck_it(@"should deliver errors onto 'errors'", ^{
-	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
+	RACCommand<RACSignal *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
 		return signal;
 	}];
 
@@ -394,7 +394,7 @@ qck_it(@"should not deliver non-error events onto 'errors'", ^{
 });
 
 qck_it(@"should send errors on the main thread", ^{
-	RACCommand *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
+	RACCommand<RACSignal *> *command = [[RACCommand alloc] initWithSignalBlock:^(RACSignal *signal) {
 		return signal;
 	}];
 


### PR DESCRIPTION
Inputs to `RACCommand` to do not suffer from the same issues as `RACSignal` when attempting to adopt lightweight generics as discussed in #2085. As such, adding them is as simple as declaring a `<__covariant InputType>` in the interface.

In projects that are still using RAC 2.X, this will be helpful to ensure that commands are executed with an input of the correct type. It also helps to catch programmer error when refactoring commands.

I was unable to find a way to expose this annotated type to the compiler when bridging a `RACCommand` to `Action` in `ObjectiveCBridging.swift`. Open to any suggestions on how this might be possible.