### PR TITLE
Add SignalProducer equivalents for UIKit RACSignal extensions

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		02D2602B1C1D6DB8003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
+		43047EA31CA1A75A00B82CB6 /* SignalProducerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43047EA11CA1A75A00B82CB6 /* SignalProducerExtensions.swift */; };
+		43047EA01CA1A55800B82CB6 /* UIKitExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43047E9F1CA1A55800B82CB6 /* UIKitExtensions.swift */; };
 		579504331BB8A34200A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		579504341BB8A34300A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		57A4D1B11BA13D7A00F7D4B1 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
@@ -794,6 +796,8 @@
 		02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalLifetimeSpec.swift; sourceTree = "<group>"; };
 		314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		43047EA11CA1A75A00B82CB6 /* SignalProducerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProducerExtensions.swift; sourceTree = "<group>"; };
+		43047E9F1CA1A55800B82CB6 /* UIKitExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitExtensions.swift; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A4D2441BA13F9700F7D4B1 /* tvOS-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Application.xcconfig"; sourceTree = "<group>"; };
 		57A4D2451BA13F9700F7D4B1 /* tvOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -1496,6 +1500,7 @@
 		D03B4A3A19F4C26D009E02AC /* Internal Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				43047EA11CA1A75A00B82CB6 /* SignalProducerExtensions.swift */,
 				D00004081A46864E000E7D41 /* TupleExtensions.swift */,
 			);
 			name = "Internal Utilities";
@@ -1505,6 +1510,7 @@
 			isa = PBXGroup;
 			children = (
 				D03B4A3C19F4C39A009E02AC /* FoundationExtensions.swift */,
+				43047E9F1CA1A55800B82CB6 /* UIKitExtensions.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2587,8 +2593,10 @@
 				D037657D19EDA41200A782A9 /* RACEagerSequence.m in Sources */,
 				D037657919EDA41200A782A9 /* RACDynamicSignal.m in Sources */,
 				D037659519EDA41200A782A9 /* RACImmediateScheduler.m in Sources */,
+				43047EA31CA1A75A00B82CB6 /* SignalProducerExtensions.swift in Sources */,
 				D037651719EDA41200A782A9 /* NSObject+RACDeallocating.m in Sources */,
 				D037658519EDA41200A782A9 /* RACEmptySignal.m in Sources */,
+				43047EA01CA1A55800B82CB6 /* UIKitExtensions.swift in Sources */,
 				D037663719EDA41200A782A9 /* UIDatePicker+RACSignalSupport.m in Sources */,
 				D08C54B71A69A3DB00AD8286 /* Event.swift in Sources */,
 				D037654719EDA41200A782A9 /* NSURLConnection+RACSupport.m in Sources */,

--- a/ReactiveCocoa/Swift/SignalProducerExtensions.swift
+++ b/ReactiveCocoa/Swift/SignalProducerExtensions.swift
@@ -1,0 +1,21 @@
+//
+//  SignalProducerExtensions.swift
+//  ReactiveCocoa
+//
+//  Created by Nate Stedman on 3/22/16.
+//  Copyright © 2016 GitHub. All rights reserved.
+//
+
+import enum Result.NoError
+
+extension SignalProducer {
+	func demoteErrors() -> SignalProducer<Value, NoError> {
+		return flatMapError { _ in SignalProducer<Value, NoError>.empty }
+	}
+}
+
+extension SignalProducer {
+	func constrainToType<T>(type: T.Type) -> SignalProducer<T, Error> {
+		return map({ $0 as? T }).ignoreNil()
+	}
+}

--- a/ReactiveCocoa/Swift/UIKitExtensions.swift
+++ b/ReactiveCocoa/Swift/UIKitExtensions.swift
@@ -66,3 +66,20 @@ extension TextSignalProvidingType {
 			.map { $0 as? String }
 	}
 }
+
+// MARK: - gestureProducer
+public protocol GestureSignalProvidingType {
+	func rac_gestureSignal() -> RACSignal!
+}
+
+extension UIGestureRecognizer: GestureSignalProvidingType {}
+
+extension GestureSignalProvidingType {
+	/// Returns a signal producer that sends the receiver when its gesture occurs.
+	public var gestureProducer: SignalProducer<Self, NoError> {
+		return rac_gestureSignal().toSignalProducer()
+			.demoteErrors()
+			.map { $0 as? Self }
+			.ignoreNil()
+	}
+}

--- a/ReactiveCocoa/Swift/UIKitExtensions.swift
+++ b/ReactiveCocoa/Swift/UIKitExtensions.swift
@@ -27,3 +27,21 @@ extension PrepareForReuseSignalProvidingType {
 			.map { _ in () }
 	}
 }
