### PR TITLE
Add Property map operator

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -60,6 +60,17 @@ public struct AnyProperty<Value>: PropertyType {
 	}
 }
 
+extension PropertyType {
+	/// Maps the current value and all subsequent values to a new value.
+	public func map<U>(transform: Value -> U) -> AnyProperty<U> {
+		let mappedProducer = SignalProducer<U, NoError> { observer, disposable in
+			disposable += ActionDisposable { self }
+			disposable += self.producer.map(transform).start(observer)
+		}
+		return AnyProperty(initialValue: transform(value), producer: mappedProducer)
+	}
+}
+
 /// A property that never changes.
 public struct ConstantProperty<Value>: PropertyType {
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -520,6 +520,20 @@ class PropertySpec: QuickSpec {
 			}
 		}
 
+		describe("map") {
+			it("should transform the current value and all subsequent values") {
+				let property = MutableProperty(1)
+				let mappedProperty = property
+					.map { $0 + 1 }
+					.map { $0 + 2 }
+
+				expect(mappedProperty.value) == 4
+
+				property.value = 2
+				expect(mappedProperty.value) == 5
+			}
+		}
+
 		describe("binding") {
 			describe("from a Signal") {
 				it("should update the property with values sent from the signal") {


### PR DESCRIPTION
I need a way to map the current value of a property and all subsequent values to a new read-only property.

To achieve this, currently one has to map the current value and the signal/signal producer separately:
```
let name = MutableProperty("")
let transform = { !$0.isEmpty }
let nameValid = AnyProperty(initialValue: transform(name.value), signal: name.signal.map(transform))
```
This seems like a lot of code for what essentially is mapping a property.

Alternatively one can bind the signal producer of `name` to `nameValid`:
```
let name = MutableProperty("")
let nameValid = MutableProperty(false)
nameValid <~ name.producer.map { !$0.isEmpty }
```
The downside to this approach is that I have to supply an initial value for `nameValid` even though it will be overridden immediately after by the binding operator.
Also `nameValid` needs to be a `MutableProperty`.

I think it would be useful to introduce a `map` operator for properties.

To-dos:
- [x] Add unit tests.
- [x] Add inline documentation.
- [x] Squash WIP commits.