### PR TITLE
[RFC] Add type-safe method lifting with weak reference semantics

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		4A3F079F1CDD089B00E568D3 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */; };
 		4A3F07A01CDD089C00E568D3 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */; };
 		4A3F07A11CDD089D00E568D3 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */; };
+		4A3F07A31CE00C1200E568D3 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07A21CE00C1200E568D3 /* Bindable.swift */; };
+		4A3F07A41CE00C1200E568D3 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07A21CE00C1200E568D3 /* Bindable.swift */; };
+		4A3F07A51CE00C1200E568D3 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07A21CE00C1200E568D3 /* Bindable.swift */; };
+		4A3F07A61CE00C1200E568D3 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07A21CE00C1200E568D3 /* Bindable.swift */; };
 		579504331BB8A34200A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		579504341BB8A34300A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		57A4D1B11BA13D7A00F7D4B1 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
@@ -907,6 +911,7 @@
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
 		4A3F07951CDD074500E568D3 /* Method.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
 		4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodSpec.swift; sourceTree = "<group>"; };
+		4A3F07A21CE00C1200E568D3 /* Bindable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bindable.swift; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A4D2441BA13F9700F7D4B1 /* tvOS-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Application.xcconfig"; sourceTree = "<group>"; };
 		57A4D2451BA13F9700F7D4B1 /* tvOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -1612,6 +1617,7 @@
 			isa = PBXGroup;
 			children = (
 				D08C54AF1A69A2AC00AD8286 /* Action.swift */,
+				4A3F07A21CE00C1200E568D3 /* Bindable.swift */,
 				CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */,
 				D85C65291C0D84C7005A77AD /* Flatten.swift */,
 				4A3F07951CDD074500E568D3 /* Method.swift */,
@@ -2406,6 +2412,7 @@
 				57A4D1F31BA13D7A00F7D4B1 /* RACScopedDisposable.m in Sources */,
 				57A4D1F41BA13D7A00F7D4B1 /* RACSequence.m in Sources */,
 				57A4D1F51BA13D7A00F7D4B1 /* RACSerialDisposable.m in Sources */,
+				4A3F07A61CE00C1200E568D3 /* Bindable.swift in Sources */,
 				57A4D1F61BA13D7A00F7D4B1 /* RACSignal.m in Sources */,
 				57D476921C4206DF00EFE697 /* UISegmentedControl+RACSignalSupport.m in Sources */,
 				57A4D1F71BA13D7A00F7D4B1 /* RACSignal+Operations.m in Sources */,
@@ -2579,6 +2586,7 @@
 				A9B3159D1B3940750001CB9C /* RACSubject.m in Sources */,
 				A9B3159E1B3940750001CB9C /* RACSubscriber.m in Sources */,
 				A9B3159F1B3940750001CB9C /* RACSubscriptingAssignmentTrampoline.m in Sources */,
+				4A3F07A51CE00C1200E568D3 /* Bindable.swift in Sources */,
 				A9B315A01B3940750001CB9C /* RACSubscriptionScheduler.m in Sources */,
 				A9B315A11B3940750001CB9C /* RACTargetQueueScheduler.m in Sources */,
 				A9B315A21B3940750001CB9C /* RACTestScheduler.m in Sources */,
@@ -2635,6 +2643,7 @@
 				D037654E19EDA41200A782A9 /* RACArraySequence.m in Sources */,
 				D037652219EDA41200A782A9 /* NSObject+RACLifting.m in Sources */,
 				D037650619EDA41200A782A9 /* NSIndexSet+RACSequenceAdditions.m in Sources */,
+				4A3F07A31CE00C1200E568D3 /* Bindable.swift in Sources */,
 				D037650E19EDA41200A782A9 /* NSNotificationCenter+RACSupport.m in Sources */,
 				D03765FA19EDA41200A782A9 /* RACSubscriptionScheduler.m in Sources */,
 				D85C652A1C0D84C7005A77AD /* Flatten.swift in Sources */,
