### PR TITLE
Inject side effect on next and failed

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -547,6 +547,12 @@ extension SignalType {
 	func doNext(sideEffect: SideEffect) -> Signal<Self.Value, Self.Error> {
 		return self.on(event: nil, failed: nil, completed: nil, interrupted: nil, terminated: nil, disposed: nil, next: sideEffect)
 	}
+	
+	@warn_unused_result(message="Did you forget to call `start` on the signal?")
+	typealias SideEffectFailed = (Self.Error) -> ()
+	func doFailed(sideEffect: SideEffectFailed) -> Signal<Self.Value, Self.Error> {
+		return self.on(event: nil, failed: sideEffect, completed: nil, interrupted: nil, terminated: nil, disposed: nil, next: nil)
+	}
 }
 
 private struct SampleState<Value> {

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -540,6 +540,13 @@ extension SignalType {
 			return disposable
 		}
 	}
+	
+	/// Injects side effects to be performed upon the specified signal events.
+	typealias SideEffect = (Self.Value) -> ()
+	@warn_unused_result(message="Did you forget to call `start` on the signal?")
+	func doNext(sideEffect: SideEffect) -> Signal<Self.Value, Self.Error> {
+		return self.on(event: nil, failed: nil, completed: nil, interrupted: nil, terminated: nil, disposed: nil, next: sideEffect)
+	}
 }
 
 private struct SampleState<Value> {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -844,6 +844,13 @@ extension SignalProducerType {
 			}
 		}
 	}
+	
+	/// Injects side effects to be performed upon the specified signal events.
+	typealias SideEffect = (Value) -> ()
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	func doNext(sideEffect: SideEffect) -> SignalProducer<Self.Value, Self.Error> {
+		return self.on(started: nil, event: nil, failed: nil, completed: nil, interrupted: nil, terminated: nil, disposed: nil, next: sideEffect)
+	}
 
 	/// Starts the returned signal on the given Scheduler.
 	///

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -846,10 +846,17 @@ extension SignalProducerType {
 	}
 	
 	/// Injects side effects to be performed upon the specified signal events.
-	typealias SideEffect = (Value) -> ()
+	typealias SideEffect = (Self.Value) -> ()
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	func doNext(sideEffect: SideEffect) -> SignalProducer<Self.Value, Self.Error> {
 		return self.on(started: nil, event: nil, failed: nil, completed: nil, interrupted: nil, terminated: nil, disposed: nil, next: sideEffect)
+	}
+	
+	/// Injects side effects to be performed upon the specified signal events.
+	typealias SideEffectFailed = (Self.Error) -> ()
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	func doFailed(sideEffect: SideEffectFailed) -> SignalProducer<Self.Value, Self.Error> {
+		return self.on(started: nil, event: nil, failed: sideEffect, completed: nil, interrupted: nil, terminated: nil, disposed: nil, next: nil)
 	}
 
 	/// Starts the returned signal on the given Scheduler.


### PR DESCRIPTION
Side effect on Next and Failed is very popular. It's more convenient than `on` if need only one status

example:

`producer.on(next: bar.foo))`

or

`producer.doNext(bar.foo)`