### PR TITLE
DynamicProperty operators tweaks

### DIFF
--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -66,3 +66,20 @@ import enum Result.NoError
 			}
 	}
 }
+
+// MARK: Operators
+
+/// Binds a signal to a `DynamicProperty`, automatically bridging values to Objective-C.
+public func <~ <S: SignalType where S.Value: _ObjectiveCBridgeable, S.Error == NoError>(property: DynamicProperty, signal: S) -> Disposable {
+	return property <~ signal.map { $0._bridgeToObjectiveC() }
+}
+
+/// Binds a signal producer to a `DynamicProperty`, automatically bridging values to Objective-C.
+public func <~ <S: SignalProducerType where S.Value: _ObjectiveCBridgeable, S.Error == NoError>(property: DynamicProperty, producer: S) -> Disposable {
+	return property <~ producer.map { $0._bridgeToObjectiveC() }
+}
+
+/// Binds `destinationProperty` to the latest values of `sourceProperty`, automatically bridging values to Objective-C.
+public func <~ <Source: PropertyType where Source.Value: _ObjectiveCBridgeable>(destinationProperty: DynamicProperty, sourceProperty: Source) -> Disposable {
+	return destinationProperty <~ sourceProperty.producer
+}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -253,22 +253,6 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 }
 
 
-/// Binds a signal to a `DynamicProperty`, automatically bridging values to Objective-C.
-public func <~ <S: SignalType where S.Value: _ObjectiveCBridgeable, S.Error == NoError>(property: DynamicProperty, signal: S) -> Disposable {
-	return property <~ signal.map { $0._bridgeToObjectiveC() }
-}
-
-/// Binds a signal producer to a `DynamicProperty`, automatically bridging values to Objective-C.
-public func <~ <S: SignalProducerType where S.Value: _ObjectiveCBridgeable, S.Error == NoError>(property: DynamicProperty, producer: S) -> Disposable {
-	return property <~ producer.map { $0._bridgeToObjectiveC() }
-}
-
-/// Binds `destinationProperty` to the latest values of `sourceProperty`, automatically bridging values to Objective-C.
-public func <~ <Source: PropertyType where Source.Value: _ObjectiveCBridgeable>(destinationProperty: DynamicProperty, sourceProperty: Source) -> Disposable {
-	return destinationProperty <~ sourceProperty.producer
-}
-
-
 /// Binds `destinationProperty` to the latest values of `sourceProperty`.
 ///
 /// The binding will automatically terminate when either property is

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -254,17 +254,17 @@ public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.
 
 
 /// Binds a signal to a `DynamicProperty`, automatically bridging values to Objective-C.
-public func <~ <Value: _ObjectiveCBridgeable>(property: DynamicProperty, signal: Signal<Value, NoError>) -> Disposable {
+public func <~ <S: SignalType where S.Value: _ObjectiveCBridgeable, S.Error == NoError>(property: DynamicProperty, signal: S) -> Disposable {
 	return property <~ signal.map { $0._bridgeToObjectiveC() }
 }
 
 /// Binds a signal producer to a `DynamicProperty`, automatically bridging values to Objective-C.
-public func <~ <Value: _ObjectiveCBridgeable>(property: DynamicProperty, producer: SignalProducer<Value, NoError>) -> Disposable {
+public func <~ <S: SignalProducerType where S.Value: _ObjectiveCBridgeable, S.Error == NoError>(property: DynamicProperty, producer: S) -> Disposable {
 	return property <~ producer.map { $0._bridgeToObjectiveC() }
 }
 
 /// Binds `destinationProperty` to the latest values of `sourceProperty`, automatically bridging values to Objective-C.
-public func <~ <Value: _ObjectiveCBridgeable, Source: PropertyType where Source.Value == Value>(destinationProperty: DynamicProperty, sourceProperty: Source) -> Disposable {
+public func <~ <Source: PropertyType where Source.Value: _ObjectiveCBridgeable>(destinationProperty: DynamicProperty, sourceProperty: Source) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }
 


### PR DESCRIPTION
- Use `SignalType` / `SignalProducerType` and generic constraints for `DynamicProperty` operators
- Factor out the operators into `DynamicProperty.swift`
