### PR TITLE
Validate playground

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,14 @@ before_script:
   - git submodule update --init --recursive
 script:
   - set -o pipefail
-  - xcodebuild $XCODE_ACTION
-      -workspace "$TRAVIS_XCODE_WORKSPACE"
-      -scheme "$TRAVIS_XCODE_SCHEME"
-      -sdk "$XCODE_SDK"
-      -configuration Release
-      ENABLE_TESTABILITY=YES
-      GCC_GENERATE_DEBUGGING_SYMBOLS=NO
-      RUN_CLANG_STATIC_ANALYZER=NO
-      | xcpretty
+  - script/build
 xcode_workspace: ReactiveCocoa.xcworkspace
 matrix:
   include:
     - xcode_scheme: ReactiveCocoa-Mac
       env:
         - XCODE_SDK=macosx
-        - XCODE_ACTION=test
+        - XCODE_ACTION="build test"
     - xcode_scheme: ReactiveCocoa-iOS
       env:
         - XCODE_SDK=iphonesimulator

--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -312,11 +312,13 @@ scopedExample("`take`") {
 scopedExample("`observeOn`") {
     let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4 ])
     let completion = { print("is main thread? \(NSThread.currentThread().isMainThread)") }
-    
+
+    if #available(OSX 10.10, *) {
     baseProducer
-        .observeOn(QueueScheduler(name: "test"))
+        .observeOn(QueueScheduler(qos: QOS_CLASS_DEFAULT, name: "test"))
         .startWithCompleted(completion)
-    
+    }
+
     baseProducer
         .startWithCompleted(completion)
 }

--- a/script/build
+++ b/script/build
@@ -13,6 +13,16 @@ if [[ -z $TRAVIS_XCODE_SCHEME ]]; then
 	TRAVIS_XCODE_SCHEME="ReactiveCocoa-Mac"
 fi
 
+if [[ -z $XCODE_ACTION ]]; then
+      echo "\$XCODE_ACTION is not set. Using \`build\`"
+      XCODE_ACTION="build"
+fi
+
+if [[ -z $XCODE_SDK ]]; then
+      echo "\$XCODE_SDK is not set. Using \`macosx\`"
+      XCODE_SDK="macosx"
+fi
+
 xcodebuild $XCODE_ACTION \
       -workspace "$TRAVIS_XCODE_WORKSPACE" \
       -scheme "$TRAVIS_XCODE_SCHEME" \

--- a/script/build
+++ b/script/build
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+BUILD_DIRECTORY="build"
+CONFIGURATION=Release
+
+if [[ -z $TRAVIS_XCODE_WORKSPACE ]]; then
+	echo "\$TRAVIS_XCODE_WORKSPACE is not set. Using \`ReactiveCocoa.xcworkspace\`"
+	TRAVIS_XCODE_WORKSPACE="ReactiveCocoa.xcworkspace"
+fi
+
+if [[ -z $TRAVIS_XCODE_SCHEME ]]; then
+	echo "\$TRAVIS_XCODE_SCHEME is not set. Using \`ReactiveCocoa-Mac\`"
+	TRAVIS_XCODE_SCHEME="ReactiveCocoa-Mac"
+fi
+
+xcodebuild $XCODE_ACTION \
+      -workspace "$TRAVIS_XCODE_WORKSPACE" \
+      -scheme "$TRAVIS_XCODE_SCHEME" \
+      -sdk "$XCODE_SDK" \
+      -derivedDataPath "${BUILD_DIRECTORY}" \
+      -configuration $CONFIGURATION \
+      ENABLE_TESTABILITY=YES \
+      GCC_GENERATE_DEBUGGING_SYMBOLS=NO \
+      RUN_CLANG_STATIC_ANALYZER=NO \
+      | xcpretty
+
+# Compile code in playgrounds 
+if [[ $XCODE_SDK -eq "macosx" ]]; then
+      echo "SDK is $XCODE_SDK, validating playground..."
+      . script/validate-playground.sh
+else
+      echo "SDK is $XCODE_SDK, not validating playground."
+fi

--- a/script/build
+++ b/script/build
@@ -37,6 +37,4 @@ xcodebuild $XCODE_ACTION \
 if [[ $XCODE_SDK -eq "macosx" ]]; then
       echo "SDK is $XCODE_SDK, validating playground..."
       . script/validate-playground.sh
