### PR TITLE
rac_notifications update redux

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" ~> 0.9
 github "Quick/Quick" ~> 0.9.2
-github "Quick/Nimble" ~> 4.0
+github "Quick/Nimble" ~> 4.0.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v4.0.0"
+github "Quick/Nimble" "v4.0.1"
 github "Quick/Quick" "v0.9.2"
 github "antitypical/Result" "2.0.0"
 github "jspahrsummers/xcconfigs" "0.9"

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -23,8 +23,16 @@ private extension NSObject {
 
 extension NSNotificationCenter {
 	/// Returns a producer of notifications posted that match the given criteria.
-	/// This producer will not terminate naturally, so it must be explicitly
-	/// disposed to avoid leaks.
+	///
+	/// If the `object` is an instance of non-`NSObject` classes and the instance
+	/// is deallocated before starting the producer, the producer will terminate
+	/// immediatelly with an .Interrupted event.
+	///
+	/// If the `object` is `NSObject`, the producer will terminate automatically
+	/// when the given object is deallocated.
+	///
+	/// Otherwise, the producer will not terminate naturally, so it must be
+	/// explicitly disposed to avoid leaks.
 	public func rac_notifications(name: String? = nil, object: AnyObject? = nil) -> SignalProducer<NSNotification, NoError> {
 		// We're weakly capturing an optional reference here, which makes destructuring awkward.
 		let objectWasNil = (object == nil)

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -30,16 +30,17 @@ extension NSNotificationCenter {
 		let objectWasNil = (object == nil)
 
 		let producer = SignalProducer<NSNotification, NoError> { [weak object] observer, disposable in
-			if object != nil || objectWasNil {
-				let notificationObserver = self.addObserverForName(name, object: object, queue: nil) { notification in
-					observer.sendNext(notification)
-				}
-
-				disposable.addDisposable {
-					self.removeObserver(notificationObserver)
-				}
-			} else {
+			guard object != nil || objectWasNil else {
 				observer.sendInterrupted()
+				return
+			}
+
+			let notificationObserver = self.addObserverForName(name, object: object, queue: nil) { notification in
+				observer.sendNext(notification)
+			}
+
+			disposable.addDisposable {
+				self.removeObserver(notificationObserver)
 			}
 		}
 

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -9,6 +9,18 @@
 import Foundation
 import enum Result.NoError
 
+private extension NSObject {
+	var willDeallocProducer: SignalProducer<(), NoError> {
+		return rac_willDeallocSignal()
+			.toSignalProducer()
+			.map { _ in () }
+			.mapError { error in
+				fatalError("Unexpected error: \(error)")
+				()
+		}
+	}
+}
+
 extension NSNotificationCenter {
 	/// Returns a producer of notifications posted that match the given criteria.
 	/// This producer will not terminate naturally, so it must be explicitly
@@ -16,7 +28,8 @@ extension NSNotificationCenter {
 	public func rac_notifications(name: String? = nil, object: AnyObject? = nil) -> SignalProducer<NSNotification, NoError> {
 		// We're weakly capturing an optional reference here, which makes destructuring awkward.
 		let objectWasNil = (object == nil)
-		return SignalProducer { [weak object] observer, disposable in
+
+		let producer = SignalProducer<NSNotification, NoError> { [weak object] observer, disposable in
 			if object != nil || objectWasNil {
 				let notificationObserver = self.addObserverForName(name, object: object, queue: nil) { notification in
 					observer.sendNext(notification)
@@ -28,6 +41,12 @@ extension NSNotificationCenter {
 			} else {
 				observer.sendInterrupted()
 			}
+		}
+
+		if let object = object as? NSObject {
+			return producer.takeUntil(object.willDeallocProducer)
+		} else {
+			return producer
 		}
 	}
 }

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -14,9 +14,9 @@ import ReactiveCocoa
 class FoundationExtensionsSpec: QuickSpec {
 	override func spec() {
 		describe("NSNotificationCenter.rac_notifications") {
+			let center = NSNotificationCenter.defaultCenter()
 
 			it("should send notifications on the producer") {
-				let center = NSNotificationCenter.defaultCenter()
 				let producer = center.rac_notifications("rac_notifications_test")
 
 				var notif: NSNotification? = nil
@@ -34,6 +34,21 @@ class FoundationExtensionsSpec: QuickSpec {
 				center.postNotificationName("rac_notifications_test", object: nil)
 				expect(notif).to(beNil())
 			}
+
+			it("should send Interrupted when the observed object is freed") {
+				var observedObject: AnyObject? = NSObject()
+				let producer = center.rac_notifications(object: observedObject)
+				observedObject = nil
+
+				var interrupted = false
+				let disposable = producer.startWithInterrupted {
+					interrupted = true
+				}
+				expect(interrupted).to(beTrue())
+
+				disposable.dispose()
+			}
+
 		}
 	}
 }

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -52,7 +52,7 @@ class FoundationExtensionsSpec: QuickSpec {
 			}
 
 			context("observing NSObject-derived objects") {
-				it("should send Completed when the observed object is freed before resulting producer is started") {
+				it("should send Completed when the observed object is freed before the resulting producer is started") {
 					var observedObject: AnyObject? = NSObject()
 					let producer = center.rac_notifications(object: observedObject)
 					observedObject = nil
@@ -66,7 +66,7 @@ class FoundationExtensionsSpec: QuickSpec {
 					disposable.dispose()
 				}
 
-				it("should send Completed when the observed object is freed after resulting producer is started") {
+				it("should send Completed when the observed object is freed after the resulting producer is started") {
 					var observedObject: AnyObject? = NSObject()
 					let producer = center.rac_notifications(object: observedObject)
 


### PR DESCRIPTION
Supersedes #2747.

I've added `takeUntil` to the returned producer only when the given object is `NSObject`. The specs are updated accordingly.