@@ -2873,6 +2882,7 @@
 				D037652B19EDA41200A782A9 /* NSObject+RACSelectorSignal.m in Sources */,
 				D03765AF19EDA41200A782A9 /* RACPassthroughSubscriber.m in Sources */,
 				D03765BD19EDA41200A782A9 /* RACReturnSignal.m in Sources */,
+				4A3F07A41CE00C1200E568D3 /* Bindable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -11,6 +11,13 @@
 		02D2602B1C1D6DB8003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
+		4A3F07961CDD074500E568D3 /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07951CDD074500E568D3 /* Method.swift */; };
+		4A3F07971CDD074500E568D3 /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07951CDD074500E568D3 /* Method.swift */; };
+		4A3F07981CDD074500E568D3 /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07951CDD074500E568D3 /* Method.swift */; };
+		4A3F07991CDD074500E568D3 /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F07951CDD074500E568D3 /* Method.swift */; };
+		4A3F079F1CDD089B00E568D3 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */; };
+		4A3F07A01CDD089C00E568D3 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */; };
+		4A3F07A11CDD089D00E568D3 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */; };
 		579504331BB8A34200A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		579504341BB8A34300A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		57A4D1B11BA13D7A00F7D4B1 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
@@ -898,6 +905,8 @@
 		02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalLifetimeSpec.swift; sourceTree = "<group>"; };
 		314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		4A3F07951CDD074500E568D3 /* Method.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
+		4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodSpec.swift; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A4D2441BA13F9700F7D4B1 /* tvOS-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Application.xcconfig"; sourceTree = "<group>"; };
 		57A4D2451BA13F9700F7D4B1 /* tvOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -1605,6 +1614,7 @@
 				D08C54AF1A69A2AC00AD8286 /* Action.swift */,
 				CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */,
 				D85C65291C0D84C7005A77AD /* Flatten.swift */,
+				4A3F07951CDD074500E568D3 /* Method.swift */,
 				D08C54B01A69A2AC00AD8286 /* Property.swift */,
 				D08C54B11A69A2AC00AD8286 /* Signal.swift */,
 				D08C54B21A69A2AC00AD8286 /* SignalProducer.swift */,
@@ -1790,6 +1800,7 @@
 				D0C312EF19EF2A7700984962 /* BagSpec.swift */,
 				D0C312F019EF2A7700984962 /* DisposableSpec.swift */,
 				D8170FC01B100EBC004192AD /* FoundationExtensionsSpec.swift */,
+				4A3F079A1CDD07EE00E568D3 /* MethodSpec.swift */,
 				D0A226101A72F30B00D33B74 /* ObjectiveCBridgingSpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */,
 				D0C312F219EF2A7700984962 /* SchedulerSpec.swift */,
@@ -2314,6 +2325,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A3F07991CDD074500E568D3 /* Method.swift in Sources */,
 				57A4D1B11BA13D7A00F7D4B1 /* Optional.swift in Sources */,
 				57D476951C4206EC00EFE697 /* UITableViewCell+RACSignalSupport.m in Sources */,
 				57A4D1B21BA13D7A00F7D4B1 /* RACCompoundDisposableProvider.d in Sources */,
@@ -2443,6 +2455,7 @@
 				7DFBED391CDB8DE300EE435B /* NSObjectRACPropertySubscribingSpec.m in Sources */,
 				7DFBED3A1CDB8DE300EE435B /* NSObjectRACSelectorSignalSpec.m in Sources */,
 				7DFBED3B1CDB8DE300EE435B /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,
+				4A3F07A11CDD089D00E568D3 /* MethodSpec.swift in Sources */,
 				7DFBED3D1CDB8DE300EE435B /* NSUserDefaultsRACSupportSpec.m in Sources */,
 				7DFBED3E1CDB8DE300EE435B /* RACBlockTrampolineSpec.m in Sources */,
 				7DFBED401CDB8DE300EE435B /* RACChannelExamples.m in Sources */,
