### PR TITLE
Add sampleWith method

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -551,7 +551,15 @@ private struct SampleState<Value> {
 }
 
 extension SignalType {
-	// TODO: fix the doc here
+	/// Forwards the latest value from `self` with the value from `sampler` as a tuple,
+	/// only when`sampler` sends a Next event.
+	///
+	/// If `sampler` fires before a value has been observed on `self`, nothing
+	/// happens.
+	///
+	/// Returns a signal that will send values from `self` and `sampler`, sampled (possibly
+	/// multiple times) by `sampler`, then complete once both input signals have
+	/// completed, or interrupt if either input signal is interrupted.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func sampleWith<T>(sampler: Signal<T, NoError>) -> Signal<(Value, T), Error> {
 		return Signal { observer in
@@ -610,13 +618,13 @@ extension SignalType {
 		}
 	}
 	
-	/// Forwards the latest value from `signal` whenever `sampler` sends a Next
+	/// Forwards the latest value from `self` whenever `sampler` sends a Next
 	/// event.
 	///
-	/// If `sampler` fires before a value has been observed on `signal`, nothing
+	/// If `sampler` fires before a value has been observed on `self`, nothing
 	/// happens.
 	///
-	/// Returns a signal that will send values from `signal`, sampled (possibly
+	/// Returns a signal that will send values from `self`, sampled (possibly
 	/// multiple times) by `sampler`, then complete once both input signals have
 	/// completed, or interrupt if either input signal is interrupted.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -579,6 +579,18 @@ extension SignalProducerType {
 		return lift { $0.materialize() }
 	}
 
+	// TODO: fix doc here
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func sampleWith<T>(sampler: SignalProducer<T, NoError>) -> SignalProducer<(Value, T), Error> {
+		return liftLeft(Signal.sampleWith)(sampler)
+	}
+	
+	// TODO: fix doc here
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func sampleWith<T>(sampler: Signal<T, NoError>) -> SignalProducer<(Value, T), Error> {
+		return lift(Signal.sampleWith)(sampler)
+	}
+
 	/// Forwards the latest value from `self` whenever `sampler` sends a Next
 	/// event.
 	///

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -579,13 +579,29 @@ extension SignalProducerType {
 		return lift { $0.materialize() }
 	}
 
-	// TODO: fix doc here
+	/// Forwards the latest value from `self` with the value from `sampler` as a tuple,
+	/// only when`sampler` sends a Next event.
+	///
+	/// If `sampler` fires before a value has been observed on `self`, nothing
+	/// happens.
+	///
+	/// Returns a producer that will send values from `self` and `sampler`, sampled (possibly
+	/// multiple times) by `sampler`, then complete once both input producers have
+	/// completed, or interrupt if either input producer is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func sampleWith<T>(sampler: SignalProducer<T, NoError>) -> SignalProducer<(Value, T), Error> {
 		return liftLeft(Signal.sampleWith)(sampler)
 	}
 	
-	// TODO: fix doc here
+	/// Forwards the latest value from `self` with the value from `sampler` as a tuple,
+	/// only when`sampler` sends a Next event.
+	///
+	/// If `sampler` fires before a value has been observed on `self`, nothing
+	/// happens.
+	///
+	/// Returns a producer that will send values from `self` and `sampler`, sampled (possibly
+	/// multiple times) by `sampler`, then complete once both inputs have
+	/// completed, or interrupt if either input is interrupted.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func sampleWith<T>(sampler: Signal<T, NoError>) -> SignalProducer<(Value, T), Error> {
 		return lift(Signal.sampleWith)(sampler)

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -580,7 +580,7 @@ extension SignalProducerType {
 	}
 
 	/// Forwards the latest value from `self` with the value from `sampler` as a tuple,
-	/// only when`sampler` sends a Next event.
+	/// only when `sampler` sends a Next event.
 	///
 	/// If `sampler` fires before a value has been observed on `self`, nothing
 	/// happens.
@@ -594,7 +594,7 @@ extension SignalProducerType {
 	}
 	
 	/// Forwards the latest value from `self` with the value from `sampler` as a tuple,
-	/// only when`sampler` sends a Next event.
+	/// only when `sampler` sends a Next event.
 	///
 	/// If `sampler` fires before a value has been observed on `self`, nothing
 	/// happens.


### PR DESCRIPTION
This pull request adds a new `sampleWith` method which acts exactly the same as `sampleOn`, except it pass along with the next event value from the given sampler.

## Rationale

I found myself very frequently need this method when I was developing a game-ish app. The basic scenario is that I have a clock signal looks like

`Signal<NSDate, NoError>`

It's basically emitted from `CADisplayLink` or other signal for syncing with display

and I have some properties of game objects, say like position

```Swift
class Player {
    let position: AnyProperty<CGPoint>
    /// ...
}
```

To display the game object position, I need to sample the game object's position when I see a next event emit from `CADisplayLink`. And also, very often, I need to know the current game clock from that `CADisplayLink` signal.

Another case is sometimes, I want to do some async operations for a game object along with another signal. In this case, I tried to use `combineLatestWith`

```Swift
focusObject.producer
    .combineLatestWith(activeEffect)
    .flatMap { (object, effect) in
        // .... apply effect on object
    }
```

but the problem in this case is, I want `activeEffect` to only affect current `focusObject`, but not a new object just becomes the focus. With `combineLatestWith`, when `focusObject` is changed, it also emits a next event, will end up also consuming the `activeEffect`.

To solve the problem I can use `sampleWith`.

```Swift
focusObject.producer
    .sampleWith(activeEffect)
    .flatMap { (object, effect) in
        // .... apply effect on object
    }
```

I don't care how `focusObject` changes, I only care if the `activeEffect` changes, then it should sample the object and apply on it.

There are also lots of cases like this, the scenario is pretty much like, I only want to sample the signal when another signal emits, but I also need the value from the another signal.

## TODOs

- [x] Add documents for `sampleWith`

## Discussion

Not sure why `sampleOn` was designed to not to carry any value, but it kinda limits what you can do with it as if you need the value from the sampler. I tried to implement this with compositions of different operations as simple as possible, but still not as easy to just modify `sampleOn` method, to make it carry out the next value, and make `sampleOn` just dropping the value. Maybe I missed something, is there actually an easy way to make `sampleOn` carrying the sampler value? If it's the case, not sure is it worthwhile to add this operation. What do you guys think about this?