### PR TITLE
Property composition and enhancements

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -236,6 +236,9 @@
 		7DFBED6D1CDB8F7D00EE435B /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
 		7DFBED6E1CDB918900EE435B /* UIBarButtonItem+RACCommandSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = D03764C719EDA41200A782A9 /* UIBarButtonItem+RACCommandSupport.m */; };
 		7DFBED6F1CDB926400EE435B /* UIBarButtonItem+RACCommandSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = D03764C619EDA41200A782A9 /* UIBarButtonItem+RACCommandSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9AF03BF91CEDF54A008AF0CF /* DynamicPropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF03BF71CEDF4B3008AF0CF /* DynamicPropertySpec.swift */; };
+		9AF03BFA1CEDF54E008AF0CF /* DynamicPropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF03BF71CEDF4B3008AF0CF /* DynamicPropertySpec.swift */; };
+		9AF03BFB1CEDF54F008AF0CF /* DynamicPropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF03BF71CEDF4B3008AF0CF /* DynamicPropertySpec.swift */; };
 		A1046B7A1BFF5661004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1046B7B1BFF5662004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1046B7C1BFF5662004D8045 /* EXTRuntimeExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D037666719EDA57100A782A9 /* EXTRuntimeExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -915,6 +918,7 @@
 		7A70657E1A3F88B8001E8354 /* RACKVOProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxy.m; sourceTree = "<group>"; };
 		7A7065831A3F8967001E8354 /* RACKVOProxySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RACKVOProxySpec.m; sourceTree = "<group>"; };
 		7DFBED031CDB8C9500EE435B /* ReactiveCocoaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveCocoaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9AF03BF71CEDF4B3008AF0CF /* DynamicPropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicPropertySpec.swift; sourceTree = "<group>"; };
 		A97451331B3A935E00F48E55 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Application.xcconfig"; sourceTree = "<group>"; };
 		A97451341B3A935E00F48E55 /* watchOS-Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Base.xcconfig"; sourceTree = "<group>"; };
 		A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Framework.xcconfig"; sourceTree = "<group>"; };
@@ -1804,6 +1808,7 @@
 				D8170FC01B100EBC004192AD /* FoundationExtensionsSpec.swift */,
 				D0A226101A72F30B00D33B74 /* ObjectiveCBridgingSpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */,
+				9AF03BF71CEDF4B3008AF0CF /* DynamicPropertySpec.swift */,
 				D0C312F219EF2A7700984962 /* SchedulerSpec.swift */,
 				02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */,
 				D0A2260A1A72E6C500D33B74 /* SignalProducerSpec.swift */,
@@ -2483,6 +2488,7 @@
 				7DFBED591CDB8DE300EE435B /* RACSubclassObject.m in Sources */,
 				7DFBED5A1CDB8DE300EE435B /* RACSubjectSpec.m in Sources */,
 				7DFBED5C1CDB8DE300EE435B /* RACSubscriberExamples.m in Sources */,
+				9AF03BFA1CEDF54E008AF0CF /* DynamicPropertySpec.swift in Sources */,
 				7DFBED5D1CDB8DE300EE435B /* RACSubscriberSpec.m in Sources */,
 				7DFBED5E1CDB8DE300EE435B /* RACSubscriptingAssignmentTrampolineSpec.m in Sources */,
 				7DFBED5F1CDB8DE300EE435B /* RACTargetQueueSchedulerSpec.m in Sources */,
@@ -2748,6 +2754,7 @@
 				D037670319EDA60000A782A9 /* RACSubjectSpec.m in Sources */,
 				D03766F119EDA60000A782A9 /* RACSchedulerSpec.m in Sources */,
 				D03766DF19EDA60000A782A9 /* RACCompoundDisposableSpec.m in Sources */,
+				9AF03BFB1CEDF54F008AF0CF /* DynamicPropertySpec.swift in Sources */,
 				D03766E519EDA60000A782A9 /* RACDisposableSpec.m in Sources */,
 				D0C3132019EF2D9700984962 /* RACTestObject.m in Sources */,
 				D03766D319EDA60000A782A9 /* NSUserDefaultsRACSupportSpec.m in Sources */,
