### PR TITLE
Add inclusive `takeWhile` on `Signal` and `SignalProducer`

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -827,10 +827,13 @@ extension SignalType {
 	/// Forwards any values from `self` until `predicate` returns false,
 	/// at which point the returned signal will complete.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
-	public func takeWhile(predicate: Value -> Bool) -> Signal<Value, Error> {
+	public func takeWhile(inclusive: Bool = false, _ predicate: Value -> Bool) -> Signal<Value, Error> {
 		return Signal { observer in
 			return self.observe { event in
 				if case let .Next(value) = event where !predicate(value) {
+					if inclusive {
+						observer.action(event)
+					}
 					observer.sendCompleted()
 				} else {
 					observer.action(event)

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -679,8 +679,8 @@ extension SignalProducerType {
 	/// Forwards any values from `self` until `predicate` returns false,
 	/// at which point the returned producer will complete.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func takeWhile(predicate: Value -> Bool) -> SignalProducer<Value, Error> {
-		return lift { $0.takeWhile(predicate) }
+	public func takeWhile(inclusive: Bool = false, _ predicate: Value -> Bool) -> SignalProducer<Value, Error> {
+		return lift { $0.takeWhile(inclusive, predicate) }
 	}
 
 	/// Zips elements of two producers into pairs. The elements of any Nth pair

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -631,10 +631,12 @@ class SignalProducerLiftingSpec: QuickSpec {
 		describe("takeWhile") {
 			var producer: SignalProducer<Int, NoError>!
 			var observer: Signal<Int, NoError>.Observer!
+			var inclusive: Bool!
 
 			beforeEach {
+				inclusive = false
 				let (baseProducer, incomingObserver) = SignalProducer<Int, NoError>.buffer(1)
-				producer = baseProducer.takeWhile { $0 <= 4 }
+				producer = baseProducer.takeWhile(inclusive) { $0 <= 4 }
 				observer = incomingObserver
 			}
 
@@ -660,7 +662,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				observer.sendNext(5)
-				expect(latestValue) == 4
+				expect(latestValue) == (inclusive == true ? 5 : 4)
 				expect(completed) == true
 			}
 
@@ -680,6 +682,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				observer.sendNext(5)
+				if inclusive == true {
+					expect(latestValue) == 5
+				} else {
+					expect(latestValue).to(beNil())
+				}
 				expect(latestValue).to(beNil())
 				expect(completed) == true
 			}

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1028,10 +1028,12 @@ class SignalSpec: QuickSpec {
 		describe("takeWhile") {
 			var signal: Signal<Int, NoError>!
 			var observer: Signal<Int, NoError>.Observer!
+			var inclusive: Bool!
 
 			beforeEach {
+				inclusive = false
 				let (baseSignal, incomingObserver) = Signal<Int, NoError>.pipe()
-				signal = baseSignal.takeWhile { $0 <= 4 }
+				signal = baseSignal.takeWhile(inclusive) { $0 <= 4 }
 				observer = incomingObserver
 			}
 
@@ -1057,7 +1059,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				observer.sendNext(5)
-				expect(latestValue) == 4
+				expect(latestValue) == (inclusive == true ? 5 : 4)
 				expect(completed) == true
 			}
 
@@ -1077,7 +1079,11 @@ class SignalSpec: QuickSpec {
 				}
 
 				observer.sendNext(5)
-				expect(latestValue).to(beNil())
+				if inclusive == true {
+					expect(latestValue) == 5
+				} else {
+					expect(latestValue).to(beNil())
+				}
 				expect(completed) == true
 			}
 		}


### PR DESCRIPTION
Sometimes we want to be able to listen to a signal until a value conforms to certain criteria but we want to include this value in the stream before completing.

This PR adds an optional parameter to the `takeWhile` methods on `Signal` and `SignalProducer` to allow us to specify that we want to include the `Value` which fails `predicate`, while (hopefully) maintaining backward compatibility and defaulting to the original non-inclusive behaviour.

Let me know if this is good and if anything should be done differently.