+
+// MARK: - producerForControlEvents
+public protocol SignalForControlEventsProvidingType {
+	func rac_signalForControlEvents(controlEvents: UIControlEvents) -> RACSignal!
+}
+
+extension UIControl: SignalForControlEventsProvidingType {}
+
+extension SignalForControlEventsProvidingType {
+	/// Creates a signal producer that sends the sender of the control event
+	/// whenever one of the control events is triggered.
+	public func producerForControlEvents(controlEvents: UIControlEvents) -> SignalProducer<Self, NoError> {
+		return rac_signalForControlEvents(controlEvents).toSignalProducer()
+			.demoteErrors()
+			.map { $0 as? Self }
+			.ignoreNil()
+	}
+}

--- a/ReactiveCocoa/Swift/UIKitExtensions.swift
+++ b/ReactiveCocoa/Swift/UIKitExtensions.swift
@@ -1,0 +1,29 @@
+//
+//  UIKitExtensions.swift
+//  ReactiveCocoa
+//
+//  Created by Nate Stedman on 3/22/16.
+//  Copyright © 2016 GitHub. All rights reserved.
+//
+
+import UIKit
+import enum Result.NoError
+
+// MARK: - prepareForReuse
+public protocol PrepareForReuseSignalProvidingType {
+	var rac_prepareForReuseSignal: RACSignal! { get }
+}
+
+extension UICollectionReusableView: PrepareForReuseSignalProvidingType {}
+extension UITableViewCell: PrepareForReuseSignalProvidingType {}
+extension UITableViewHeaderFooterView: PrepareForReuseSignalProvidingType {}
+
+extension PrepareForReuseSignalProvidingType {
+	/// A signal producer which will send `()` whenever -prepareForReuse is invoked
+	/// upon the receiver.
+	public var prepareForReuseProducer: SignalProducer<(), NoError> {
+		return rac_prepareForReuseSignal.toSignalProducer()
+			.demoteErrors()
+			.map { _ in () }
+	}
+}

--- a/ReactiveCocoa/Swift/UIKitExtensions.swift
+++ b/ReactiveCocoa/Swift/UIKitExtensions.swift
@@ -45,3 +45,24 @@ extension SignalForControlEventsProvidingType {
 			.ignoreNil()
 	}
 }
+
+// MARK: - textProducer
+public protocol TextSignalProvidingType {
+	func rac_textSignal() -> RACSignal!
+}
+
+extension UITextField: TextSignalProvidingType {}
+extension UITextView: TextSignalProvidingType {}
+
+extension TextSignalProvidingType {
+	/// Creates and returns a signal producer for the text of the receiver,
+	/// starting with the current text.
+	///
+	/// For underlying behavior and potential side-effects, see the
+	/// documentation for the receiver's implementation of `rac_textSignal`.
+	var textProducer: SignalProducer<String?, NoError> {
+		return rac_textSignal().toSignalProducer()
+			.demoteErrors()
+			.map { $0 as? String }
+	}
+}


### PR DESCRIPTION
This pull request adds `SignalProducer` equivalents for `RACSignal` extensions to `UI`-prefixed classes. There are a few exceptions:

- `UIActionSheet` - this class is deprecated.
- `UIAlertView` - this class is deprecated.
- `UIImagePickerController` - I feel like this whole thing deserves a better Swift API than just sending a dictionary of `String` to `AnyObject`. I think this is better handled by a dedicated µframework, especially once the Swift Package Manager goes mainstream and those become very easy to use and consume.

I've added protocol types for each signal-providing category message that is wrapped. The `SignalProducer` implementations are then written as extensions of those protocols. This allows classes providing a similar signal to reuse the same implementation (e.g. `prepareForReuse`), and, more importantly, allows `SignalProducer` `Value` types to be `Self`. For example, a simple implementation of the `UIGestureRecognizer` extension would be:

```swift
extension UIGestureRecognizer {
	/// Returns a signal producer that sends the receiver when its gesture occurs.
	public var gestureProducer: SignalProducer<Self, NoError> {
		return rac_gestureSignal().toSignalProducer()
			.demoteErrors()
			.map { $0 as? Self }
			.ignoreNil()
	}
}
```

That's not valid Swift right now, but it's important to have the actual type of the gesture recognizer, not just `UIGestureRecognizer`, so that subclass properties and methods can be accessed. Instead, using a protocol:

```swift
public protocol GestureSignalProvidingType {
	func rac_gestureSignal() -> RACSignal!
}

extension UIGestureRecognizer: GestureSignalProvidingType {}

extension GestureSignalProvidingType {
	/// Returns a signal producer that sends the receiver when its gesture occurs.
	public var gestureProducer: SignalProducer<Self, NoError> {
		return rac_gestureSignal().toSignalProducer()
			.demoteErrors()
			.map { $0 as? Self }
			.ignoreNil()
	}
}
```

Works correctly - `panGestureRecognizer.gestureProducer` is of type `SignalProducer<UIPanGestureRecognizer, NoError>`.

----

Right now there aren't any tests for this, because the version of `Nimble` referenced by `master` won't build in Xcode 7.3 - once that is fixed, I can add tests for these producers.