### PR TITLE
fix memory leak caused by unremoved disposable object

### DIFF
--- a/ReactiveCocoa/Objective-C/UIControl+RACSignalSupport.m
+++ b/ReactiveCocoa/Objective-C/UIControl+RACSignalSupport.m
@@ -25,12 +25,15 @@
 			@strongify(self);
 
 			[self addTarget:subscriber action:@selector(sendNext:) forControlEvents:controlEvents];
-			[self.rac_deallocDisposable addDisposable:[RACDisposable disposableWithBlock:^{
+
+			RACDisposable *disposable = [RACDisposable disposableWithBlock:^{
 				[subscriber sendCompleted];
-			}]];
+			}];
+			[self.rac_deallocDisposable addDisposable:disposable];
 
 			return [RACDisposable disposableWithBlock:^{
 				@strongify(self);
+				[self.rac_deallocDisposable removeDisposable:disposable];
 				[self removeTarget:subscriber action:@selector(sendNext:) forControlEvents:controlEvents];
 			}];
 		}]


### PR DESCRIPTION
Fix "Memory leak" caused by unremoved disposable object in UIControl, after calling `rac_signalForControlEvents` and `dispose` over and over again.

See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2787 for more detail.