### PR TITLE
CocoaAction separation

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -381,6 +381,10 @@
 		BEBDD6E81CDC292F009A75A9 /* RACDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = D037646B19EDA41200A782A9 /* RACDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFA6B94D1A7604D400C846D1 /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
 		BFA6B94E1A7604D500C846D1 /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
+		C7142DBC1CDEA167009F402D /* CocoaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7142DBB1CDEA167009F402D /* CocoaAction.swift */; };
+		C7142DBD1CDEA194009F402D /* CocoaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7142DBB1CDEA167009F402D /* CocoaAction.swift */; };
+		C7142DBE1CDEA194009F402D /* CocoaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7142DBB1CDEA167009F402D /* CocoaAction.swift */; };
+		C7142DBF1CDEA195009F402D /* CocoaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7142DBB1CDEA167009F402D /* CocoaAction.swift */; };
 		C79B64741CD38B2B003F2376 /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79B64731CD38B2B003F2376 /* TestLogger.swift */; };
 		C79B64751CD38B2B003F2376 /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79B64731CD38B2B003F2376 /* TestLogger.swift */; };
 		C79B647C1CD52E23003F2376 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79B647B1CD52E23003F2376 /* EventLogger.swift */; };
@@ -914,6 +918,7 @@
 		A9B315541B3940610001CB9C /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B696FB801A7640C00075236D /* TestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignalProducerNimbleMatchers.swift; path = Swift/SignalProducerNimbleMatchers.swift; sourceTree = "<group>"; };
+		C7142DBB1CDEA167009F402D /* CocoaAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaAction.swift; sourceTree = "<group>"; };
 		C79B64731CD38B2B003F2376 /* TestLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
 		C79B647B1CD52E23003F2376 /* EventLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		CA6F284F1C52626B001879D2 /* FlattenSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlattenSpec.swift; sourceTree = "<group>"; };
@@ -1603,6 +1608,7 @@
 			isa = PBXGroup;
 			children = (
 				D08C54AF1A69A2AC00AD8286 /* Action.swift */,
+				C7142DBB1CDEA167009F402D /* CocoaAction.swift */,
 				CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */,
 				D85C65291C0D84C7005A77AD /* Flatten.swift */,
 				D08C54B01A69A2AC00AD8286 /* Property.swift */,
@@ -2369,6 +2375,7 @@
 				57A4D1DE1BA13D7A00F7D4B1 /* RACDisposable.m in Sources */,
 				EBCC7DBF1BBF01E200A2AE92 /* Observer.swift in Sources */,
 				57A4D1DF1BA13D7A00F7D4B1 /* RACDynamicSequence.m in Sources */,
+				C7142DBF1CDEA195009F402D /* CocoaAction.swift in Sources */,
 				57A4D1E01BA13D7A00F7D4B1 /* RACDynamicSignal.m in Sources */,
 				57A4D1E11BA13D7A00F7D4B1 /* RACEagerSequence.m in Sources */,
 				C79B64801CD52E4E003F2376 /* EventLogger.swift in Sources */,
@@ -2547,6 +2554,7 @@
 				A9B3158C1B3940750001CB9C /* RACKVOProxy.m in Sources */,
 				A9B3158D1B3940750001CB9C /* RACKVOTrampoline.m in Sources */,
 				A9B3158E1B3940750001CB9C /* RACMulticastConnection.m in Sources */,
+				C7142DBE1CDEA194009F402D /* CocoaAction.swift in Sources */,
 				A9B3158F1B3940750001CB9C /* RACObjCRuntime.m in Sources */,
 				A9B315901B3940750001CB9C /* RACPassthroughSubscriber.m in Sources */,
 				A9B315911B3940750001CB9C /* RACQueueScheduler.m in Sources */,
@@ -2630,6 +2638,7 @@
 				D037654A19EDA41200A782A9 /* NSUserDefaults+RACSupport.m in Sources */,
 				D037660E19EDA41200A782A9 /* RACUnarySequence.m in Sources */,
 				D03765FE19EDA41200A782A9 /* RACTargetQueueScheduler.m in Sources */,