@@ -2924,6 +2931,7 @@
 				D03766EE19EDA60000A782A9 /* RACMulticastConnectionSpec.m in Sources */,
 				D03766EA19EDA60000A782A9 /* RACKVOChannelSpec.m in Sources */,
 				CA6F28511C52626B001879D2 /* FlattenSpec.swift in Sources */,
+				9AF03BF91CEDF54A008AF0CF /* DynamicPropertySpec.swift in Sources */,
 				D0C3132119EF2D9700984962 /* RACTestObject.m in Sources */,
 				D03766FC19EDA60000A782A9 /* RACSignalSpec.m in Sources */,
 				D037670819EDA60000A782A9 /* RACSubscriberSpec.m in Sources */,

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -54,7 +54,7 @@ import enum Result.NoError
 			}
 	}
 
-	/// Atomically modifies the variable.
+	/// Modifies the variable.
 	///
 	/// Returns the old value.
 	public func modify(@noescape action: (Value) throws -> Value) rethrows -> Value {
@@ -63,7 +63,7 @@ import enum Result.NoError
 		return oldValue
 	}
 
-	/// Atomically performs an arbitrary action using the current value of the
+	/// Performs an arbitrary action using the current value of the
 	/// variable.
 	///
 	/// Returns the result of the action.

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -15,18 +15,6 @@ import enum Result.NoError
 
 	private var property: MutableProperty<AnyObject?>?
 
-	/// The current value of the property, as read and written using Key-Value
-	/// Coding.
-	public var value: AnyObject? {
-		@objc(rac_value) get {
-			return object?.valueForKeyPath(keyPath)
-		}
-
-		@objc(setRac_value:) set(newValue) {
-			object?.setValue(newValue, forKeyPath: keyPath)
-		}
-	}
-
 	/// A producer that will create a Key-Value Observer for the given object,
 	/// send its initial value then all changes over time, and then complete
 	/// when the observed object has deallocated.
@@ -64,6 +52,23 @@ import enum Result.NoError
 					self.property = nil
 				}
 			}
+	}
+
+	/// Atomically modifies the variable.
+	///
+	/// Returns the old value.
+	public func modify(@noescape action: (Value) throws -> Value) rethrows -> Value {
+		let oldValue = value
+		object?.setValue(try action(oldValue), forKey: keyPath)
+		return oldValue
+	}
+
+	/// Atomically performs an arbitrary action using the current value of the
+	/// variable.
+	///
+	/// Returns the result of the action.
+	public func withValue<Result>(@noescape action: (Value) throws -> Result) rethrows -> Result {
+		return try action(object?.valueForKeyPath(keyPath))
 	}
 }
 

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -121,7 +121,9 @@ extension PropertyType where Value: PropertyType {
 	public func flattenLatest() -> AnyProperty<Value.Value> {
 		return lift { $0.flatMap(.Latest) { $0.producer } }
 	}
+}
 
+extension PropertyType {
 	/// Maps a property to a new property, and then flattens it in the manner
 	/// described by `flattenLatest`.
 	@warn_unused_result(message="Did you forget to use the composed property?")
@@ -137,9 +139,7 @@ extension PropertyType where Value: PropertyType {
 			}
 		}
 	}
-}
 
