### PR TITLE
Add `prefix(value:)`

### DIFF
--- a/ReactiveCocoa/Swift/Flatten.swift
+++ b/ReactiveCocoa/Swift/Flatten.swift
@@ -385,6 +385,12 @@ extension SignalProducerType {
 	public func concat(next: SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
 		return SignalProducer<SignalProducer<Value, Error>, Error>(values: [ self.producer, next ]).flatten(.Concat)
 	}
+
+	/// `concat`s `self` onto initial `value`.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func beginWith(value: Value) -> SignalProducer<Value, Error> {
+		return SignalProducer(value: value).concat(self.producer)
+	}
 }
 
 private final class ConcatState<Value, Error: ErrorType> {

--- a/ReactiveCocoa/Swift/Flatten.swift
+++ b/ReactiveCocoa/Swift/Flatten.swift
@@ -388,7 +388,7 @@ extension SignalProducerType {
 
 	/// `concat`s `self` onto initial `value`.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
-	public func beginWith(value: Value) -> SignalProducer<Value, Error> {
+	public func prefix(value value: Value) -> SignalProducer<Value, Error> {
 		return SignalProducer(value: value).concat(self.producer)
 	}
 }

--- a/ReactiveCocoaTests/Swift/FlattenSpec.swift
+++ b/ReactiveCocoaTests/Swift/FlattenSpec.swift
@@ -841,5 +841,27 @@ class FlattenSpec: QuickSpec {
 				expect(completed) == true
 			}
 		}
+
+		describe("SignalProducer.beginWith()") {
+			it("should emit initial value") {
+				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
+
+				let mergedSignals = signal.beginWith(0)
+
+				var lastValue: Int?
+				mergedSignals.startWithNext { lastValue = $0 }
+
+				expect(lastValue) == 0
+
+				observer.sendNext(1)
+				expect(lastValue) == 1
+
+				observer.sendNext(2)
+				expect(lastValue) == 2
+
+				observer.sendNext(3)
+				expect(lastValue) == 3
+			}
+		}
 	}
 }

--- a/ReactiveCocoaTests/Swift/FlattenSpec.swift
+++ b/ReactiveCocoaTests/Swift/FlattenSpec.swift
@@ -842,11 +842,11 @@ class FlattenSpec: QuickSpec {
 			}
 		}
 
-		describe("SignalProducer.beginWith()") {
+		describe("SignalProducer.prefix(value:)") {
 			it("should emit initial value") {
 				let (signal, observer) = SignalProducer<Int, NoError>.pipe()
 
-				let mergedSignals = signal.beginWith(0)
+				let mergedSignals = signal.prefix(value: 0)
 
 				var lastValue: Int?
 				mergedSignals.startWithNext { lastValue = $0 }


### PR DESCRIPTION
As discussed in Slack channel recently, there seem to have many reinvention of `beginWith` (old `- (instancetype)startWith:(id)value`), so I think it's good time to add one for Swift code.

Example of `beginWith` are:

- [JavaScript example](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754)
- [Swift example](https://github.com/inamiy/ReactiveCocoaCatalog/blob/20a01590f4bfb056e09f8a73dffb16d1c0a5e0b3/ReactiveCocoaCatalog/Samples/WhoToFollowViewController.swift)

---

**2016/05/31 Updated:** Renamed `beginWith()` to `prefix(value:)`