### PR TITLE
[UIScheduler] Don't rely on `NSThread.isMainThread()`

### DIFF
--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -52,15 +52,28 @@ public final class ImmediateScheduler: SchedulerType {
 	}
 }
 
-/// A scheduler that performs all work on the main thread, as soon as possible.
+/// A scheduler that performs all work on the main queue, as soon as possible.
 ///
-/// If the caller is already running on the main thread when an action is
+/// If the caller is already running on the main queue when an action is
 /// scheduled, it may be run synchronously. However, ordering between actions
 /// will always be preserved.
 public final class UIScheduler: SchedulerType {
+	private static var dispatchOnceToken: dispatch_once_t = 0
+	private static var dispatchSpecificKey: UInt8 = 0
+	private static var dispatchSpecificContext: UInt8 = 0
+
 	private var queueLength: Int32 = 0
 
-	public init() {}
+	public init() {
+		dispatch_once(&UIScheduler.dispatchOnceToken) {
+			dispatch_queue_set_specific(
+				dispatch_get_main_queue(),
+				&UIScheduler.dispatchSpecificKey,
+				&UIScheduler.dispatchSpecificContext,
+				nil
+			)
+		}
+	}
 
 	public func schedule(action: () -> Void) -> Disposable? {
 		let disposable = SimpleDisposable()
@@ -74,9 +87,9 @@ public final class UIScheduler: SchedulerType {
 
 		let queued = OSAtomicIncrement32(&queueLength)
 
-		// If we're already running on the main thread, and there isn't work
+		// If we're already running on the main queue, and there isn't work
 		// already enqueued, we can skip scheduling and just execute directly.
-		if NSThread.isMainThread() && queued == 1 {
+		if queued == 1 && dispatch_get_specific(&UIScheduler.dispatchSpecificKey) == &UIScheduler.dispatchSpecificContext {
 			actionAndDecrement()
 		} else {
 			dispatch_async(dispatch_get_main_queue(), actionAndDecrement)


### PR DESCRIPTION
Use `dispatch_queue_set_specific` for the main queue and `dispatch_get_specific` instead.

Should fix #2635.
