### PR TITLE
Add `.uniqueValues` to SignalProducer

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1042,11 +1042,7 @@ extension SignalType where Value: Hashable {
 			let seenValues = Atomic<Set<Value>>(Set<Value>())
 			
 			return self
-				.filter { value in
-					return seenValues.withValue { set in
-						!set.contains(value)
-					}
-				}
+				.filter { value in return seenValues.withValue { !$0.contains(value) } }
 				.observe { event in
 					switch event {
 					case let .Next(value):

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1033,9 +1033,9 @@ extension SignalType {
 
 extension SignalType where Value: Hashable {
 	/// Forwards only those values from `self` that are unique across the set of
-	/// all values that have been seen
+	/// all values that have been seen.
 	/// Note: This causes values that are forwarded to be retained to check for
-	/// uniquness
+	/// uniquness.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func uniqueValues() -> Signal<Value, Error> {
 		return Signal { observer in

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1039,7 +1039,7 @@ extension SignalType where Value: Hashable {
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func uniqueValues() -> Signal<Value, Error> {
 		return Signal { observer in
-			let seenValues = Atomic<Set<Value>>(Set<Value>())
+			let seenValues: Atomic<Set<Value>> = Atomic([])
 			
 			return self
 				.filter { value in return seenValues.withValue { !$0.contains(value) } }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -777,6 +777,8 @@ extension SignalProducerType where Value: Equatable {
 extension SignalProducer where Value: Hashable {
 	/// Forwards only those values from `self` that are unique across the set of
 	/// all values that have been seen
+	/// Note: This causes values that are forwarded to be retained to check for
+	/// uniquness
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func uniqueValues() -> SignalProducer<Value, Error> {
 		let producer = SignalProducer.init { observer, disposable in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -783,13 +783,20 @@ extension SignalProducer where Value: Hashable {
 	public func uniqueValues() -> SignalProducer<Value, Error> {
 		let producer = SignalProducer.init { observer, disposable in
 			var set = Set<Value>()
+			let lock = NSLock()
+			lock.name = "org.reactivecocoa.ReactiveCocoa.SignalProducer.uniqueValues"
 			
 			self
 				.filter { value in
-					return !set.contains(value)
+					lock.lock()
+					let containsValue = !set.contains(value)
+					lock.unlock()
+					return containsValue
 				}
 				.on( next: { value in
+					lock.lock()
 					set.insert(value)
+					lock.unlock()
 				})
 				.start(observer)
 		}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -774,34 +774,14 @@ extension SignalProducerType where Value: Equatable {
 	}
 }
 
-extension SignalProducer where Value: Hashable {
+extension SignalProducerType where Value: Hashable {
 	/// Forwards only those values from `self` that are unique across the set of
 	/// all values that have been seen
 	/// Note: This causes values that are forwarded to be retained to check for
 	/// uniquness
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func uniqueValues() -> SignalProducer<Value, Error> {
-		let producer = SignalProducer.init { observer, disposable in
-			var set = Set<Value>()
-			let lock = NSLock()
-			lock.name = "org.reactivecocoa.ReactiveCocoa.SignalProducer.uniqueValues"
-			
-			self
-				.filter { value in
-					lock.lock()
-					let containsValue = !set.contains(value)
-					lock.unlock()
-					return containsValue
-				}
-				.on( next: { value in
-					lock.lock()
-					set.insert(value)
-					lock.unlock()
-				})
-				.start(observer)
-		}
-		
-		return producer
+		return lift { $0.uniqueValues() }
 	}
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -779,15 +779,20 @@ extension SignalProducer where Value: Hashable {
 	/// all values that have been seen
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func uniqueValues() -> SignalProducer<Value, Error> {
-		var set = Set<Value>()
+		let producer = SignalProducer.init { observer, disposable in
+			var set = Set<Value>()
+			
+			self
+				.filter { value in
+					return !set.contains(value)
+				}
+				.on( next: { value in
+					set.insert(value)
+				})
+				.start(observer)
+		}
 		
-		return self
-			.filter { value in
-				return !set.contains(value)
-			}
-			.on( next: { value in
-				set.insert(value)
-			})
+		return producer
 	}
 }
 

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -774,6 +774,22 @@ extension SignalProducerType where Value: Equatable {
 	}
 }
 
+extension SignalProducer where Value: Hashable {
+	/// Forwards only those values from `self` that are unique across the set of
+	/// all values that have been seen
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func uniqueValues() -> SignalProducer<Value, Error> {
+		var set = Set<Value>()
+		
+		return self
+			.filter { value in
+				return !set.contains(value)
+			}
+			.on( next: { value in
+				set.insert(value)
+			})
+	}
+}
 
 /// Creates a repeating timer of the given interval, with a reasonable
 /// default leeway, sending updates on the given scheduler.

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -258,7 +258,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(values) == [ "a", "cc", "d" ]
 			}
 		}
-		
+
 		describe("skipWhile") {
 			var producer: SignalProducer<Int, NoError>!
 			var observer: Signal<Int, NoError>.Observer!

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -258,6 +258,31 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(values) == [ "a", "cc", "d" ]
 			}
 		}
+		
+		describe("uniqueValues", {
+			it("should skip values that have been already seen"){
+				let (baseProducer, observer) = SignalProducer<String, NoError>.buffer(1)
+				let producer = baseProducer.uniqueValues()
+				
+				var values: [String] = []
+				producer.startWithNext { values.append($0) }
+				
+				observer.sendNext("a")
+				expect(values) == [ "a" ]
+				
+				observer.sendNext("b")
+				expect(values) == [ "a", "b" ]
+				
+				observer.sendNext("a")
+				expect(values) == [ "a", "b" ]
+				
+				observer.sendNext("b")
+				expect(values) == [ "a", "b" ]
+				
+				observer.sendNext("c")
+				expect(values) == [ "a", "b", "c" ]
+			}
+		})
 
 		describe("skipWhile") {
 			var producer: SignalProducer<Int, NoError>!

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -259,31 +259,6 @@ class SignalProducerLiftingSpec: QuickSpec {
 			}
 		}
 		
-		describe("uniqueValues", {
-			it("should skip values that have been already seen"){
-				let (baseProducer, observer) = SignalProducer<String, NoError>.buffer(1)
-				let producer = baseProducer.uniqueValues()
-				
-				var values: [String] = []
-				producer.startWithNext { values.append($0) }
-				
-				observer.sendNext("a")
-				expect(values) == [ "a" ]
-				
-				observer.sendNext("b")
-				expect(values) == [ "a", "b" ]
-				
-				observer.sendNext("a")
-				expect(values) == [ "a", "b" ]
-				
-				observer.sendNext("b")
-				expect(values) == [ "a", "b" ]
-				
-				observer.sendNext("c")
-				expect(values) == [ "a", "b", "c" ]
-			}
-		})
-
 		describe("skipWhile") {
 			var producer: SignalProducer<Int, NoError>!
 			var observer: Signal<Int, NoError>.Observer!

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -651,6 +651,9 @@ class SignalSpec: QuickSpec {
 				
 				observer.sendNext("c")
 				expect(values) == [ "a", "b", "c" ]
+				
+				observer.sendCompleted()
+				expect(values) == [ "a", "b", "c" ]
 			}
 		})
 		

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -626,7 +626,34 @@ class SignalSpec: QuickSpec {
 				expect(values) == [ "a", "cc", "d" ]
 			}
 		}
+		
+		describe("uniqueValues", {
+			it("should skip values that have been already seen"){
+				let (baseSignal, observer) = Signal<String, NoError>.pipe()
+				let signal = baseSignal.uniqueValues()
+				
+				var values: [String] = []
+				signal.observeNext { values.append($0) }
+				
+				expect(values) == []
 
+				observer.sendNext("a")
+				expect(values) == [ "a" ]
+				
+				observer.sendNext("b")
+				expect(values) == [ "a", "b" ]
+				
+				observer.sendNext("a")
+				expect(values) == [ "a", "b" ]
+				
+				observer.sendNext("b")
+				expect(values) == [ "a", "b" ]
+				
+				observer.sendNext("c")
+				expect(values) == [ "a", "b", "c"]
+			}
+		})
+		
 		describe("skipWhile") {
 			var signal: Signal<Int, NoError>!
 			var observer: Signal<Int, NoError>.Observer!

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -650,7 +650,7 @@ class SignalSpec: QuickSpec {
 				expect(values) == [ "a", "b" ]
 				
 				observer.sendNext("c")
-				expect(values) == [ "a", "b", "c"]
+				expect(values) == [ "a", "b", "c" ]
 			}
 		})
 		


### PR DESCRIPTION
Adds a `uniqueValues` function to SignalProducer so that only values that are unique across the entire stream will be sent.

## Rationale

A common operation that I've needed for a recent project is to take only the unique values that come out of a SignalProducer.  In this project I have a data source which returns snapshots are regular intervals, however what I want is only the items that have never been seen before.  I've needed this in several places and so I've generalized it into a pull request.

## Quick Demo

![quickdemo](https://cloud.githubusercontent.com/assets/18454/12878974/91d9b9a8-cde1-11e5-9765-cf9f6dd7ee38.png)

## Work Done

- [x] Code for `uniqueValues`
- [x] Inline documentation
- [x] Tests for `uniqueValues`

## Todo

- [x] Note that this causes values to be retained
- [x] Make accessing and mutating set thread safe
- [x] Fix so that each call to `start` gets its own Set
- [x] Add lifted Signal version

## Feedback

- Is this something that makes sense in the ReactiveCocoa proper?
- Is `uniqueValues` a good name for the operation?
- Is there anything else I can do to make this code feel at home in RAC?

## Thanks

I've been using ReactiveCocoa for the last 6 months and it's changed the way I write applications.  This is my first contribution and I want to say thanks for maintaining a project which has been very useful to me.  🎉