@@ -2550,6 +2563,7 @@
 				A9B3158F1B3940750001CB9C /* RACObjCRuntime.m in Sources */,
 				A9B315901B3940750001CB9C /* RACPassthroughSubscriber.m in Sources */,
 				A9B315911B3940750001CB9C /* RACQueueScheduler.m in Sources */,
+				4A3F07981CDD074500E568D3 /* Method.swift in Sources */,
 				A9B315921B3940750001CB9C /* RACReplaySubject.m in Sources */,
 				A9B315931B3940750001CB9C /* RACReturnSignal.m in Sources */,
 				A9B315941B3940750001CB9C /* RACScheduler.m in Sources */,
@@ -2643,6 +2657,7 @@
 				D037659019EDA41200A782A9 /* RACGroupedSignal.m in Sources */,
 				D037655E19EDA41200A782A9 /* RACChannel.m in Sources */,
 				D037657C19EDA41200A782A9 /* RACEagerSequence.m in Sources */,
+				4A3F07961CDD074500E568D3 /* Method.swift in Sources */,
 				D037657819EDA41200A782A9 /* RACDynamicSignal.m in Sources */,
 				D037659419EDA41200A782A9 /* RACImmediateScheduler.m in Sources */,
 				7A7065811A3F88B8001E8354 /* RACKVOProxy.m in Sources */,
@@ -2704,6 +2719,7 @@
 				CA6F28501C52626B001879D2 /* FlattenSpec.swift in Sources */,
 				D037670119EDA60000A782A9 /* RACSubclassObject.m in Sources */,
 				D03766CD19EDA60000A782A9 /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,
+				4A3F079F1CDD089B00E568D3 /* MethodSpec.swift in Sources */,
 				D037671519EDA60000A782A9 /* RACTupleSpec.m in Sources */,
 				D03766C519EDA60000A782A9 /* NSObjectRACLiftingSpec.m in Sources */,
 				D03766D119EDA60000A782A9 /* NSURLConnectionRACSupportSpec.m in Sources */,
@@ -2757,6 +2773,7 @@
 				D43F27A31A9F7E8A00C1AD76 /* RACDynamicPropertySuperclass.m in Sources */,
 				D8E84A671B3B32FB00C3E831 /* Optional.swift in Sources */,
 				D03764EB19EDA41200A782A9 /* NSArray+RACSequenceAdditions.m in Sources */,
+				4A3F07971CDD074500E568D3 /* Method.swift in Sources */,
 				D0C312D419EF2A5800984962 /* Disposable.swift in Sources */,
 				D03765C119EDA41200A782A9 /* RACScheduler.m in Sources */,
 				D037662B19EDA41200A782A9 /* UICollectionReusableView+RACSignalSupport.m in Sources */,
@@ -2886,6 +2903,7 @@
 				D0C3132319EF2D9700984962 /* RACTestSchedulerSpec.m in Sources */,
 				D03766C419EDA60000A782A9 /* NSObjectRACDeallocatingSpec.m in Sources */,
 				D03766BE19EDA60000A782A9 /* NSEnumeratorRACSequenceAdditionsSpec.m in Sources */,
+				4A3F07A01CDD089C00E568D3 /* MethodSpec.swift in Sources */,
 				D037672019EDA60000A782A9 /* UIButtonRACSupportSpec.m in Sources */,
 				D0C3132519EF2D9700984962 /* RACTestUIButton.m in Sources */,
 				D037670219EDA60000A782A9 /* RACSubclassObject.m in Sources */,

