### PR TITLE
Extend `collect` with a count-based and a predicate-based version

### DIFF
--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -334,10 +334,10 @@ scopedExample("`observeOn`") {
 }
 
 /*:
- ### `collect`
- Returns a signal that will yield an array of values when `signal` completes.
+ ### `collect()`
+ Returns a producer that will yield an array of values until it completes.
  */
-scopedExample("`collect`") {
+scopedExample("`collect()`") {
     
     SignalProducer<Int, NoError> { observer, disposable in
         observer.sendNext(1)
@@ -347,6 +347,73 @@ scopedExample("`collect`") {
         observer.sendCompleted()
         }
         .collect()
+        .startWithNext { value in
+            print(value)
+    }
+}
+
+/*:
+ ### `collect(count:)`
+ Returns a producer that will yield an array of values until it reaches a certain count.
+ */
+scopedExample("`collect(count:)`") {
+
+    SignalProducer<Int, NoError> { observer, disposable in
+        observer.sendNext(1)
+        observer.sendNext(2)
+        observer.sendNext(3)
+        observer.sendNext(4)
+        observer.sendCompleted()
+        }
+        .collect(count: 2)
+        .startWithNext { value in
+            print(value)
+    }
+}
+
+/*:
+ ### ``collect(predicate:)` matching values inclusively`
+ Returns a producer that will yield an array of values based on a predicate
+ which matches the values collected.
+
+ When producer completes any remaining values will be sent, the last values
+ array may not match `predicate`. Alternatively, if were not collected any
+ values will sent an empty array of values.
+ */
+scopedExample("`collect(predicate:)` matching values inclusively") {
+
+    SignalProducer<Int, NoError> { observer, disposable in
+        observer.sendNext(1)
+        observer.sendNext(2)
+        observer.sendNext(3)
+        observer.sendNext(4)
+        observer.sendCompleted()
+        }
+        .collect { values in values.reduce(0, combine: +) == 3 }
+        .startWithNext { value in
+            print(value)
+    }
+}
+
+/*:
+ ### `collect(count:) matching values exclusively
+ Returns a producer that will yield an array of values based on a predicate
+ which matches the values collected and the next value.
+ 
+ When producer completes any remaining values will be sent, the last values
+ array may not match `predicate`. Alternatively, if were not collected any
+ values will sent an empty array of values.
+ */
+scopedExample("`collect(predicate:)` matching values exclusively") {
+
+    SignalProducer<Int, NoError> { observer, disposable in
+        observer.sendNext(1)
+        observer.sendNext(2)
+        observer.sendNext(3)
+        observer.sendNext(4)
+        observer.sendCompleted()
+        }
+        .collect { values, next in next == 3 }
         .startWithNext { value in
             print(value)
     }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -554,8 +554,8 @@ extension SignalProducerType {
 	///     // [7]
 	///     // [5, 6]
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func collect(predicate: (values: [Value], next: Value) -> Bool) -> SignalProducer<[Value], Error> {
-		return lift { $0.collect(predicate) }
+	public func collect(strategy: CollectStrategy, predicate: (values: [Value], next: Value) -> Bool) -> SignalProducer<[Value], Error> {
+		return lift { $0.collect(strategy, predicate: predicate) }
 	}
 
 	/// Forwards all events onto the given scheduler, instead of whichever

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -509,10 +509,53 @@ extension SignalProducerType {
 		return lift { $0.take(count) }
 	}
 
-	/// Returns a signal that will yield an array of values when `signal` completes.
+	/// Returns a producer that will yield an array of values when `self` completes.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func collect() -> SignalProducer<[Value], Error> {
 		return lift { $0.collect() }
+	}
+
+	/// Returns a producer that will yield an array of values until it reaches a
+	/// certain count.
+	///
+	/// When the count is reached the array is sent and the producer starts over
+	/// yielding a new array of values.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func collect(count: Int) -> SignalProducer<[Value], Error> {
+		return lift { $0.collect(count) }
+	}
+
+	/// Returns a producer that will yield an array of values based on a predicate.
+	///
+	/// The predicate should return `true` when the values should be sent and `false`
+	/// when the values should be collected. The predicate receives the `values`
+	/// already collected and the next value that should or should not be
+	/// collected.
+	///
+	/// #### Example
+	///
+	///     let (producer, observer) = SignalProducer<Int, NoError>.buffer(1)
+	///
+	///     producer
+	///         .collect { values, next in next != 7 }
+	///         .startWithNext { print($0) }
+	///
+	///     observer.sendNext(1)
+	///     observer.sendNext(1)
+	///     observer.sendNext(7)
+	///     observer.sendNext(7)
+	///     observer.sendNext(5)
+	///     observer.sendNext(6)
+	///     observer.sendCompleted()
+	///
+	///     // Output:
+	///     // [1, 1]
+	///     // [7]
+	///     // [7]
+	///     // [5, 6]
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func collect(predicate: (values: [Value], next: Value) -> Bool) -> SignalProducer<[Value], Error> {
+		return lift { $0.collect(predicate) }
 	}
 
 	/// Forwards all events onto the given scheduler, instead of whichever


### PR DESCRIPTION
This supersedes #2817 and resolves #2815.

This PR extends `collect` with two new operators:
- yield an array of values until it reaches a certain count
  - `collect(count: Int)`
- yield an array of values based on a predicate
  - `collect(predicate: (values: [Value], next: Value) -> Bool)`
