### PR TITLE
fix leak on lifted sampleOn

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -575,7 +575,7 @@ extension SignalProducerType {
 	/// completed, or interrupt if either input is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func sampleOn(sampler: Signal<(), NoError>) -> SignalProducer<Value, Error> {
-		return lift(Signal.sampleOn)(sampler)
+		return liftLeft(Signal.sampleOn)(SignalProducer(signal: sampler))
 	}
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed


### PR DESCRIPTION
## Issue

in following code
```swift
SignalProducer<FooObject, NoError>(value: FooObject()).sampleOn(sample).start().dispose()
```

`FooObject` will live since sampler will not deallocate

## Reason

in `Signal.sampleOn` code:

```swift
public func sampleOn(sampler: Signal<(), NoError>) -> Signal<Value, Error> {
		return Signal { observer in
			let state = Atomic(SampleState<Value>())
			let disposable = CompositeDisposable()
			disposable += self.observe { event in
				switch event {
				case let .Next(value):
					state.modify { st in
						var mutableSt = st
						mutableSt.latestValue = value
						return mutableSt
					}
				case let .Failed(error):
					observer.sendFailed(error)
				case .Completed:
					let oldState = state.modify { st in
						var mutableSt = st
						mutableSt.signalCompleted = true
						return mutableSt
					}			
					if oldState.samplerCompleted {
						observer.sendCompleted()
					}
				case .Interrupted:
					observer.sendInterrupted()
				}
			}
			disposable += sampler.observe { event in
				switch event {
				case .Next:
					if let value = state.value.latestValue {
						observer.sendNext(value)
					}
				case .Completed:
					let oldState = state.modify { st in
						var mutableSt = st
						mutableSt.samplerCompleted = true
						return mutableSt
					}	
					if oldState.signalCompleted {
						observer.sendCompleted()
					}
				case .Interrupted:
					observer.sendInterrupted()
				default:
					break
				}
			}
			return disposable
		}
	}
```

when `self` received `Complete` event - it will not react for `Interrupted` event - and in this case `state` will live unchanged until any event from `sampler`.

Let's looks closer to `lift` implementation from `SignalProducer`

```swift
	public func lift<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> Signal<U, F> -> SignalProducer<V, G> {
		return { otherSignal in
			return SignalProducer { observer, outerDisposable in
				self.startWithSignal { signal, disposable in
					outerDisposable += disposable
					outerDisposable += transform(signal)(otherSignal).observe(observer)
				}
			}
		}
	}
```

what happening with `Signal` produced by `transform(signal)(otherSignal)`?
Actually - it captured by it's observer in creation block in `sampleOn`, that captured in `self.observe` and in `sampler.observe` blocks.
The main problem is that `sample.observe` capture `observer` that capture `signal` that capture `sample.observe` - so even if we dispose `outerDisposable` - sampleOn inner state will not be freed until `sampler.observe` will not receive interruption event.

## Why fix helps?

```swift 
	private func liftLeft<U, F, V, G>(transform: Signal<Value, Error> -> Signal<U, F> -> Signal<V, G>) -> SignalProducer<U, F> -> SignalProducer<V, G> {
		return { otherProducer in
			return SignalProducer { observer, outerDisposable in
				otherProducer.startWithSignal { otherSignal, otherDisposable in
					outerDisposable.addDisposable(otherDisposable)
					
					self.startWithSignal { signal, disposable in
						outerDisposable.addDisposable(disposable)

						transform(signal)(otherSignal).observe(observer)
					}
				}
			}
		}
	}
```

in this code `otherSignal` that we pass into `sampleOn` as `sampler` just created on start of pipeline - and destroyed on dispose in `startWithSignal` - and that is destroy second binding in sampleOn, that causing deallocation of `signal` produced by `transform(signal)(otherSignal)` that holding state.

## For discussion

I think there is a major problem with `lift` abstraction in current implementation.

For 'cold' `SignalProducers` every `Signal` within is temporary object, that lifetime totally described by single `Disposable` returning by `SignalProducer` instance.
But `sampleOn` - is a perfect example when lifted function significantly changes `Signal`'s lifetime and does not provide any way to broke it.
Actually, line 
```swift
outerDisposable += transform(signal)(otherSignal).observe(observer)
``` 
hides that `transform` result could depends on `signal` or `otherSignal` lifetime - and if we dispose it - we only stop observe, but not stop transform.

Another implementations of lift wrap `Signals` to `SignalProducers`, that resolves a problem - but i suggest to remove this implementation of lift, cause it potentially buggy.