--- a/ReactiveCocoa/Swift/Bindable.swift
+++ b/ReactiveCocoa/Swift/Bindable.swift
@@ -1,0 +1,60 @@
+import enum Result.NoError
+
+infix operator <~ {
+	associativity right
+
+	// Binds tighter than assignment but looser than everything else
+	precedence 93
+}
+
+public protocol Bindable {
+	associatedtype Input
+
+	/// An optional signal that should trigger a binding to be terminated
+	/// by sending a `Completed` event.
+	///
+	/// For example, this could represent the underlying object of a bound
+	/// property being deallocated.
+	var complete: Signal<(), NoError>? { get }
+
+	/// For every value sent on `signal`, update the destination value.
+	///
+	/// A binding may automatically terminate when the `complete` signal terminates.
+	/// A binding must automatically terminate the signal sends a `Completed` event.
+	func <~ (bindable: Self, signal: Signal<Input, NoError>) -> Disposable
+
+	/// Creates a signal from the given producer, which will be immediately bound to
+	/// the destination, updating its value to the latest value sent by the signal.
+	///
+	/// A binding may automatically terminate when the `complete` signal terminates.
+	/// A binding must automatically terminate the signal sends a `Completed` event.
+	func <~ (bindable: Self, signal: SignalProducer<Input, NoError>) -> Disposable
+}
+
+/// Creates a signal from the given producer, which will be immediately bound to
+/// the destination, updating its value to the latest value sent by the signal.
+///
+/// The binding will automatically terminate if the `complete` signal sends a `Completed` event,
+/// or when the created signal sends a `Completed` event.
+public func <~ <B: Bindable>(bindable: B, producer: SignalProducer<B.Input, NoError>) -> Disposable {
+	var disposable: Disposable!
+
+	producer.startWithSignal { signal, signalDisposable in
+		disposable = signalDisposable
+		bindable <~ signal
+
+		bindable.complete?.observeCompleted {
+			signalDisposable.dispose()
+		}
+	}
+
+	return disposable
+}
+
+/// Binds `bindable` to the latest values of `sourceProperty`.
+///
+/// The binding will automatically terminate when its `complete` signal
+/// sends a `Completed` event, or when `sourceProperty` terminates.
+public func <~ <B: Bindable, P: PropertyType where P.Value == B.Input>(bindable: B, sourceProperty: P) -> Disposable {
+	return bindable <~ sourceProperty.producer
+}

--- a/ReactiveCocoa/Swift/Method.swift
+++ b/ReactiveCocoa/Swift/Method.swift
@@ -1,0 +1,103 @@
+import Result
+
+public protocol MethodType: class {
+	associatedtype Object: AnyObject
+	associatedtype Input
+	associatedtype Output
+
+	weak var object: Object? { get }
+	var function: (Object, Input) -> Output { get }
+}
+
+public extension MethodType {
+	func call(input: Input) -> Output? {
+		return object.map { function($0, input) }
+	}
+
+	func lift(with signal: Signal<Input, NoError>) -> Signal<Output, NoError> {
+		if object == nil {
+			return Signal { observer in
+				observer.sendInterrupted()
+				return nil
+			}
+		}
+
+		return signal
+			.map(call)
+			.materialize()
+			.map { event -> Event<Output?, NoError> in
+				if case .Next(.None) = event {
+					return .Interrupted
+				} else {
+					return event
+				}
+			}
+			.dematerialize()
+			.ignoreNil()
+	}
+
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	func lifted(with producer: SignalProducer<Input, NoError>) -> SignalProducer<Output, NoError> {
+		return _lifted(method: self, with: producer, lift: self.lift)
+	}
+}
+
+/// Implementation detail of overloads for `MethodType.lifted(with:)`.
+@_transparent private func _lifted<Method: MethodType>(method method: Method, with producer: SignalProducer<Method.Input, NoError>, lift: Signal<Method.Input, NoError> -> Signal<Method.Output, NoError>) -> SignalProducer<Method.Output, NoError> {
+	return SignalProducer { [weak method] observer, disposable in
+		guard method != nil else {
+			observer.sendInterrupted()
+			return
+		}
+
+		producer.startWithSignal { signal, signalDisposable in
+			disposable += signalDisposable
+			disposable += lift(signal).observe(observer)
+		}
+	}
+}
+
+public final class Method<Object: AnyObject, Input, Output>: MethodType {
+	public private(set) weak var object: Object?
+	public let function: (Object, Input) -> Output
+
+	public init(object: Object?, function: (Object, Input) -> Output) {
+		self.object = object
+		self.function = function
+	}
+
+	public init(object: Object?, function: Object -> Input -> Output) {
+		self.object = object
+		self.function = { object, input in function(object)(input) }
+	}
+}
+
+#if _runtime(_ObjC)
+public extension MethodType where Object: NSObject {
+	func lift(with signal: Signal<Input, NoError>) -> Signal<Output, NoError> {
+		guard let object: NSObject = object else { return .empty }
+
+		let (deallocated, deallocatedObserver) = Signal<(), NoError>.pipe()
+		object.rac_deallocDisposable.addDisposable(RACDisposable(block: deallocatedObserver.sendCompleted))
+
+		return signal
+			.takeUntil(deallocated)
+			.materialize()
+			.map { event -> Event<Input, NoError> in
+				if case .Completed = event {
+					return .Interrupted
+				} else {
+					return event
+				}
+			}
+			.dematerialize()
+			.map(call)
+			.ignoreNil()
+	}
+
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	func lifted(with producer: SignalProducer<Input, NoError>) -> SignalProducer<Output, NoError> {
+		return _lifted(method: self, with: producer, lift: self.lift)
+	}
+}
+#endif