+				C7142DBC1CDEA167009F402D /* CocoaAction.swift in Sources */,
 				D03765DE19EDA41200A782A9 /* RACSignalSequence.m in Sources */,
 				D037656C19EDA41200A782A9 /* RACDelegateProxy.m in Sources */,
 				D037657419EDA41200A782A9 /* RACDynamicSequence.m in Sources */,
@@ -2792,6 +2801,7 @@
 				D85C652B1C0E70E3005A77AD /* Flatten.swift in Sources */,
 				D037654F19EDA41200A782A9 /* RACArraySequence.m in Sources */,
 				D037652319EDA41200A782A9 /* NSObject+RACLifting.m in Sources */,
+				C7142DBD1CDEA194009F402D /* CocoaAction.swift in Sources */,
 				D037650719EDA41200A782A9 /* NSIndexSet+RACSequenceAdditions.m in Sources */,
 				D037665F19EDA41200A782A9 /* UITextField+RACSignalSupport.m in Sources */,
 				D037650F19EDA41200A782A9 /* NSNotificationCenter+RACSupport.m in Sources */,

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -385,6 +385,10 @@
 		C7142DBD1CDEA194009F402D /* CocoaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7142DBB1CDEA167009F402D /* CocoaAction.swift */; };
 		C7142DBE1CDEA194009F402D /* CocoaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7142DBB1CDEA167009F402D /* CocoaAction.swift */; };
 		C7142DBF1CDEA195009F402D /* CocoaAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7142DBB1CDEA167009F402D /* CocoaAction.swift */; };
+		C78C5E051CE33C2800C0CBD6 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78C5E041CE33C2800C0CBD6 /* Association.swift */; };
+		C78C5E061CE33C2800C0CBD6 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78C5E041CE33C2800C0CBD6 /* Association.swift */; };
+		C78C5E071CE33C2800C0CBD6 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78C5E041CE33C2800C0CBD6 /* Association.swift */; };
+		C78C5E081CE33C2800C0CBD6 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78C5E041CE33C2800C0CBD6 /* Association.swift */; };
 		C79B64741CD38B2B003F2376 /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79B64731CD38B2B003F2376 /* TestLogger.swift */; };
 		C79B64751CD38B2B003F2376 /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79B64731CD38B2B003F2376 /* TestLogger.swift */; };
 		C79B647C1CD52E23003F2376 /* EventLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79B647B1CD52E23003F2376 /* EventLogger.swift */; };
@@ -919,6 +923,7 @@
 		B696FB801A7640C00075236D /* TestError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SignalProducerNimbleMatchers.swift; path = Swift/SignalProducerNimbleMatchers.swift; sourceTree = "<group>"; };
 		C7142DBB1CDEA167009F402D /* CocoaAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaAction.swift; sourceTree = "<group>"; };
+		C78C5E041CE33C2800C0CBD6 /* Association.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Association.swift; sourceTree = "<group>"; };
 		C79B64731CD38B2B003F2376 /* TestLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
 		C79B647B1CD52E23003F2376 /* EventLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventLogger.swift; sourceTree = "<group>"; };
 		CA6F284F1C52626B001879D2 /* FlattenSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlattenSpec.swift; sourceTree = "<group>"; };
@@ -1610,6 +1615,7 @@
 				D08C54AF1A69A2AC00AD8286 /* Action.swift */,
 				C7142DBB1CDEA167009F402D /* CocoaAction.swift */,
 				CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */,
+				C78C5E041CE33C2800C0CBD6 /* Association.swift */,
 				D85C65291C0D84C7005A77AD /* Flatten.swift */,
 				D08C54B01A69A2AC00AD8286 /* Property.swift */,
 				D08C54B11A69A2AC00AD8286 /* Signal.swift */,
