### PR TITLE
extend CompositeDisposable with optional disposables sequence

### DIFF
--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -103,10 +103,16 @@ public final class CompositeDisposable: Disposable {
 
 		self.disposables = Atomic(bag)
 	}
+	
+	/// Initializes a CompositeDisposable containing the given sequence of
+	/// disposables.
+	public convenience init<S: SequenceType where S.Generator.Element == Disposable?>(_ disposables: S) {
+		self.init(disposables.flatMap { $0 })
+	}
 
 	/// Initializes an empty CompositeDisposable.
 	public convenience init() {
-		self.init([])
+		self.init([Disposable]())
 	}
 
 	public func dispose() {


### PR DESCRIPTION
What's in this pull request?

This PR extends CompositeDisposable that can be initialized with sequence of optional disposables.