### PR TITLE
Convinience Initializer

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -218,6 +218,14 @@ public final class CocoaAction: NSObject {
 	public convenience init<Input, Output, Error>(_ action: Action<Input, Output, Error>, input: Input) {
 		self.init(action, { _ in input })
 	}
+	
+	/// Initializes a Cocoa action that will invoke the given Action
+	/// with the input provided on `execute`. The provided input should have
+	/// the same type as the `Action`'s `Input` parameter.
+    public convenience init<Input, Output, Error>(_ action: Action<Input, Output, Error>) {
+		let identity: AnyObject? -> Input = { $0 as! Input }
+		self.init(action, identity)
+	}
 
 	deinit {
 		disposable.dispose()

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -222,7 +222,7 @@ public final class CocoaAction: NSObject {
 	/// Initializes a Cocoa action that will invoke the given Action
 	/// with the input provided on `execute`. The provided input should have
 	/// the same type as the `Action`'s `Input` parameter.
-    public convenience init<Input, Output, Error>(_ action: Action<Input, Output, Error>) {
+	public convenience init<Input, Output, Error>(_ action: Action<Input, Output, Error>) {
 		let identity: AnyObject? -> Input = { $0 as! Input }
 		self.init(action, identity)
 	}

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -52,7 +52,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 	/// it unsafe for use when the action is parameterized for something like `Void`
 	/// input. In those cases, explicitly assign a value to this property that transforms
 	/// the input to suit your needs.
-	public lazy var unsafeCocoaAction: CocoaAction = CocoaAction(self) { $0 as! Input }
+	public lazy var unsafeCocoaAction: CocoaAction = CocoaAction(self)
 
 	/// This queue is used for read-modify-write operations on the `_executing`
 	/// property.


### PR DESCRIPTION
I have a particular case where the the `CocoaAction` sits on the ViewModel and the VM is injected into the `UIViewController`. The `CocoaAction`'s input is the `UIViewController` itself. ( the[ FB SDK asks for a `UIViewController` for login)](https://developers.facebook.com/docs/facebook-login/ios/permissions). Their example:

```objc
- (void)viewDidLoad {
  [super viewDidLoad];
    if ([FBSDKAccessToken currentAccessToken]) {
       // TODO:Token is already available.
    }
}
// ....
FBSDKLoginManager *loginManager = [[FBSDKLoginManager alloc] init];
[loginManager logInWithReadPermissions:@[@"email"]
                    fromViewController:self
                               handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
  //TODO: process error or result
 }];
```
I am guessing other people might have similar needs. 