### PR TITLE
Drop `SignalProducer.buffer(1)` in MutableProperty

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -95,9 +95,11 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// underlying producer prevents sending recursive events.
 	private let lock: NSRecursiveLock
 
-	/// The getter and setter of the underlying storage, which could outlive
-	/// the property if any of the returned producer is being retained.
+	/// The getter of the underlying storage, which may outlive the property
+	/// if a returned producer is being retained.
 	private let getter: () -> Value
+
+	/// The setter of the underlying storage.
 	private let setter: Value -> Void
 
 	/// The current value of the property.

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -95,8 +95,8 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// underlying producer prevents sending recursive events.
 	private let lock: NSRecursiveLock
 
-	/// The getter and setter of the underlying storage. It could outlive
-	/// the property if any of the returned producer is retained.
+	/// The getter and setter of the underlying storage, which could outlive
+	/// the property if any of the returned producer is being retained.
 	private let getter: () -> Value
 	private let setter: Value -> Void
 
@@ -122,7 +122,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// followed by all changes over time, then complete when the property has
 	/// deinitialized.
 	public var producer: SignalProducer<Value, NoError> {
-		return SignalProducer { [getter, setter, lock, weak self] producerObserver, producerDisposable in
+		return SignalProducer { [getter, lock, weak self] producerObserver, producerDisposable in
 			lock.lock()
 			defer { lock.unlock() }
 
@@ -145,7 +145,6 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		setter = { newValue in value = newValue }
 
 		(signal, observer) = Signal.pipe()
-		observer.sendNext(initialValue)
 	}
 
 	/// Atomically replaces the contents of the variable.

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -144,6 +144,8 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		var value = initialValue
 
 		lock = NSRecursiveLock()
+		lock.name = "org.reactivecocoa.ReactiveCocoa.MutableProperty"
+
 		getter = { value }
 		setter = { newValue in value = newValue }
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -246,6 +246,23 @@ class PropertySpec: QuickSpec {
 				property.value = 1
 				expect(value) == 1
 			}
+
+			it("should not deadlock on recursive ABA observation") {
+				let propertyA = MutableProperty(0)
+				let propertyB = MutableProperty(0)
+
+				var value: Int?
+				propertyA.producer.startWithNext { _ in
+					propertyB.producer.startWithNext { _ in
+						propertyA.producer.startWithNext { x in value = x }
+					}
+				}
+
+				expect(value) == 0
+
+				propertyA.value = 1
+				expect(value) == 1
+			}
 		}
 
 		describe("AnyProperty") {


### PR DESCRIPTION
Preceded by @olegshnitko's #2744.

Goals:

Drop the use of `SignalProducer.buffer(1)` in `MutableProperty` without breaking the perceived semantic, and consequently allow signal recursion in MutableProperty.

Caveats:

1. The source of truth of a `MutableProperty` is now a pair of get-set closures which capture an underlying storage. The getter is retained until all generated producers and the property itself have been released.
2. Less locks in `MutableProperty`!
3. Included the signal recursion test case from #2744.