--- a/ReactiveCocoaTests/Swift/MethodSpec.swift
+++ b/ReactiveCocoaTests/Swift/MethodSpec.swift
@@ -192,7 +192,7 @@ final class MethodSpec: QuickSpec {
 					object = nil
 
 					var interrupted = false
-					method.lifted(with: .empty).startWithInterrupted { interrupted = true }
+					method.lifted(with: SignalProducer<Int, NoError>.empty).startWithInterrupted { interrupted = true }
 
 					expect(interrupted) == true
 				}
@@ -254,7 +254,7 @@ final class MethodSpec: QuickSpec {
 					object = nil
 
 					var interrupted = false
-					method.lifted(with: .empty).startWithInterrupted { interrupted = true }
+					method.lifted(with: SignalProducer<Int, NoError>.empty).startWithInterrupted { interrupted = true }
 
 					expect(interrupted) == true
 				}

--- a/ReactiveCocoaTests/Swift/MethodSpec.swift
+++ b/ReactiveCocoaTests/Swift/MethodSpec.swift
@@ -1,0 +1,279 @@
+import ReactiveCocoa
+import Result
+import Quick
+import Nimble
+
+final class MethodSpec: QuickSpec {
+	override func spec() {
+		describe("object") {
+			it("is weakly referenced") {
+				let method: ReactiveCocoa.Method<NSObject, (), String>
+				do {
+					let object = NSObject()
+					method = Method(object: object) { object, _ in object.description }
+				}
+				expect(method.object).to(beNil())
+			}
+		}
+
+		describe("binding to signals") {
+			describe("with a swift object") {
+				var object: TestObject!
+				var method: ReactiveCocoa.Method<TestObject, Int, String>!
+
+				beforeEach {
+					object = TestObject()
+					method = Method(object: object, function: TestObject.string(from:))
+				}
+
+				afterEach {
+					object = nil
+					method = nil
+				}
+
+				it("returns a signal with the results of calling the method with each value") {
+					let (input, inputObserver) = Signal<Int, NoError>.pipe()
+					let output = method.lift(with: input)
+
+					var outputValues: [String] = []
+					output.observeNext { outputValues.append($0) }
+
+					inputObserver.sendNext(1)
+					inputObserver.sendNext(2)
+					inputObserver.sendNext(3)
+
+					expect(outputValues) == ["1", "2", "3"]
+				}
+
+				it("is interrupted on input if the underlying object has been deallocated") {
+					let (input, inputObserver) = Signal<Int, NoError>.pipe()
+					let output = method.lift(with: input)
+
+					var outputValues: [String] = []
+					var interrupted = false
+					output.observeNext { outputValues.append($0) }
+					output.observeInterrupted { interrupted = true }
+
+					inputObserver.sendNext(1)
+					inputObserver.sendNext(2)
+					object = nil
+					inputObserver.sendNext(3)
+
+					expect(outputValues) == ["1", "2"]
+					expect(interrupted) == true
+				}
+
+				it("is interrupted immediately if the underlying object is already nil") {
+					let (input, _) = Signal<Int, NoError>.pipe()
+					object = nil
+
+					var interrupted = false
+					let output = method.lift(with: input)
+					output.observeInterrupted { interrupted = true }
+
+					expect(interrupted) == true
+				}
+			}
+
+#if _runtime(_ObjC)
+			describe("with an Objective-C object") {
+				var object: TestObjectiveCObject?
+				var method: ReactiveCocoa.Method<TestObjectiveCObject, Int, String>!
+
+				beforeEach {
+					object = TestObjectiveCObject()
+					method = Method(object: object, function: TestObjectiveCObject.string(from:))
+				}
+
+				afterEach {
+					object = nil
+					method = nil
+				}
+
+				it("returns a signal with the results of calling the method with each value") {
+					let (input, inputObserver) = Signal<Int, NoError>.pipe()
+					let output = method.lift(with: input)
+
+					var outputValues: [String] = []
+					output.observeNext { outputValues.append($0) }
+
+					inputObserver.sendNext(1)
+					inputObserver.sendNext(2)
+					inputObserver.sendNext(3)
+
+					expect(outputValues) == ["1", "2", "3"]
+				}
+
+				it("is interrupted immediately on deallocation if the underlying object is an Objective-C object") {
+					let (input, inputObserver) = Signal<Int, NoError>.pipe()
+					let output = method.lift(with: input)
+
+					var outputValues: [String] = []
+					var interrupted = false
+					output.observeNext { outputValues.append($0) }
+					output.observeInterrupted { interrupted = true }
+
+					inputObserver.sendNext(1)
+					inputObserver.sendNext(2)
+					object = nil
+
+					expect(outputValues) == ["1", "2"]
+					expect(interrupted) == true
+				}
+
+				it("is interrupted immediately if the underlying object is already nil") {
+					let (input, _) = Signal<Int, NoError>.pipe()
+					object = nil
+
+					var interrupted = false
+					let output = method.lift(with: input)
+					output.observeInterrupted { interrupted = true }
+
+					expect(interrupted) == true
+				}
+			}
+#endif
+		}
+
+		describe("binding to producers") {
+			describe("with a swift object") {
+				var object: TestObject!
+				var method: ReactiveCocoa.Method<TestObject, Int, String>!
+
+				beforeEach {
+					object = TestObject()
+					method = Method(object: object, function: TestObject.string(from:))
+				}
+
+				afterEach {
+					object = nil
+					method = nil
+				}
+
+				it("returns an output producer that lazily binds to the input producer") {
+					let input = SignalProducer<Int, NoError>(values: [1, 2, 3])
+
+					var sentInput: [Int] = []
+					let output = method.lifted(with: input.on(next: { sentInput.append($0) }))
+					expect(sentInput) == []
+
+					var sentOutput: [String] = []
+					output.startWithNext { sentOutput.append($0) }
+					expect(sentInput) == [1, 2, 3]
+					expect(sentOutput) == ["1", "2", "3"]
+				}
+
+				it("is interrupted on input if the underlying object is deallocated") {
+					let (input, inputObserver) = SignalProducer<Int, NoError>.buffer(1)
+
+					var outputValues: [String] = []
+					var interrupted = false
+					method.lifted(with: input).start { event in
+						switch event {
+						case .Next(let value):
+							outputValues.append(value)
+						case .Interrupted:
+							interrupted = true
+						default:
+							break
+						}
+					}
+
+					inputObserver.sendNext(1)
+					inputObserver.sendNext(2)
+					object = nil
+					inputObserver.sendNext(3)
+
+					expect(outputValues) == ["1", "2"]
+					expect(interrupted) == true
+				}
+
+				it("is interrupted immediately if the underlying object is already nil") {
+					object = nil
+
+					var interrupted = false
+					method.lifted(with: .empty).startWithInterrupted { interrupted = true }
+
+					expect(interrupted) == true
+				}
+			}
+
+#if _runtime(_ObjC)
+			describe("with an Objective-C object") {
+				var object: TestObjectiveCObject?
+				var method: ReactiveCocoa.Method<TestObjectiveCObject, Int, String>!
+
+				beforeEach {
+					object = TestObjectiveCObject()
+					method = Method(object: object, function: TestObjectiveCObject.string(from:))
+				}
+
+				afterEach {
+					object = nil
+					method = nil
+				}
+
+				it("returns an output producer that lazily binds to the input producer") {
+					let input = SignalProducer<Int, NoError>(values: [1, 2, 3])
+
+					var sentInput: [Int] = []
+					let output = method.lifted(with: input.on(next: { sentInput.append($0) }))
+					expect(sentInput) == []
+
+					var sentOutput: [String] = []
+					output.startWithNext { sentOutput.append($0) }
+					expect(sentInput) == [1, 2, 3]
+					expect(sentOutput) == ["1", "2", "3"]
+				}
+
+				it("is interrupted immediately if the underlying object is deallocated") {
+					let (input, inputObserver) = SignalProducer<Int, NoError>.buffer(1)
+
+					var outputValues: [String] = []
+					var interrupted = false
+					method.lifted(with: input).start { event in
+						switch event {
+						case .Next(let value):
+							outputValues.append(value)
+						case .Interrupted:
+							interrupted = true
+						default:
+							break
+						}
+					}
+
+					inputObserver.sendNext(1)
+					inputObserver.sendNext(2)
+					object = nil
+
+					expect(outputValues) == ["1", "2"]
+					expect(interrupted) == true
+				}
+
+				it("is interrupted immediately if the underlying object is already nil") {
+					object = nil
+
+					var interrupted = false
+					method.lifted(with: .empty).startWithInterrupted { interrupted = true }
+
+					expect(interrupted) == true
+				}
+			}
+#endif
+		}
+	}
+}
+
+private final class TestObject {
+	func string(from number: Int) -> String {
+		return String(number)
+	}
+}
+
+#if _runtime(_ObjC)
+private final class TestObjectiveCObject: NSObject {
+	func string(from number: Int) -> String {
+		return String(number)
+	}
+}
+#endif