@@ -2400,6 +2406,7 @@
 				57A4D1F21BA13D7A00F7D4B1 /* RACScheduler.m in Sources */,
 				57A4D1F31BA13D7A00F7D4B1 /* RACScopedDisposable.m in Sources */,
 				57A4D1F41BA13D7A00F7D4B1 /* RACSequence.m in Sources */,
+				C78C5E081CE33C2800C0CBD6 /* Association.swift in Sources */,
 				57A4D1F51BA13D7A00F7D4B1 /* RACSerialDisposable.m in Sources */,
 				57A4D1F61BA13D7A00F7D4B1 /* RACSignal.m in Sources */,
 				57D476921C4206DF00EFE697 /* UISegmentedControl+RACSignalSupport.m in Sources */,
@@ -2567,6 +2574,7 @@
 				A9B315981B3940750001CB9C /* RACSignal.m in Sources */,
 				A9B315991B3940750001CB9C /* RACSignal+Operations.m in Sources */,
 				A9B3159A1B3940750001CB9C /* RACSignalSequence.m in Sources */,
+				C78C5E071CE33C2800C0CBD6 /* Association.swift in Sources */,
 				A9B3159B1B3940750001CB9C /* RACStream.m in Sources */,
 				A9B3159C1B3940750001CB9C /* RACStringSequence.m in Sources */,
 				CD0C45E01CC9A288009F5BF0 /* DynamicProperty.swift in Sources */,
@@ -2673,6 +2681,7 @@
 				D037660619EDA41200A782A9 /* RACTuple.m in Sources */,
 				D037651E19EDA41200A782A9 /* NSObject+RACKVOWrapper.m in Sources */,
 				D037661619EDA41200A782A9 /* RACValueTransformer.m in Sources */,
+				C78C5E051CE33C2800C0CBD6 /* Association.swift in Sources */,
 				C79B647C1CD52E23003F2376 /* EventLogger.swift in Sources */,
 				D03765CC19EDA41200A782A9 /* RACSequence.m in Sources */,
 				D037652E19EDA41200A782A9 /* NSOrderedSet+RACSequenceAdditions.m in Sources */,
@@ -2773,6 +2782,7 @@
 				D03765D919EDA41200A782A9 /* RACSignal+Operations.m in Sources */,
 				D037661B19EDA41200A782A9 /* UIActionSheet+RACSignalSupport.m in Sources */,
 				D037650319EDA41200A782A9 /* NSFileHandle+RACSupport.m in Sources */,
