### PR TITLE
Add ScopedCompositeDisposable

### DIFF
--- a/ReactiveCocoaTests/Swift/DisposableSpec.swift
+++ b/ReactiveCocoaTests/Swift/DisposableSpec.swift
@@ -100,6 +100,38 @@ class DisposableSpec: QuickSpec {
 			}
 		}
 
+		describe("ScopedCompositeDisposable") {
+			it("should dispose of the added disposables upon deinitialization") {
+				let simpleDisposable1 = SimpleDisposable()
+				let simpleDisposable2 = SimpleDisposable()
+				var actionDisposableCalled = false
+				
+				func runScoped() {
+					let scopedCompositeDisposable = ScopedCompositeDisposable()
+					// add via += operator
+					scopedCompositeDisposable += simpleDisposable1
+					// add via addDisposable
+					scopedCompositeDisposable.addDisposable(simpleDisposable2)
+					// add disposable action
+					scopedCompositeDisposable.addDisposable {
+						actionDisposableCalled = true
+					}
+					expect(simpleDisposable1.disposed) == false
+					expect(simpleDisposable2.disposed) == false
+					expect(actionDisposableCalled) == false
+					expect(scopedCompositeDisposable.disposed) == false
+				}
+				
+				expect(simpleDisposable1.disposed) == false
+				expect(simpleDisposable2.disposed) == false
+				expect(actionDisposableCalled) == false
+				runScoped()
+				expect(simpleDisposable1.disposed) == true
+				expect(simpleDisposable2.disposed) == true
+				expect(actionDisposableCalled) == true
+			}
+		}
+
 		describe("SerialDisposable") {
 			var disposable: SerialDisposable!
 

--- a/ReactiveCocoaTests/Swift/DisposableSpec.swift
+++ b/ReactiveCocoaTests/Swift/DisposableSpec.swift
@@ -99,21 +99,20 @@ class DisposableSpec: QuickSpec {
 				expect(simpleDisposable.disposed) == true
 			}
 		}
-
-		describe("ScopedCompositeDisposable") {
-			it("should dispose of the added disposables upon deinitialization") {
+			
+		describe("GenericScopedDisposable") {
+			it("should dispose of the added disposables upon deinitialization with CompositeDisposable") {
 				let simpleDisposable1 = SimpleDisposable()
 				let simpleDisposable2 = SimpleDisposable()
 				var actionDisposableCalled = false
 				
 				func runScoped() {
-					let scopedCompositeDisposable = ScopedCompositeDisposable()
+					let scopedCompositeDisposable = GenericScopedDisposable(CompositeDisposable())
 					// add via += operator
 					scopedCompositeDisposable += simpleDisposable1
-					// add via addDisposable
-					scopedCompositeDisposable.addDisposable(simpleDisposable2)
+					scopedCompositeDisposable += simpleDisposable2
 					// add disposable action
-					scopedCompositeDisposable.addDisposable {
+					scopedCompositeDisposable += ActionDisposable {
 						actionDisposableCalled = true
 					}
 					expect(simpleDisposable1.disposed) == false


### PR DESCRIPTION
When I was developing apps with ReactiveCocoa 4, I try to save disposable in a property of the controller, would be like this

```Swift
class MyViewController: UIViewController {
    var bindingDisposable: CompositeDisposable?
    let imageLoader = ImageLoader()

    @IBOutlet weak var myImage: UIImageView!
    @IBOutlet weak var myLabel: UILabel!

    func bindViewModel(viewModel: MyViewModel) {
        self.bindingDisposable?.dispose()
        self.bindingDisposable = CompositeDisposable()
        self.bindingDisposable += (DynamicProperty(object: myImage, keyPath: "image") <~ viewModel.image.producer
            .loadForBinding { [unowned self] url in
                return self.imageLoader.loadImage(url)
            }
        )
        self.bindingDisposable += (DynamicProperty(object: myLabel, keyPath: "text") <~ viewModel.text)
    }
}
```

so that you can dispose all the bindings easily. However, there is a problem in the code shown above, that is if the `loadForBinding` method was called after `MyViewController` got destroyed, as the `unowned self` will be nil, that will raise accessing `self` as a nil error, and end up crashing the app.

To solve the problem, I was trying to use `ScopedDisposable` along with `CompositeDisposable` like this

```Swift
let disposable = CompositeDisposable()
self.bindingDisposable = ScopedDisposable(disposable)
disposable += (DynamicProperty(object: myLabel, keyPath: "text") <~ viewModel.text)
...
```

But it's pretty verbose, so I think it would be nice to have a `ScopedCompositeDisposable`, with that, it would be way easier to manage all binding lifecycle with the `UIViewController`, given the example, just need to change the `bindingDisposable` type to `ScopedCompositeDisposable`, and it's all done.