### PR TITLE
playground: fix printing of tuples

### DIFF
--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -345,7 +345,7 @@ scopedExample("`combineLatestWith`") {
     
     producer1.combineLatestWith(producer2)
         .startWithNext { value in
-            print(value)
+            print("\(value)")
     }
 }
 
@@ -420,7 +420,7 @@ scopedExample("`combinePrevious`") {
     SignalProducer<Int, NoError>(values: [1,2,3,4])
         .combinePrevious(42)
         .startWithNext { value in
-            print(value)
+            print("\(value)")
     }
 }
 
@@ -556,7 +556,7 @@ scopedExample("`zipWith`") {
     baseProducer
         .zipWith(zippedProducer)
         .startWithNext { value in
-            print(value)
+            print("\(value)")
     }
 }
 


### PR DESCRIPTION
The SignalProducer Playground does not execute for me with at places where tuple-values are printed:

<img width="921" alt="screen shot 2016-05-03 at 09 46 41" src="https://cloud.githubusercontent.com/assets/3407787/14977485/7f59c8b0-1114-11e6-8dd1-cee20a03463b.png">

```
Playground execution failed: SignalProducer.xcplaygroundpage:417:13: error: 'print' is unavailable: Please wrap your tuple argument in parentheses: 'print((...))'
            print(value)
            ^~~~~
Swift.print:2:13: note: 'print' has been explicitly marked unavailable here
public func print<T>(_: T)
```

I'm not sure why that is, I've tried this in another playground which works just fine:

```swift
let tuple = (1, 2)
print(tuple)
```

Cleaning the project and deleting Derived Data did not help 😃 
Using string interpolation at these places fixes the problem for me.