### PR TITLE
Debounce

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1215,6 +1215,24 @@ extension SignalType {
 			return disposable
 		}
 	}
+
+	/// Debounce values sent by the receiver, such that at least `interval`
+	/// seconds pass after the receiver has last sent a value, then
+	/// forwards the latest value on the given scheduler.
+	///
+	/// If multiple values are received before the interval has elapsed, the
+	/// latest value is the one that will be passed on.
+	///
+	/// If the input signal terminates while a value is being debounced, that value
+	/// will be discarded and the returned signal will terminate immediately.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func debounce(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> Signal<Value, Error> {
+		return materialize().flatMap(.Latest, transform: { event in
+			event.isTerminating
+				? SignalProducer(value: event).observeOn(scheduler)
+				: SignalProducer(value: event).delay(interval, onScheduler: scheduler)
+		}).dematerialize()
+	}
 }
 
 extension SignalType {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -928,6 +928,20 @@ extension SignalProducerType {
 		return lift { $0.throttle(interval, onScheduler: scheduler) }
 	}
 
+	/// Debounce values sent by the receiver, such that at least `interval`
+	/// seconds pass after the receiver has last sent a value, then
+	/// forwards the latest value on the given scheduler.
+	///
+	/// If multiple values are received before the interval has elapsed, the
+	/// latest value is the one that will be passed on.
+	///
+	/// If `self` terminates while a value is being debounced, that value
+	/// will be discarded and the returned producer will terminate immediately.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func debounce(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> SignalProducer<Value, Error> {
+		return lift { $0.debounce(interval, onScheduler: scheduler) }
+	}
+
 	/// Forwards events from `self` until `interval`. Then if producer isn't completed yet,
 	/// fails with `error` on `scheduler`.
 	///

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1297,6 +1297,93 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("debounce") {
+			var scheduler: TestScheduler!
+			var observer: Signal<Int, NoError>.Observer!
+			var signal: Signal<Int, NoError>!
+
+			beforeEach {
+				scheduler = TestScheduler()
+
+				let (baseSignal, baseObserver) = Signal<Int, NoError>.pipe()
+				observer = baseObserver
+
+				signal = baseSignal.debounce(1, onScheduler: scheduler)
+				expect(signal).notTo(beNil())
+			}
+
+			it("should send values on the given scheduler once the interval has passed since the last value was sent") {
+				var values: [Int] = []
+				signal.observeNext { value in
+					values.append(value)
+				}
+
+				expect(values) == []
+
+				observer.sendNext(0)
+				expect(values) == []
+
+				scheduler.advance()
+				expect(values) == []
+
+				observer.sendNext(1)
+				observer.sendNext(2)
+				expect(values) == []
+
+				scheduler.advanceByInterval(1.5)
+				expect(values) == [ 2 ]
+
+				scheduler.advanceByInterval(3)
+				expect(values) == [ 2 ]
+
+				observer.sendNext(3)
+				expect(values) == [ 2 ]
+
+				scheduler.advance()
+				expect(values) == [ 2 ]
+
+				observer.sendNext(4)
+				observer.sendNext(5)
+				scheduler.advance()
+				expect(values) == [ 2 ]
+
+				scheduler.run()
+				expect(values) == [ 2, 5 ]
+			}
+
+			it("should schedule completion immediately") {
+				var values: [Int] = []
+				var completed = false
+
+				signal.observe { event in
+					switch event {
+					case let .Next(value):
+						values.append(value)
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
+
+				observer.sendNext(0)
+				scheduler.advance()
+				expect(values) == []
+
+				observer.sendNext(1)
+				observer.sendCompleted()
+				expect(completed) == false
+
+				scheduler.advance()
+				expect(values) == []
+				expect(completed) == true
+
+				scheduler.run()
+				expect(values) == []
+				expect(completed) == true
+			}
+		}
+
 		describe("sampleWith") {
 			var sampledSignal: Signal<(Int, String), NoError>!
 			var observer: Signal<Int, NoError>.Observer!

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1287,6 +1287,10 @@ class SignalSpec: QuickSpec {
 				observer.sendCompleted()
 				expect(completed) == false
 
+				scheduler.advance()
+				expect(values) == [ 0 ]
+				expect(completed) == true
+
 				scheduler.run()
 				expect(values) == [ 0 ]
 				expect(completed) == true


### PR DESCRIPTION
This is a potential implementation of https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2075. It's derived from a [previous implementation](https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2075#issuecomment-148425140) that did not handle terminating events correctly. I use that version on a long-lived property, so terminating events hadn't come up yet.

This matches the behavior of `RACSignal` and [Rx](http://rxmarbles.com/#debounce), but it doesn't appear to match the way that the term `debounce` is commonly used in JavaScript frameworks. The goal of #2075 is to revive the `RACSignal` throttle behavior, and the term `debounce` came up later, so if it is inappropriate, it could definitely be renamed.

My use case for this operator is to throttle expensive writes of configuration changes that a user can alter rapidly, until the user stops taking actions and the configuration value reaches a resting point.

In the process, I also added [an additional check](https://github.com/ReactiveCocoa/ReactiveCocoa/commit/44ca545d30476ba1948e2cc34630531d40f31f57) to the `throttle` test, to match what I think (from the documentation of `throttle`) is the expected behavior - terminating events should be scheduled to run immediately, whereas only checking `TestScheduler`'s `run` just tests that they run eventually, without allowing any additional values to be sent. I think that this more strictly validates the behavior of `throttle` and `debounce`.