### PR TITLE
Display playgrounds as rendered by default, so more people will grok RAC

### DIFF
--- a/ReactiveCocoa.playground/contents.xcplayground
+++ b/ReactiveCocoa.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='osx' display-mode='raw'>
+<playground version='6.0' target-platform='osx' display-mode='rendered'>
     <pages>
         <page name='SignalProducer'/>
         <page name='Signal'/>


### PR DESCRIPTION
Hope this isn't too controversial.  I ummed and ahhed about adding a line to the preamble of each playground to "get to raw mode" for those who didn't like the default rendered mode but ended up not doing that for the fact that if you _really_ are the kind of person who wants to see the raw text of an Xcode playground, you won't need help finding the `Show Raw Markup` button/checkbox.

side note: happy to bounce a couple of ideas around with respect to the `Schedulers` and `Properties` playground pages which you're still working on.  I definitely have a fresh set of eyes when it comes to FRP so am able to provide n00b commentary :)