### PR DESCRIPTION
This is a potential improvement I'd like to submit for review as part of #2535.

---

### Overview: `Method` and `MethodType`

This change introduces a new `MethodType` protocol and concrete `Method` class. A `Method` encapsulates a weak reference to an object, and a function that accepts a reference to the object, some input, and returns the method's output.

When a `Method` is lifted using a signal or signal producer of input, it returns a signal or signal producer (respectively) of output from the results of calling the function with the input.

If the weakly-referenced object is deallocated, the lifted signal or signal producer will send an interrupted event. When the Objective-C runtime is present, this is achieved by observing the object's deallocation at runtime. There is a fallback implementation for native Swift objects: even though it's impossible to be notified when a weakly-referenced Swift object is deallocated, we can wait until the next input value is sent and lazily interrupt the signal if the result of the method call is `nil`.

---

### Also: Even better bindings?

The changes as they are right now are not the end goal: I'd also like to add support for the `<~` operator, and create a unifying `Bindable` protocol that both `MethodType` and `MutablePropertyType` would conform to. This would mean that the same set of overloads would work for both kinds of bindable things. Just spitballing here, but this might look something like:

```swift
func <~ <Target: Bindable>(target: Target, signal: Signal<Target.Input, NoError>) -> Disposable
func <~ <Target: Bindable>(target: Target, producer: SignalProducer<Target.Input, NoError>) -> Disposable
// etc.
```

And then in use, you might end up with something like this:

```swift
RAC(refreshControl, UIRefreshControl.endRefreshing) <~ feedController.feedRefresh
RAC(tableView, UITableView.reloadData) <~ feedController.feedRefreshed
```

Also, `Method` solves the "I shouldn't have to set up KVO to bind to a property" problem:

```swift
extension UIImageView {
  var rac_setImage: Method<UIImageView, UIImage, Void> {
    return Method(object: self) { $0.image = $1 }
  }
}

// ...
imageView.rac_setImage <~ viewModel.image
```

---

I plan to push up more comments fleshing these other features out.

Would love to hear your thoughts!