### PR TITLE
Confusing unused line removed

### DIFF
--- a/ReactiveCocoa/Objective-C/RACStream.m
+++ b/ReactiveCocoa/Objective-C/RACStream.m
@@ -80,7 +80,6 @@
 }
 
 - (instancetype)flatten {
-	__weak RACStream *stream __attribute__((unused)) = self;
 	return [[self flattenMap:^(id value) {
 		return value;
 	}] setNameWithFormat:@"[%@] -flatten", self.name];


### PR DESCRIPTION
Long time ago there was an assert. But now it's removed.

Source:
https://github.com/ReactiveCocoa/ReactiveCocoa/commit/594d7abcdd2faae6388d3bd6f3898f2a1cf091df?diff=split