-extension PropertyType {
 	/// Forwards only those values from `self` that have unique identities across the set of
 	/// all values that have been seen.
 	///

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -146,16 +146,7 @@ extension PropertyType {
 	public func flatMap<P: PropertyType>(strategy: PropertyFlattenStrategy, transform: Value -> P) -> AnyProperty<P.Value> {
 		switch strategy {
 		case .Latest:
-			let disposable = CompositeDisposable()
-
-			return lift(disposable) { producer -> SignalProducer<P.Value, NoError> in
-				return producer.flatMap(.Latest) { property -> SignalProducer<P.Value, NoError> in
-					let mappedProperty = transform(property)
-					let token = disposable.addDisposable { mappedProperty }
-
-					return mappedProperty.producer.on(disposed: { token.remove() })
-				}
-			}
+			return lift { $0.flatMap(.Latest) { transform($0).producer } }
 		}
 	}
 

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -33,9 +33,10 @@ extension PropertyType {
 		return withValue { $0 }
 	}
 
-	/// Maps the current value and all subsequent values to a new value.
+	/// Maps the current value and all subsequent values as a new property.
 	///
 	/// A mapped property would retain its source property.
+	@warn_unused_result(message="Did you forget to use the composed property?")
 	public func map<U>(transform: Value -> U) -> AnyProperty<U> {
 		return withValue { currentValue in
 			let producer = SignalProducer(signal: signal)
@@ -46,10 +47,12 @@ extension PropertyType {
 		}
 	}
 
-	/// Combine the current value and all subsequent values from two `Property`s
-	/// to obtain a new value by applying the supplied transform.
+	/// Combines the current value and the subsequent values of two `Property`s in
+	/// the manner described by `Signal.combineLatestWith:`, and applys the supplied
+	/// transform on the combined pair.
 	///
 	/// A combined property would retain its source properties.
+	@warn_unused_result(message="Did you forget to use the composed property?")
 	public func combineLatest<P: PropertyType, U>(with other: P, combining transform: (Value, P.Value) -> U) -> AnyProperty<U> {
 		return withValue { currentValue in
 			return other.withValue { currentOtherValue in
@@ -63,18 +66,21 @@ extension PropertyType {
 		}
 	}
 
-	/// Combine the current value and all subsequent values from two `Property`s
-	/// to a tuple.
+	/// Combines the current value and the subsequent values of two `Property`s in
+	/// the manner described by `Signal.combineLatestWith:`.
 	///
 	/// A zipped property would retain its source properties.
+	@warn_unused_result(message="Did you forget to use the composed property?")
 	public func combineLatest<P: PropertyType>(with other: P) -> AnyProperty<(Value, P.Value)> {
 		return combineLatest(with: other, combining: { $0 })
 	}
 
-	/// Zip the current value and all subsequent values from two `Property`s
-	/// to obtain a new value by applying the supplied transform.
+	/// Zips the current value and the subsequent values of two `Property`s in
+	/// the manner described by `Signal.zipWith:`, and applys the supplied
+	/// transform on the zipped pair.
 	///
 	/// A zipped property would retain its source properties.
+	@warn_unused_result(message="Did you forget to use the composed property?")
 	public func zip<P: PropertyType, U>(with other: P, combining transform: (Value, P.Value) -> U) -> AnyProperty<U> {
 		return withValue { currentValue in
 			return other.withValue { currentOtherValue in
@@ -88,10 +94,11 @@ extension PropertyType {
 		}
 	}
 
-	/// Zip the current value and all subsequent values from two `Property`s
-	/// to a tuple.
+	/// Zips the current value and the subsequent values of two `Property`s in
+	/// the manner described by `Signal.zipWith`.
 	///
 	/// A zipped property would retain its source properties.
+	@warn_unused_result(message="Did you forget to use the composed property?")
 	public func zip<P: PropertyType>(with other: P) -> AnyProperty<(Value, P.Value)> {
 		return zip(with: other, combining: { $0 })
 	}

--- a/ReactiveCocoaTests/Swift/DynamicPropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/DynamicPropertySpec.swift
@@ -1,0 +1,259 @@
+//
+//  DynamicPropertySpec.swift
+//  ReactiveCocoa
+//
+//  Created by Justin Spahr-Summers on 2015-01-23.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+import Foundation
+import Result
+import Nimble
+import Quick
+import ReactiveCocoa
+
+private let initialPropertyValue = "InitialValue"
+private let subsequentPropertyValue = "SubsequentValue"
+private let finalPropertyValue = "FinalValue"
+
+class DynamicPropertySpec: QuickSpec {
+	override func spec() {
+		describe("DynamicProperty") {
+			var object: ObservableObject!
+			var property: DynamicProperty!
+
+			let propertyValue: () -> Int? = {
+				if let value: AnyObject = property?.value {
+					return value as? Int
+				} else {
+					return nil
+				}
+			}
+
+			beforeEach {
+				object = ObservableObject()
+				expect(object.rac_value) == 0
+
+				property = DynamicProperty(object: object, keyPath: "rac_value")
+			}
+
+			afterEach {
+				object = nil
+			}
+
+			it("should read the underlying object") {
+				expect(propertyValue()) == 0
+
+				object.rac_value = 1
+				expect(propertyValue()) == 1
+			}
+
+			it("should write the underlying object") {
+				property.value = 1
+				expect(object.rac_value) == 1
+				expect(propertyValue()) == 1
+			}
+
+			it("should yield a producer that sends the current value and then the changes for the key path of the underlying object") {
+				var values: [Int] = []
+				property.producer.startWithNext { value in
+					expect(value).notTo(beNil())
+					values.append(value as! Int)
+				}
+
+				expect(values) == [ 0 ]
+
+				property.value = 1
+				expect(values) == [ 0, 1 ]
+
+				object.rac_value = 2
+				expect(values) == [ 0, 1, 2 ]
+			}
+
+			it("should yield a producer that sends the current value and then the changes for the key path of the underlying object, even if the value actually remains unchanged") {
+				var values: [Int] = []
+				property.producer.startWithNext { value in
+					expect(value).notTo(beNil())
+					values.append(value as! Int)
+				}
+
+				expect(values) == [ 0 ]
+
+				property.value = 0
+				expect(values) == [ 0, 0 ]
+
+				object.rac_value = 0
+				expect(values) == [ 0, 0, 0 ]
+			}
+
+			it("should yield a signal that emits subsequent values for the key path of the underlying object") {
+				var values: [Int] = []
+				property.signal.observeNext { value in
+					expect(value).notTo(beNil())
+					values.append(value as! Int)
+				}
+
+				expect(values) == []
+
+				property.value = 1
+				expect(values) == [ 1 ]
+
+				object.rac_value = 2
+				expect(values) == [ 1, 2 ]
+			}
+
+			it("should yield a signal that emits subsequent values for the key path of the underlying object, even if the value actually remains unchanged") {
+				var values: [Int] = []
+				property.signal.observeNext { value in
+					expect(value).notTo(beNil())
+					values.append(value as! Int)
+				}
+
+				expect(values) == []
+
+				property.value = 0
+				expect(values) == [ 0 ]
+
+				object.rac_value = 0
+				expect(values) == [ 0, 0 ]
+			}
+
+			it("should have a completed producer when the underlying object deallocates") {
+				var completed = false
+
+				property = {
+					// Use a closure so this object has a shorter lifetime.
+					let object = ObservableObject()
+					let property = DynamicProperty(object: object, keyPath: "rac_value")
+
+					property.producer.startWithCompleted {
+						completed = true
+					}
+
+					expect(completed) == false
+					expect(property.value).notTo(beNil())
+					return property
+				}()
+
+				expect(completed).toEventually(beTruthy())
+				expect(property.value).to(beNil())
+			}
+
+			it("should have a completed signal when the underlying object deallocates") {
+				var completed = false
+
+				property = {
+					// Use a closure so this object has a shorter lifetime.
+					let object = ObservableObject()
+					let property = DynamicProperty(object: object, keyPath: "rac_value")
+
+					property.signal.observeCompleted {
+						completed = true
+					}
+
+					expect(completed) == false
+					expect(property.value).notTo(beNil())
+					return property
+				}()
+
+				expect(completed).toEventually(beTruthy())
+				expect(property.value).to(beNil())
+			}
+
+			it("should retain property while DynamicProperty's underlying object is retained"){
+				weak var dynamicProperty: DynamicProperty? = property
+
+				property = nil
+				expect(dynamicProperty).toNot(beNil())
+
+				object = nil
+				expect(dynamicProperty).to(beNil())
+			}
+
+
+			it("should modify the value") {
+				property.value = 1
+				expect(property.modify({ _ in 2 }) as? NSNumber) == 1
+				expect(property.value as? NSNumber) == 2
+			}
+
+			it("should modify the value and subsquently send out a Next event with the new value") {
+				property.value = 1
+				var value: AnyObject?
+
+				property.producer.startWithNext {
+					value = $0
+				}
+
+				expect(value as? NSNumber) == 1
+				expect(property.modify({ _ in 2 }) as? NSNumber) == 1
+
+				expect(property.value as? NSNumber) == 2
+				expect(value as? NSNumber) == 2
+			}
+
+			it("should swap the value") {
+				property.value = 1
+
+				expect(property.swap(2) as? NSNumber) == 1
+				expect(property.value as? NSNumber) == 2
+			}
+
+			it("should swap the value and subsquently send out a Next event with the new value") {
+				property.value = 1
+				var value: AnyObject?
+
+				property.producer.startWithNext {
+					value = $0
+				}
+
+				expect(value as? NSNumber) == 1
+				expect(property.swap(2) as? NSNumber) == 1
+
+				expect(property.value as? NSNumber) == 2
+				expect(value as? NSNumber) == 2
+			}
+		}
+
+		describe("binding") {
+			describe("to a dynamic property") {
+				var object: ObservableObject!
+				var property: DynamicProperty!
+
+				beforeEach {
+					object = ObservableObject()
+					expect(object.rac_value) == 0
+
+					property = DynamicProperty(object: object, keyPath: "rac_value")
+				}
+				
+				afterEach {
+					object = nil
+				}
+				
+				it("should bridge values sent on a signal to Objective-C") {
+					let (signal, observer) = Signal<Int, NoError>.pipe()
+					property <~ signal
+					observer.sendNext(1)
+					expect(object.rac_value) == 1
+				}
+				
+				it("should bridge values sent on a signal producer to Objective-C") {
+					let producer = SignalProducer<Int, NoError>(value: 1)
+					property <~ producer
+					expect(object.rac_value) == 1
+				}
+				
+				it("should bridge values from a source property to Objective-C") {
+					let source = MutableProperty(1)
+					property <~ source
+					expect(object.rac_value) == 1
+				}
+			}
+		}
+	}
+}
+
+private class ObservableObject: NSObject {
+	dynamic var rac_value: Int = 0
+}


### PR DESCRIPTION
Here is an implementation of the #2841 proposal, seeking for your comments.
Swift 3.0 is not required.

#### Objective
This PR aims to introduce new composition operators on `PropertyType`.

On the other hand, `AnyMutableProperty` is introduced for users who would like to build higher level constructs that operate on the `MutablePropertyType` abstraction. An example would be two-way bindings between two `MutablePropertyType`s.

#### Implementation
This PR carries breaking changes to those who have custom implementations of the `PropertyType` protocols.

##### Type-erasing wrappers
1. `AnyProperty` now uses a private, type erasing box.
2. A new type erased wrapper `AnyMutableProperty`.
3. The producer and the signal of an `AnyProperty` now completes only when the source has completed.

##### Protocols
4. Introduce `withValue` and `modify` in the protocols.
5. `value` and `swap(newValue:)` are now protocol extension methods.

##### Property Composition
1. New combining operators: `combineLatest` and `zip`
2. New value operators: `combinePrevious`, `skipRepeats` and `uniqueValues`
3. New flattening operators: `flattenLatest` and `flatMapLatest`

##### Miscellaneous
1. Separated the `DynamicProperty` tests from the rest of the PropertySpec. 
2. Reorganised the `Property.swift`, with protocols & protocol extensions at the top, followed by implementations, bindings and finally the private utility classes.

#### Caveats
##### Type erasing boxes
The current closure approach cannot be expressed non-escaping blocks and rethrowing functions in Swift 2.2 so far, and Swift 3 has tackled only one of them so far. Without these, `withValue` and `modify` cannot be brought to the protocols.

In the future (post Swift 3.0), these wrappers should be replaceable by typealiases of a generalised existential type without breaking any user code.

-
Edited on 21 May 2016