### PR TITLE
Playground subscription behaviour examples

### DIFF
--- a/ReactiveCocoa.playground/Pages/Signal.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/Signal.xcplaygroundpage/Contents.swift
@@ -43,6 +43,34 @@ import Foundation
  */
 
 /*:
+ ### `Subscription`
+ A Signal represents and event stream that is already "in progress", sometimes also called "hot". This means, that a subscriber may miss events that have been sent before the subscription.
+ Furthermore, the subscription to a signal does not trigger any side effects
+ */
+scopedExample("Subscription") {
+    // Signal.pipe is a way to manually control a signal. the returned observer can be used to send values to the signal
+    let (signal, observer) = Signal<Int, NoError>.pipe()
+    
+    let subscriber1 = Observer<Int, NoError>(next: { print("Subscriber 1 received \($0)") })
+    let subscriber2 = Observer<Int, NoError>(next: { print("Subscriber 2 received \($0)") })
+    
+    print("Subscriber 1 subscribes to the signal")
+    signal.observe(subscriber1)
+    
+    print("Send value `10` on the signal")
+    // subscriber1 will receive the value
+    observer.sendNext(10)
+    
+    print("Subscriber 2 subscribes to the signal")
+    // Notice how nothing happens at this moment, i.e. subscriber2 does not receive the previously sent value
+    signal.observe(subscriber2)
+    
+    print("Send value `20` on the signal")
+    // Notice that now, subscriber1 and subscriber2 will receive the value
+    observer.sendNext(20)
+}
+
+/*:
  ### `empty`
  A Signal that completes immediately without emitting any value.
  */

--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -42,6 +42,29 @@ import Foundation
  */
 
 /*:
+ ### `Subscription`
+ A SignalProducer represents an operation that can be started on demand. Starting the operation returns a Signal on which the result(s) of the operation can be observed. This behavior is sometimes also called "cold". 
+This means that a subscriber will never miss any valus sent by the SignalProducer.
+ */
+scopedExample("Subscription") {
+    let producer = SignalProducer<Int, NoError>({ (observer, _) in
+        print("New subscription, starting operation")
+        observer.sendNext(1)
+        observer.sendNext(2)
+    })
+    
+    let subscriber1 = Observer<Int, NoError>(next: { print("Subscriber 1 received \($0)") })
+    let subscriber2 = Observer<Int, NoError>(next: { print("Subscriber 2 received \($0)") })
+
+    print("Subscriber 1 subscribes to producer")
+    producer.start(subscriber1)
+
+    print("Subscriber 2 subscribes to producer")
+    // Notice, how the producer will start the work again
+    producer.start(subscriber2)
+}
+
+/*:
  ### `empty`
  A producer for a Signal that will immediately complete without sending
  any values.


### PR DESCRIPTION
These examples illustrate the different behaviours at subscription between `Signal` and `SignalProducer`

The `Signal` example produces the following output:

```
--- Subscription ---

Subscriber 1 subscribes to the signal
Send value `10` on the signal
Subscriber 1 received 10
Subscriber 2 subscribes to the signal
Send value `20` on the signal
Subscriber 1 received 20
Subscriber 2 received 20
```

The `SignalProducer` example produces the following output: 

```
--- Subscription ---

Subscriber 1 subscribes to producer
New subscription, starting operation
Subscriber 1 received 1
Subscriber 1 received 2
Subscriber 2 subscribes to producer
New subscription, starting operation
Subscriber 2 received 1
Subscriber 2 received 2
```