-else
-      echo "SDK is $XCODE_SDK, not validating playground."
 fi

--- a/script/build
+++ b/script/build
@@ -4,35 +4,34 @@ BUILD_DIRECTORY="build"
 CONFIGURATION=Release
 
 if [[ -z $TRAVIS_XCODE_WORKSPACE ]]; then
-	echo "\$TRAVIS_XCODE_WORKSPACE is not set. Using \`ReactiveCocoa.xcworkspace\`"
-	TRAVIS_XCODE_WORKSPACE="ReactiveCocoa.xcworkspace"
+    echo "Error: \$TRAVIS_XCODE_WORKSPACE is not set."
+    exit 1
 fi
 
 if [[ -z $TRAVIS_XCODE_SCHEME ]]; then
-	echo "\$TRAVIS_XCODE_SCHEME is not set. Using \`ReactiveCocoa-Mac\`"
-	TRAVIS_XCODE_SCHEME="ReactiveCocoa-Mac"
+    echo "Error: \$TRAVIS_XCODE_SCHEME is not set!"
+    exit 1
 fi
 
 if [[ -z $XCODE_ACTION ]]; then
-      echo "\$XCODE_ACTION is not set. Using \`build\`"
-      XCODE_ACTION="build"
+    echo "Error: \$XCODE_ACTION is not set!"
+    exit 1
 fi
 
 if [[ -z $XCODE_SDK ]]; then
-      echo "\$XCODE_SDK is not set. Using \`macosx\`"
-      XCODE_SDK="macosx"
+      echo "Error: \$XCODE_SDK is not set!"
+      exit 1
 fi
 
 xcodebuild $XCODE_ACTION \
-      -workspace "$TRAVIS_XCODE_WORKSPACE" \
-      -scheme "$TRAVIS_XCODE_SCHEME" \
-      -sdk "$XCODE_SDK" \
-      -derivedDataPath "${BUILD_DIRECTORY}" \
-      -configuration $CONFIGURATION \
-      ENABLE_TESTABILITY=YES \
-      GCC_GENERATE_DEBUGGING_SYMBOLS=NO \
-      RUN_CLANG_STATIC_ANALYZER=NO \
-      | xcpretty
+    -workspace "$TRAVIS_XCODE_WORKSPACE" \
+    -scheme "$TRAVIS_XCODE_SCHEME" \
+    -sdk "$XCODE_SDK" \
+    -derivedDataPath "${BUILD_DIRECTORY}" \
+    -configuration $CONFIGURATION \
+    ENABLE_TESTABILITY=YES \
+    GCC_GENERATE_DEBUGGING_SYMBOLS=NO \
+    RUN_CLANG_STATIC_ANALYZER=NO | xcpretty
 
 # Compile code in playgrounds 
 if [[ $XCODE_SDK -eq "macosx" ]]; then

--- a/script/validate-playground.sh
+++ b/script/validate-playground.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Bash script to lint the content of playgrounds
+# Heavily based on RxSwift's 
+# https://github.com/ReactiveX/RxSwift/blob/master/scripts/validate-playgrounds.sh
+
+if [ -z "$BUILD_DIRECTORY" ]; then
+	echo "\$BUILD_DIRECTORY is not set. Are you trying to run \`validate-playgrounds.sh\` without building RAC first?\n"
+	echo "To validate the playground, run \`script/build\`."
+	exit 1
+fi
+
+PAGES_PATH=${BUILD_DIRECTORY}/Build/Products/${CONFIGURATION}/all-playground-pages.swift
+
+cat ReactiveCocoa.playground/Sources/*.swift ReactiveCocoa.playground/Pages/**/*.swift > ${PAGES_PATH}
+
+swift -v -D NOT_IN_PLAYGROUND -F ${BUILD_DIRECTORY}/Build/Products/${CONFIGURATION} ${PAGES_PATH} > /dev/null
+
+# Cleanup
+rm -Rf $BUILD_DIRECTORY


### PR DESCRIPTION
This pull request addresses #2879.

I moved the command building the framework into a bash script, called "build". Should I go for something more explicit with "lint", "check"..? Also I'm not sure I should lint the playground with all the platform, I should probably do it only for the mac.

This is a WIP until the Travis build actually passes. 🍀  