### PR TITLE
rac_notifications update redux

### DIFF
--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -17,16 +17,17 @@ extension NSNotificationCenter {
 		// We're weakly capturing an optional reference here, which makes destructuring awkward.
 		let objectWasNil = (object == nil)
 		return SignalProducer { [weak object] observer, disposable in
-			if object != nil || objectWasNil {
-				let notificationObserver = self.addObserverForName(name, object: object, queue: nil) { notification in
-					observer.sendNext(notification)
-				}
-
-				disposable.addDisposable {
-					self.removeObserver(notificationObserver)
-				}
-			} else {
+			guard object != nil || objectWasNil else {
 				observer.sendInterrupted()
+				return
+			}
+
+			let notificationObserver = self.addObserverForName(name, object: object, queue: nil) { notification in
+				observer.sendNext(notification)
+			}
+
+			disposable.addDisposable {
+				self.removeObserver(notificationObserver)
 			}
 		}
 	}

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -11,8 +11,10 @@ import enum Result.NoError
 
 extension NSNotificationCenter {
 	/// Returns a producer of notifications posted that match the given criteria.
-	/// This producer will not terminate naturally, so it must be explicitly
-	/// disposed to avoid leaks.
+	/// If the `object` is deallocated before starting the producer, it will 
+	/// terminate immediatelly with an Interrupted event. Otherwise, the producer
+	/// will not terminate naturally, so it must be explicitly disposed to avoid
+	/// leaks.
 	public func rac_notifications(name: String? = nil, object: AnyObject? = nil) -> SignalProducer<NSNotification, NoError> {
 		// We're weakly capturing an optional reference here, which makes destructuring awkward.
 		let objectWasNil = (object == nil)

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -14,9 +14,9 @@ import ReactiveCocoa
 class FoundationExtensionsSpec: QuickSpec {
 	override func spec() {
 		describe("NSNotificationCenter.rac_notifications") {
+			let center = NSNotificationCenter.defaultCenter()
 
 			it("should send notifications on the producer") {
-				let center = NSNotificationCenter.defaultCenter()
 				let producer = center.rac_notifications("rac_notifications_test")
 
 				var notif: NSNotification? = nil
@@ -34,6 +34,21 @@ class FoundationExtensionsSpec: QuickSpec {
 				center.postNotificationName("rac_notifications_test", object: nil)
 				expect(notif).to(beNil())
 			}
+
+			it("should send Interrupted when the observed object is freed") {
+				var observedObject: AnyObject? = NSObject()
+				let producer = center.rac_notifications(object: observedObject)
+				observedObject = nil
+
+				var interrupted = false
+				let disposable = producer.startWithInterrupted {
+					interrupted = true
+				}
+				expect(interrupted).to(beTrue())
+
+				disposable.dispose()
+			}
+
 		}
 	}
 }

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -44,7 +44,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				let disposable = producer.startWithInterrupted {
 					interrupted = true
 				}
-				expect(interrupted).to(beTrue())
+				expect(interrupted) == true
 
 				disposable.dispose()
 			}


### PR DESCRIPTION
Supersedes #2747 and #2854.

Gave up the `takeUntil` approach (which is originally suggested in #2747) as discussed in #2854.