+				C78C5E061CE33C2800C0CBD6 /* Association.swift in Sources */,
 				D08C54B91A69A9D100AD8286 /* SignalProducer.swift in Sources */,
 				D03765E319EDA41200A782A9 /* RACStream.m in Sources */,
 				D037655719EDA41200A782A9 /* RACBehaviorSubject.m in Sources */,

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -47,13 +47,6 @@ public final class Action<Input, Output, Error: ErrorType> {
 	/// Whether the instantiator of this action wants it to be enabled.
 	private let userEnabled: AnyProperty<Bool>
 
-	/// Lazy creation and storage of a UI bindable `CocoaAction`. The default behavior
-	/// force casts the AnyObject? input to match the action's `Input` type. This makes
-	/// it unsafe for use when the action is parameterized for something like `Void`
-	/// input. In those cases, explicitly assign a value to this property that transforms
-	/// the input to suit your needs.
-	public lazy var unsafeCocoaAction: CocoaAction = CocoaAction(self) { $0 as! Input }
-
 	/// This queue is used for read-modify-write operations on the `_executing`
 	/// property.
 	private let executingQueue = dispatch_queue_create("org.reactivecocoa.ReactiveCocoa.Action.executingQueue", DISPATCH_QUEUE_SERIAL)
@@ -155,82 +148,6 @@ public protocol ActionType {
 extension Action: ActionType {
 	public var action: Action {
 		return self
-	}
-}
-
-/// Wraps an Action for use by a GUI control (such as `NSControl` or
-/// `UIControl`), with KVO, or with Cocoa Bindings.
-public final class CocoaAction: NSObject {
-	/// The selector that a caller should invoke upon a CocoaAction in order to
-	/// execute it.
-	public static let selector: Selector = #selector(CocoaAction.execute(_:))
-
-	/// Whether the action is enabled.
-	///
-	/// This property will only change on the main thread, and will generate a
-	/// KVO notification for every change.
-	public var enabled: Bool {
-		return _enabled
-	}
-
-	/// Whether the action is executing.
-	///
-	/// This property will only change on the main thread, and will generate a
-	/// KVO notification for every change.
-	public var executing: Bool {
-		return _executing
-	}
-
-	private var _enabled = false
-	private var _executing = false
-	private let _execute: AnyObject? -> Void
-	private let disposable = CompositeDisposable()
-
-	/// Initializes a Cocoa action that will invoke the given Action by
-	/// transforming the object given to execute().
-	public init<Input, Output, Error>(_ action: Action<Input, Output, Error>, _ inputTransform: AnyObject? -> Input) {
-		_execute = { input in
-			let producer = action.apply(inputTransform(input))
-			producer.start()
-		}
-
-		super.init()
-
-		disposable += action.enabled.producer
-			.observeOn(UIScheduler())
-			.startWithNext { [weak self] value in
-				self?.willChangeValueForKey("enabled")
-				self?._enabled = value
-				self?.didChangeValueForKey("enabled")
-			}
-
-		disposable += action.executing.producer
-			.observeOn(UIScheduler())
-			.startWithNext { [weak self] value in
-				self?.willChangeValueForKey("executing")
-				self?._executing = value
-				self?.didChangeValueForKey("executing")
-			}
-	}
-
-	/// Initializes a Cocoa action that will invoke the given Action by
-	/// always providing the given input.
-	public convenience init<Input, Output, Error>(_ action: Action<Input, Output, Error>, input: Input) {
-		self.init(action, { _ in input })
-	}
-
-	deinit {
-		disposable.dispose()
-	}
-
-	/// Attempts to execute the underlying action with the given input, subject
-	/// to the behavior described by the initializer that was used.
-	@IBAction public func execute(input: AnyObject?) {
-		_execute(input)
-	}
-
-	public override class func automaticallyNotifiesObserversForKey(key: String) -> Bool {
-		return false
 	}
 }
 

--- a/ReactiveCocoa/Swift/Association.swift
+++ b/ReactiveCocoa/Swift/Association.swift
@@ -3,7 +3,7 @@ import Foundation
 /// On first use attaches the object returned from `initial` to the `host` object using
 /// `key` via `objc_setAssociatedObject`. On subsequent usage, returns said object via
 /// `objc_getAssociatedObject`.
-public func associatedObject<Host: AnyObject, T: AnyObject>(host: Host, key: UnsafePointer<()>, @noescape initial: Host -> T) -> T {
+func associatedObject<Host: AnyObject, T: AnyObject>(host: Host, key: UnsafePointer<()>, @noescape initial: Host -> T) -> T {
 	var value = objc_getAssociatedObject(host, key) as? T
 	if value == nil {
 		value = initial(host)

--- a/ReactiveCocoa/Swift/Association.swift
+++ b/ReactiveCocoa/Swift/Association.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// On first use attaches the object returned from `initial` to the `host` object using
+/// `key` via `objc_setAssociatedObject`. On subsequent usage, returns said object via
+/// `objc_getAssociatedObject`.
+public func associatedObject<Host: AnyObject, T: AnyObject>(host: Host, key: UnsafePointer<()>, @noescape initial: Host -> T) -> T {
+	var value = objc_getAssociatedObject(host, key) as? T
+	if value == nil {
+		value = initial(host)
+		objc_setAssociatedObject(host, key, value, .OBJC_ASSOCIATION_RETAIN)
+	}
+	return value!
+}

--- a/ReactiveCocoa/Swift/CocoaAction.swift
+++ b/ReactiveCocoa/Swift/CocoaAction.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Wraps an Action for use by a GUI control (such as `NSControl` or
+/// `UIControl`), with KVO, or with Cocoa Bindings.
+public final class CocoaAction: NSObject {
+	/// The selector that a caller should invoke upon a CocoaAction in order to
+	/// execute it.
+	public static let selector: Selector = #selector(CocoaAction.execute(_:))
+	
+	/// Whether the action is enabled.
+	///
+	/// This property will only change on the main thread, and will generate a
+	/// KVO notification for every change.
+	public var enabled: Bool {
+		return _enabled
+	}
+	
+	/// Whether the action is executing.
+	///
+	/// This property will only change on the main thread, and will generate a
+	/// KVO notification for every change.
+	public var executing: Bool {
+		return _executing
+	}
+	
+	private var _enabled = false
+	private var _executing = false
+	private let _execute: AnyObject? -> Void
+	private let disposable = CompositeDisposable()
+	
+	/// Initializes a Cocoa action that will invoke the given Action by
+	/// transforming the object given to execute().
+	public init<Input, Output, Error>(_ action: Action<Input, Output, Error>, _ inputTransform: AnyObject? -> Input) {
+		_execute = { input in
+			let producer = action.apply(inputTransform(input))
+			producer.start()
+		}
+		
+		super.init()
+		
+		disposable += action.enabled.producer
+			.observeOn(UIScheduler())
+			.startWithNext { [weak self] value in
+				self?.willChangeValueForKey("enabled")
+				self?._enabled = value
+				self?.didChangeValueForKey("enabled")
+		}
+		
+		disposable += action.executing.producer
+			.observeOn(UIScheduler())
+			.startWithNext { [weak self] value in
+				self?.willChangeValueForKey("executing")
+				self?._executing = value
+				self?.didChangeValueForKey("executing")
+		}
+	}
+	
+	/// Initializes a Cocoa action that will invoke the given Action by
+	/// always providing the given input.
+	public convenience init<Input, Output, Error>(_ action: Action<Input, Output, Error>, input: Input) {
+		self.init(action, { _ in input })
+	}
+	
+	deinit {
+		disposable.dispose()
+	}
+	
+	/// Attempts to execute the underlying action with the given input, subject
+	/// to the behavior described by the initializer that was used.
+	@IBAction public func execute(input: AnyObject?) {
+		_execute(input)
+	}
+	
+	public override class func automaticallyNotifiesObserversForKey(key: String) -> Bool {
+		return false
+	}
+}
+
+extension Action {
+	
+	/// Lazy creation and storage of a UI bindable `CocoaAction`. The default behavior
+	/// force casts the AnyObject? input to match the action's `Input` type. This makes
+	/// it unsafe for use when the action is parameterized for something like `Void`
+	/// input. In those cases, explicitly assign a value to this property that transforms
+	/// the input to suit your needs.
+	public var unsafeCocoaAction: CocoaAction {
+		return CocoaAction(self) { $0 as! Input }
+	}
+}

--- a/ReactiveCocoa/Swift/CocoaAction.swift
+++ b/ReactiveCocoa/Swift/CocoaAction.swift
@@ -77,13 +77,16 @@ public final class CocoaAction: NSObject {
 }
 
 extension Action {
-	
 	/// Lazy creation and storage of a UI bindable `CocoaAction`. The default behavior
 	/// force casts the AnyObject? input to match the action's `Input` type. This makes
 	/// it unsafe for use when the action is parameterized for something like `Void`
 	/// input. In those cases, explicitly assign a value to this property that transforms
 	/// the input to suit your needs.
 	public var unsafeCocoaAction: CocoaAction {
-		return CocoaAction(self) { $0 as! Input }
+		return associatedObject(self, key: &unsafeCocoaActionKey, initial: { host in
+			CocoaAction(host) { $0 as! Input }
+		})
 	}
 }
+
+private var unsafeCocoaActionKey: UInt8 = 0


### PR DESCRIPTION
Since we want a "pure" repo for the Swift implementation and CocoaAction uses KVO, it should be separated.