### PR TITLE
avoid signal retain in `bind`

### DIFF
--- a/ReactiveCocoaTests/Objective-C/RACSignalSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACSignalSpec.m
@@ -251,6 +251,19 @@ qck_describe(@"-bind:", ^{
 		expect(@(secondSubscribed)).to(beFalsy());
 		expect(@(errored)).to(beTruthy());
 	});
+	
+	qck_it(@"should not retain signals that are subscribed", ^{
+		__weak RACSignal *weakSignal;
+		@autoreleasepool {
+			RACSignal *delaySignal = [[RACSignal return:@123] delay:1];
+			[[delaySignal map:^id(id value) {
+				return @456;
+			}] subscribeNext:^(id x) {
+			}];
+			weakSignal = delaySignal;
+		}
+		expect(weakSignal).to(beNil());
+	});
 });
 
 qck_describe(@"subscribing", ^{


### PR DESCRIPTION
`bind` will retain signals when subscribe, this is not necessary and is leak-prone. The code below will fail

```objc
    __weak RACSignal *s1;
    @autoreleasepool {
        RACSignal *s2 = [[RACSignal return:@123] delay:1];
        [[s2 map:^id(id value) {
            return @456;
        }] subscribeNext:^(id x) {
            NSLog(@"%@", x);
        }];
        s1 = s2;
    }
    NSAssert(s1 == nil, @"should be nil");
```

PR fix this issue and makes rac_textSignal of UITextField/UITextView simpler.