### PR TITLE
Change void return types to using Void

### DIFF
--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -311,7 +311,7 @@ scopedExample("`take`") {
  */
 scopedExample("`observeOn`") {
     let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
-    let completion: () -> () = { print("is main thread? \(NSThread.currentThread().isMainThread)") }
+    let completion = { print("is main thread? \(NSThread.currentThread().isMainThread)") }
     
     baseProducer
         .observeOn(QueueScheduler(name: "test"))

--- a/ReactiveCocoa.playground/Sources/PlaygroundUtility.swift
+++ b/ReactiveCocoa.playground/Sources/PlaygroundUtility.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public func scopedExample(exampleDescription: String, _ action: () -> ()) {
+public func scopedExample(exampleDescription: String, _ action: () -> Void) {
 	print("\n--- \(exampleDescription) ---\n")
 	action()
 }

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -183,7 +183,7 @@ public final class CocoaAction: NSObject {
 
 	private var _enabled = false
 	private var _executing = false
-	private let _execute: AnyObject? -> ()
+	private let _execute: AnyObject? -> Void
 	private let disposable = CompositeDisposable()
 
 	/// Initializes a Cocoa action that will invoke the given Action by

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -33,14 +33,14 @@ public final class SimpleDisposable: Disposable {
 
 /// A disposable that will run an action upon disposal.
 public final class ActionDisposable: Disposable {
-	private let action: Atomic<(() -> ())?>
+	private let action: Atomic<(() -> Void)?>
 
 	public var disposed: Bool {
 		return action.value == nil
 	}
 
 	/// Initializes the disposable to run the given action upon disposal.
-	public init(action: () -> ()) {
+	public init(action: () -> Void) {
 		self.action = Atomic(action)
 	}
 
@@ -152,7 +152,7 @@ public final class CompositeDisposable: Disposable {
 	}
 
 	/// Adds an ActionDisposable to the list.
-	public func addDisposable(action: () -> ()) -> DisposableHandle {
+	public func addDisposable(action: () -> Void) -> DisposableHandle {
 		return addDisposable(ActionDisposable(action: action))
 	}
 }

--- a/ReactiveCocoa/Swift/EventLogger.swift
+++ b/ReactiveCocoa/Swift/EventLogger.swift
@@ -28,7 +28,7 @@ private func defaultEventLog(identifier: String, event: String, fileName: String
 	print("[\(identifier)] \(event) fileName: \(fileName), functionName: \(functionName), lineNumber: \(lineNumber)")
 }
 
-public typealias EventLogger = (identifier: String, event: String, fileName: String, functionName: String, lineNumber: Int) -> ()
+public typealias EventLogger = (identifier: String, event: String, fileName: String, functionName: String, lineNumber: Int) -> Void
 
 extension SignalType {
 	/// Logs all events that the receiver sends.
@@ -36,15 +36,15 @@ extension SignalType {
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func logEvents(identifier identifier: String = "", events: Set<SignalLoggingEvent> = SignalLoggingEvent.allEvents, fileName: String = #file, functionName: String = #function, lineNumber: Int = #line, logger: EventLogger = defaultEventLog) -> Signal<Value, Error> {
 		
-		let logEvent: String -> () = { event in
+		let logEvent: String -> Void = { event in
 			logger(identifier: identifier, event: event, fileName: fileName, functionName: functionName, lineNumber: lineNumber)
 		}
 		
-		func log(event: SignalLoggingEvent) -> (() -> ())? {
+		func log(event: SignalLoggingEvent) -> (() -> Void)? {
 			return events.contains(event) ? { logEvent("\(event.rawValue)") } : nil
 		}
 		
-		func logValue<T>(event: SignalLoggingEvent) -> (T -> ())? {
+		func logValue<T>(event: SignalLoggingEvent) -> (T -> Void)? {
 			return events.contains(event) ? { logEvent("\(event.rawValue) \($0)") } : nil
 		}
 		
@@ -65,15 +65,15 @@ extension SignalProducerType {
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func logEvents(identifier identifier: String = "", events: Set<SignalProducerLoggingEvent> = SignalProducerLoggingEvent.allEvents, fileName: String = #file, functionName: String = #function, lineNumber: Int = #line, logger: EventLogger = defaultEventLog) -> SignalProducer<Value, Error> {
 		
-		let logEvent: String -> () = { event in
+		let logEvent: String -> Void = { event in
 			logger(identifier: identifier, event: event, fileName: fileName, functionName: functionName, lineNumber: lineNumber)
 		}
 		
-		func log(event: SignalProducerLoggingEvent) -> (() -> ())? {
+		func log(event: SignalProducerLoggingEvent) -> (() -> Void)? {
 			return events.contains(event) ? { logEvent("\(event.rawValue)") } : nil
 		}
 		
-		func logValue<T>(event: SignalProducerLoggingEvent) -> (T -> ())? {
+		func logValue<T>(event: SignalProducerLoggingEvent) -> (T -> Void)? {
 			return events.contains(event) ? { logEvent("\(event.rawValue) \($0)") } : nil
 		}
 		

--- a/ReactiveCocoa/Swift/Flatten.swift
+++ b/ReactiveCocoa/Swift/Flatten.swift
@@ -278,7 +278,7 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 
 	private func observeMerge(observer: Observer<Value.Value, Error>, _ disposable: CompositeDisposable) -> Disposable? {
 		let inFlight = Atomic(1)
-		let decrementInFlight: () -> () = {
+		let decrementInFlight = {
 			let orig = inFlight.modify { $0 - 1 }
 			if orig == 1 {
 				observer.sendCompleted()

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -14,16 +14,16 @@ extension RACScheduler: DateSchedulerType {
 		return NSDate()
 	}
 
-	public func schedule(action: () -> ()) -> Disposable? {
+	public func schedule(action: () -> Void) -> Disposable? {
 		let disposable: RACDisposable = self.schedule(action) // Call the Objective-C implementation
 		return disposable as Disposable?
 	}
 
-	public func scheduleAfter(date: NSDate, action: () -> ()) -> Disposable? {
+	public func scheduleAfter(date: NSDate, action: () -> Void) -> Disposable? {
 		return self.after(date, schedule: action)
 	}
 
-	public func scheduleAfter(date: NSDate, repeatingEvery: NSTimeInterval, withLeeway: NSTimeInterval, action: () -> ()) -> Disposable? {
+	public func scheduleAfter(date: NSDate, repeatingEvery: NSTimeInterval, withLeeway: NSTimeInterval, action: () -> Void) -> Disposable? {
 		return self.after(date, repeatingEvery: repeatingEvery, withLeeway: withLeeway, schedule: action)
 	}
 }

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -9,7 +9,7 @@
 /// An Observer is a simple wrapper around a function which can receive Events
 /// (typically from a Signal).
 public struct Observer<Value, Error: ErrorType> {
-	public typealias Action = Event<Value, Error> -> ()
+	public typealias Action = Event<Value, Error> -> Void
 
 	public let action: Action
 
@@ -17,7 +17,7 @@ public struct Observer<Value, Error: ErrorType> {
 		self.action = action
 	}
 
-	public init(failed: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, next: (Value -> ())? = nil) {
+	public init(failed: (Error -> Void)? = nil, completed: (() -> Void)? = nil, interrupted: (() -> Void)? = nil, next: (Value -> Void)? = nil) {
 		self.init { event in
 			switch event {
 			case let .Next(value):

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -111,7 +111,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	private let getter: () -> Value
 
 	/// The setter of the underlying storage.
-	private let setter: Value -> ()
+	private let setter: Value -> Void
 
 	/// The current value of the property.
 	///

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -187,7 +187,7 @@ extension SignalType {
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callbacks. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeNext(next: Value -> ()) -> Disposable? {
+	public func observeNext(next: Value -> Void) -> Disposable? {
 		return observe(Observer(next: next))
 	}
 
@@ -197,7 +197,7 @@ extension SignalType {
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeCompleted(completed: () -> ()) -> Disposable? {
+	public func observeCompleted(completed: () -> Void) -> Disposable? {
 		return observe(Observer(completed: completed))
 	}
 	
@@ -207,7 +207,7 @@ extension SignalType {
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeFailed(error: Error -> ()) -> Disposable? {
+	public func observeFailed(error: Error -> Void) -> Disposable? {
 		return observe(Observer(failed: error))
 	}
 	
@@ -218,7 +218,7 @@ extension SignalType {
 	/// Returns a Disposable which can be used to stop the invocation of the
 	/// callback. Disposing of the Disposable will have no effect on the Signal
 	/// itself.
-	public func observeInterrupted(interrupted: () -> ()) -> Disposable? {
+	public func observeInterrupted(interrupted: () -> Void) -> Disposable? {
 		return observe(Observer(interrupted: interrupted))
 	}
 
@@ -246,7 +246,7 @@ extension SignalType {
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func filter(predicate: Value -> Bool) -> Signal<Value, Error> {
 		return Signal { observer in
-			return self.observe { (event: Event<Value, Error>) -> () in
+			return self.observe { (event: Event<Value, Error>) -> Void in
 				if case let .Next(value) = event {
 					if predicate(value) {
 						observer.sendNext(value)
@@ -505,7 +505,7 @@ private final class CombineLatestState<Value> {
 }
 
 extension SignalType {
-	private func observeWithStates<U>(signalState: CombineLatestState<Value>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ onBothNext: () -> (), _ onFailed: Error -> (), _ onBothCompleted: () -> (), _ onInterrupted: () -> ()) -> Disposable? {
+	private func observeWithStates<U>(signalState: CombineLatestState<Value>, _ otherState: CombineLatestState<U>, _ lock: NSLock, _ onBothNext: () -> Void, _ onFailed: Error -> Void, _ onBothCompleted: () -> Void, _ onInterrupted: () -> Void) -> Disposable? {
 		return self.observe { event in
 			switch event {
 			case let .Next(value):
@@ -552,7 +552,7 @@ extension SignalType {
 			let signalState = CombineLatestState<Value>()
 			let otherState = CombineLatestState<U>()
 			
-			let onBothNext = { () -> () in
+			let onBothNext = {
 				observer.sendNext((signalState.latestValue!, otherState.latestValue!))
 			}
 			
@@ -674,7 +674,7 @@ extension SignalType where Value: EventType, Error == NoError {
 extension SignalType {
 	/// Injects side effects to be performed upon the specified signal events.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
-	public func on(event event: (Event<Value, Error> -> ())? = nil, failed: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil, next: (Value -> ())? = nil) -> Signal<Value, Error> {
+	public func on(event event: (Event<Value, Error> -> Void)? = nil, failed: (Error -> Void)? = nil, completed: (() -> Void)? = nil, interrupted: (() -> Void)? = nil, terminated: (() -> Void)? = nil, disposed: (() -> Void)? = nil, next: (Value -> Void)? = nil) -> Signal<Value, Error> {
 		return Signal { observer in
 			let disposable = CompositeDisposable()
 
@@ -1040,7 +1040,7 @@ extension SignalType {
 			let states = Atomic(ZipState<Value>(), ZipState<U>())
 			let disposable = CompositeDisposable()
 			
-			let flush = { () -> () in
+			let flush = {
 				var originalStates: (ZipState<Value>, ZipState<U>)!
 				states.modify { states in
 					originalStates = states

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -18,7 +18,7 @@ import Result
 public struct SignalProducer<Value, Error: ErrorType> {
 	public typealias ProducedSignal = Signal<Value, Error>
 
-	private let startHandler: (Signal<Value, Error>.Observer, CompositeDisposable) -> ()
+	private let startHandler: (Signal<Value, Error>.Observer, CompositeDisposable) -> Void
 
 	/// Initializes a SignalProducer that will emit the same events as the given signal.
 	///
@@ -41,7 +41,7 @@ public struct SignalProducer<Value, Error: ErrorType> {
 	/// event is sent to the observer, the given CompositeDisposable will be
 	/// disposed, at which point work should be interrupted and any temporary
 	/// resources cleaned up.
-	public init(_ startHandler: (Signal<Value, Error>.Observer, CompositeDisposable) -> ()) {
+	public init(_ startHandler: (Signal<Value, Error>.Observer, CompositeDisposable) -> Void) {
 		self.startHandler = startHandler
 	}
 
@@ -139,7 +139,7 @@ public struct SignalProducer<Value, Error: ErrorType> {
 			// Assigned to when replay() is invoked synchronously below.
 			var token: RemovalToken?
 
-			let replay: () -> () = {
+			let replay = {
 				let originalState = state.modify { state in
 					var state = state
 					token = state.observers?.insert(observer)
@@ -229,7 +229,7 @@ public struct SignalProducer<Value, Error: ErrorType> {
 	/// The closure will also receive a disposable which can be used to
 	/// interrupt the work associated with the signal and immediately send an
 	/// `Interrupted` event.
-	public func startWithSignal(@noescape setUp: (Signal<Value, Error>, Disposable) -> ()) {
+	public func startWithSignal(@noescape setUp: (Signal<Value, Error>, Disposable) -> Void) {
 		let (signal, observer) = Signal<Value, Error>.pipe()
 
 		// Disposes of the work associated with the SignalProducer and any
@@ -311,7 +311,7 @@ public protocol SignalProducerType {
 
 	/// Creates a Signal from the producer, passes it into the given closure,
 	/// then starts sending events on the Signal when the closure has returned.
-	func startWithSignal(@noescape setUp: (Signal<Value, Error>, Disposable) -> ())
+	func startWithSignal(@noescape setUp: (Signal<Value, Error>, Disposable) -> Void)
 }
 
 extension SignalProducer: SignalProducerType {
@@ -349,7 +349,7 @@ extension SignalProducerType {
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func startWithNext(next: Value -> ()) -> Disposable {
+	public func startWithNext(next: Value -> Void) -> Disposable {
 		return start(Observer(next: next))
 	}
 
@@ -359,7 +359,7 @@ extension SignalProducerType {
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal.
-	public func startWithCompleted(completed: () -> ()) -> Disposable {
+	public func startWithCompleted(completed: () -> Void) -> Disposable {
 		return start(Observer(completed: completed))
 	}
 	
@@ -369,7 +369,7 @@ extension SignalProducerType {
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal.
-	public func startWithFailed(failed: Error -> ()) -> Disposable {
+	public func startWithFailed(failed: Error -> Void) -> Disposable {
 		return start(Observer(failed: failed))
 	}
 	
@@ -379,7 +379,7 @@ extension SignalProducerType {
 	///
 	/// Returns a Disposable which can be used to interrupt the work associated
 	/// with the Signal.
-	public func startWithInterrupted(interrupted: () -> ()) -> Disposable {
+	public func startWithInterrupted(interrupted: () -> Void) -> Disposable {
 		return start(Observer(interrupted: interrupted))
 	}
 
@@ -994,7 +994,7 @@ public func timer(interval: NSTimeInterval, onScheduler scheduler: DateScheduler
 extension SignalProducerType {
 	/// Injects side effects to be performed upon the specified signal events.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func on(started started: (() -> ())? = nil, event: (Event<Value, Error> -> ())? = nil, failed: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil, terminated: (() -> ())? = nil, disposed: (() -> ())? = nil, next: (Value -> ())? = nil) -> SignalProducer<Value, Error> {
+	public func on(started started: (() -> Void)? = nil, event: (Event<Value, Error> -> Void)? = nil, failed: (Error -> Void)? = nil, completed: (() -> Void)? = nil, interrupted: (() -> Void)? = nil, terminated: (() -> Void)? = nil, disposed: (() -> Void)? = nil, next: (Value -> Void)? = nil) -> SignalProducer<Value, Error> {
 		return SignalProducer { observer, compositeDisposable in
 			started?()
 			self.startWithSignal { signal, disposable in

--- a/ReactiveCocoaTests/Swift/SchedulerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SchedulerSpec.swift
@@ -26,7 +26,7 @@ class SchedulerSpec: QuickSpec {
 		}
 
 		describe("UIScheduler") {
-			func dispatchSyncInBackground(action: () -> ()) {
+			func dispatchSyncInBackground(action: () -> Void) {
 				let group = dispatch_group_create()
 				dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), action)
 				dispatch_group_wait(group, DISPATCH_TIME_FOREVER)

--- a/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
@@ -125,7 +125,7 @@ class SignalLifetimeSpec: QuickSpec {
 
 				// Use an inner closure to help ARC deallocate things as we
 				// expect.
-				let test: () -> () = {
+				let test = {
 					let (signal, observer) = Signal<(), TestError>.pipe()
 					weakSignal = signal
 					testScheduler.schedule {
@@ -146,7 +146,7 @@ class SignalLifetimeSpec: QuickSpec {
 
 				// Use an inner closure to help ARC deallocate things as we
 				// expect.
-				let test: () -> () = {
+				let test = {
 					let (signal, observer) = Signal<(), TestError>.pipe()
 					weakSignal = signal
 					testScheduler.schedule {
@@ -165,7 +165,7 @@ class SignalLifetimeSpec: QuickSpec {
 				let testScheduler = TestScheduler()
 				weak var weakSignal: Signal<(), NoError>?
 
-				let test: () -> () = {
+				let test = {
 					let (signal, observer) = Signal<(), NoError>.pipe()
 					weakSignal = signal
 

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -1063,9 +1063,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			describe("memory") {
 				class Payload {
-					let action: () -> ()
+					let action: () -> Void
 
-					init(onDeinit action: () -> ()) {
+					init(onDeinit action: () -> Void) {
 						self.action = action
 					}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -644,7 +644,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should release observer when disposed") {
 				weak var objectRetainedByObserver: NSObject?
 				var disposable: Disposable!
-				let test: () -> () = {
+				let test = {
 					let producer = SignalProducer<Int, NoError>.never
 					let object = NSObject()
 					objectRetainedByObserver = object
@@ -891,15 +891,15 @@ class SignalProducerSpec: QuickSpec {
 				var terminated = 0
 
 				let producer = baseProducer
-					.on(started: { () -> () in
+					.on(started: {
 						started += 1
-					}, event: { (e: Event<Int, TestError>) -> () in
+					}, event: { e in
 						event += 1
-					}, next: { (n: Int) -> () in
+					}, next: { n in
 						next += 1
-					}, completed: { () -> () in
+					}, completed: {
 						completed += 1
-					}, terminated: { () -> () in
+					}, terminated: {
 						terminated += 1
 					})
 
@@ -1026,9 +1026,9 @@ class SignalProducerSpec: QuickSpec {
 		describe("flatten") {
 			describe("FlattenStrategy.Concat") {
 				describe("sequencing") {
-					var completePrevious: (() -> ())!
-					var sendSubsequent: (() -> ())!
-					var completeOuter: (() -> ())!
+					var completePrevious: (() -> Void)!
+					var sendSubsequent: (() -> Void)!
+					var completeOuter: (() -> Void)!
 
 					var subsequentStarted = false
 
@@ -1100,8 +1100,8 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				describe("completion") {
-					var completeOuter: (() -> ())!
-					var completeInner: (() -> ())!
+					var completeOuter: (() -> Void)!
+					var completeInner: (() -> Void)!
 
 					var completed = false
 
@@ -1140,10 +1140,10 @@ class SignalProducerSpec: QuickSpec {
 
 			describe("FlattenStrategy.Merge") {
 				describe("behavior") {
-					var completeA: (() -> ())!
-					var sendA: (() -> ())!
-					var completeB: (() -> ())!
-					var sendB: (() -> ())!
+					var completeA: (() -> Void)!
+					var sendA: (() -> Void)!
+					var completeB: (() -> Void)!
+					var sendB: (() -> Void)!
 
 					var outerCompleted = false
 
@@ -1317,7 +1317,7 @@ class SignalProducerSpec: QuickSpec {
 			describe("interruption") {
 				var innerObserver: Signal<(), NoError>.Observer!
 				var outerObserver: Signal<SignalProducer<(), NoError>, NoError>.Observer!
-				var execute: (FlattenStrategy -> ())!
+				var execute: (FlattenStrategy -> Void)!
 
 				var interrupted = false
 				var completed = false
@@ -1409,9 +1409,9 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			describe("disposal") {
-				var completeOuter: (() -> ())!
-				var disposeOuter: (() -> ())!
-				var execute: (FlattenStrategy -> ())!
+				var completeOuter: (() -> Void)!
+				var disposeOuter: (() -> Void)!
+				var execute: (FlattenStrategy -> Void)!
 
 				var innerDisposable = SimpleDisposable()
 				var interrupted = false
@@ -2072,9 +2072,9 @@ class SignalProducerSpec: QuickSpec {
 
 				it("does not leak buffered values") {
 					final class Value {
-						private let deinitBlock: () -> ()
+						private let deinitBlock: () -> Void
 
-						init(deinitBlock: () -> ()) {
+						init(deinitBlock: () -> Void) {
 							self.deinitBlock = deinitBlock
 						}
 
@@ -2109,7 +2109,7 @@ class SignalProducerSpec: QuickSpec {
 			
 			describe("log events") {
 				it("should output the correct event") {
-					let expectations: [String -> ()] = [
+					let expectations: [String -> Void] = [
 						{ event in expect(event) == "[] Started" },
 						{ event in expect(event) == "[] Next 1" },
 						{ event in expect(event) == "[] Completed" },

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -257,7 +257,7 @@ class SignalSpec: QuickSpec {
 				weak var testStr: NSMutableString?
 				let (signal, observer) = Signal<Int, NoError>.pipe()
 
-				let test: () -> () = {
+				let test = {
 					let innerStr: NSMutableString = NSMutableString()
 					signal.observeNext { value in
 						innerStr.appendString("\(value)")
@@ -279,7 +279,7 @@ class SignalSpec: QuickSpec {
 				weak var testStr: NSMutableString?
 				let (signal, observer) = Signal<Int, NoError>.pipe()
 
-				let test: () -> () = {
+				let test = {
 					let innerStr: NSMutableString = NSMutableString()
 					signal.observeNext { value in
 						innerStr.appendString("\(value)")
@@ -2049,7 +2049,7 @@ class SignalSpec: QuickSpec {
 			
 			describe("log events") {
 				it("should output the correct event without identifier") {
-					let expectations: [String -> ()] = [
+					let expectations: [String -> Void] = [
 						{ event in expect(event) == "[] Next 1" },
 						{ event in expect(event) == "[] Completed" },
 						{ event in expect(event) == "[] Terminated" },
@@ -2068,7 +2068,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				it("should output the correct event with identifier") {
-					let expectations: [String -> ()] = [
+					let expectations: [String -> Void] = [
 						{ event in expect(event) == "[test.rac] Next 1" },
 						{ event in expect(event) == "[test.rac] Failed Error1" },
 						{ event in expect(event) == "[test.rac] Terminated" },
@@ -2087,7 +2087,7 @@ class SignalSpec: QuickSpec {
 				}
 				
 				it("should only output the events specified in the `events` parameter") {
-					let expectations: [String -> ()] = [
+					let expectations: [String -> Void] = [
 						{ event in expect(event) == "[test.rac] Failed Error1" },
 					]
 					

--- a/ReactiveCocoaTests/Swift/TestLogger.swift
+++ b/ReactiveCocoaTests/Swift/TestLogger.swift
@@ -10,9 +10,9 @@ import Foundation
 @testable import ReactiveCocoa
 
 final class TestLogger {
-	private var expectations: [String -> ()]
+	private var expectations: [String -> Void]
 	
-	init(expectations: [String -> ()]) {
+	init(expectations: [String -> Void]) {
 		self.expectations = expectations
 	}
 }


### PR DESCRIPTION
Let's use `Void` over `()` for return types. This should make the codebase more readable. And also using `()` over `Void` for an empty parameter list makes sense to me. See the followings for the details:

- Originally motivated by http://ericasadun.com/2015/05/11/swift-vs-void/
- The original PR: #2059
- The recent discussion: https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2865#discussion_r62208760
