### PR TITLE
Clarify flatten works on both Signal & SignalProducer

### DIFF
--- a/Documentation/BasicOperators.md
+++ b/Documentation/BasicOperators.md
@@ -273,9 +273,9 @@ The `zipWith` operator works in the same way, but as an operator.
 
 ## Flattening producers
 
-The `flatten` operator transforms a `SignalProducer`-of-`SignalProducer`s into a single `SignalProducer` whose values are forwarded from the inner producer in accordance with the provided `FlattenStrategy`.
+The `flatten` operator transforms a stream-of-streams into a single stream - where values are forwarded from the inner stream in accordance with the provided `FlattenStrategy`. The flattened result becomes that of the outer stream type - i.e. a `SignalProducer`-of-`SignalProducer`s or `SignalProducer`-of-`Signal`s gets flattened to a `SignalProducer`, and likewise a `Signal`-of-`SignalProducer`s or `Signal`-of-`Signal`s gets flattened to a `Signal`.   
 
-To understand, why there are different strategies and how they compare to each other, take a look at this example and imagine the column offsets as time:
+To understand why there are different strategies and how they compare to each other, take a look at this example and imagine the column offsets as time:
 
 ```Swift
 let values = [


### PR DESCRIPTION
Flatten technically works on either a SignalProducer-of-SignalProducers or Signal-of-SignalProducers .  

Example: 
```
let (producerA, lettersObserver) = SignalProducer<String, NoError>.buffer(5)
let (producerB, numbersObserver) = SignalProducer<String, NoError>.buffer(5)
let (signal, observer) = Signal<SignalProducer<String, NoError>, NoError>.pipe()

signal.flatten(.Merge)
    .observeNext {next in
    print("merged next: \(next)")
}

observer.sendNext(producerA)
observer.sendNext(producerB)
lettersObserver.sendNext("hi")
numbersObserver.sendNext("1")
```