### PR TITLE
Action tweaks

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -69,7 +69,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 		errors = events.map { $0.error }.ignoreNil()
 
 		_enabled <~ enabledIf.producer
-			.combineLatestWith(executing.producer)
+			.combineLatestWith(_executing.producer)
 			.map(Action.shouldBeEnabled)
 	}
 

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -110,7 +110,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 				disposable.addDisposable(signalDisposable)
 
 				signal.observe { event in
-					observer.action(event.mapError { .ProducerError($0) })
+					observer.action(event.mapError(ActionError.ProducerError))
 					self.eventsObserver.sendNext(event)
 				}
 			}


### PR DESCRIPTION
Additionally, I'm not sure what is the point of `executingQueue`. The targeted `_executing` is a `MutableProperty` which is thread-safe, and the access to the variable in `disposable.addDisposable { ... }` is not surrounded by `dispatch_sync(self.executingQueue) { ... }`. Can we remove it or should we add `dispatch_sync` in the disposable action?