### PR TITLE
rac_notifications shouldn't strongly capture the observed object

### DIFF
--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -14,9 +14,9 @@ import ReactiveCocoa
 class FoundationExtensionsSpec: QuickSpec {
 	override func spec() {
 		describe("NSNotificationCenter.rac_notifications") {
+			let center = NSNotificationCenter.defaultCenter()
 
 			it("should send notifications on the producer") {
-				let center = NSNotificationCenter.defaultCenter()
 				let producer = center.rac_notifications("rac_notifications_test")
 
 				var notif: NSNotification? = nil
@@ -34,6 +34,21 @@ class FoundationExtensionsSpec: QuickSpec {
 				center.postNotificationName("rac_notifications_test", object: nil)
 				expect(notif).to(beNil())
 			}
+
+			it("should send Interrupted when the observed object is freed") {
+				var observedObject: AnyObject? = NSObject()
+				let producer = center.rac_notifications(object: observedObject)
+				observedObject = nil
+
+				var interrupted = false
+				let disposable = producer.startWithInterrupted {
+					interrupted = true
+				}
+				expect(interrupted).to(beTrue())
+
+				disposable.dispose()
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
Other Observer-pattern-style APIs (e.g. `rac_valuesForKey`) weakly reference the observed object; I was surprised to find that `rac_notifications` extended its lifetime.

As an aside (not covered in this revision), I was surprised to find that the subscription wasn’t terminated when the observed object deallocated. I guess that’s because the API supports `AnyObject`, and we can’t observe any arbitrary object for deallocation? We could make a `Signal`-returning variant of this method—with a required `NSObject` observed object argument—which could automatically terminate the underlying effects correctly.