### PR TITLE
Debounce

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1215,6 +1215,24 @@ extension SignalType {
 			return disposable
 		}
 	}
+
+	/// Debounce values sent by the receiver, such that at least `interval`
+	/// seconds pass after the receiver has last sent a value, then
+	/// forwards the latest value on the given scheduler.
+	///
+	/// If multiple values are received before the interval has elapsed, the
+	/// latest value is the one that will be passed on.
+	///
+	/// If the input signal terminates while a value is being debounced, that value
+	/// will be discarded and the returned signal will terminate immediately.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func debounce(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> Signal<Value, Error> {
+		return materialize().flatMap(.Latest, transform: { event in
+			event.isTerminating
+				? SignalProducer(value: event).observeOn(scheduler)
+				: SignalProducer(value: event).delay(interval, onScheduler: scheduler)
+		}).dematerialize()
+	}
 }
 
 extension SignalType {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -928,6 +928,20 @@ extension SignalProducerType {
 		return lift { $0.throttle(interval, onScheduler: scheduler) }
 	}
 
+	/// Debounce values sent by the receiver, such that at least `interval`
+	/// seconds pass after the receiver has last sent a value, then
+	/// forwards the latest value on the given scheduler.
+	///
+	/// If multiple values are received before the interval has elapsed, the
+	/// latest value is the one that will be passed on.
+	///
+	/// If `self` terminates while a value is being debounced, that value
+	/// will be discarded and the returned producer will terminate immediately.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func debounce(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> SignalProducer<Value, Error> {
+		return lift { $0.debounce(interval, onScheduler: scheduler) }
+	}
+
 	/// Forwards events from `self` until `interval`. Then if producer isn't completed yet,
 	/// fails with `error` on `scheduler`.
 	///

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1297,6 +1297,93 @@ class SignalSpec: QuickSpec {
 			}
 		}
 
+		describe("debounce") {
+			var scheduler: TestScheduler!
+			var observer: Signal<Int, NoError>.Observer!
+			var signal: Signal<Int, NoError>!
+
+			beforeEach {
+				scheduler = TestScheduler()
+
+				let (baseSignal, baseObserver) = Signal<Int, NoError>.pipe()
+				observer = baseObserver
+
+				signal = baseSignal.debounce(1, onScheduler: scheduler)
+				expect(signal).notTo(beNil())
+			}
+
+			it("should send values on the given scheduler once the interval has passed since the last value was sent") {
+				var values: [Int] = []
+				signal.observeNext { value in
+					values.append(value)
+				}
+
+				expect(values) == []
+
+				observer.sendNext(0)
+				expect(values) == []
+
+				scheduler.advance()
+				expect(values) == []
+
+				observer.sendNext(1)
+				observer.sendNext(2)
+				expect(values) == []
+
+				scheduler.advanceByInterval(1.5)
+				expect(values) == [ 2 ]
+
+				scheduler.advanceByInterval(3)
+				expect(values) == [ 2 ]
+
+				observer.sendNext(3)
+				expect(values) == [ 2 ]
+
+				scheduler.advance()
+				expect(values) == [ 2 ]
+
+				observer.sendNext(4)
+				observer.sendNext(5)
+				scheduler.advance()
+				expect(values) == [ 2 ]
+
+				scheduler.run()
+				expect(values) == [ 2, 5 ]
+			}
+
+			it("should schedule completion immediately") {
+				var values: [Int] = []
+				var completed = false
+
+				signal.observe { event in
+					switch event {
+					case let .Next(value):
+						values.append(value)
+					case .Completed:
+						completed = true
+					default:
+						break
+					}
+				}
+
+				observer.sendNext(0)
+				scheduler.advance()
+				expect(values) == []
+
+				observer.sendNext(1)
+				observer.sendCompleted()
+				expect(completed) == false
+
+				scheduler.advance()
+				expect(values) == []
+				expect(completed) == true
+
+				scheduler.run()
+				expect(values) == []
+				expect(completed) == true
+			}
+		}
+
 		describe("sampleWith") {
 			var sampledSignal: Signal<(Int, String), NoError>!
 			var observer: Signal<Int, NoError>.Observer!

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1287,6 +1287,10 @@ class SignalSpec: QuickSpec {
 				observer.sendCompleted()
 				expect(completed) == false
 
+				scheduler.advance()
+				expect(values) == [ 0 ]
+				expect(completed) == true
+
 				scheduler.run()
 				expect(values) == [ 0 ]
 				expect(completed) == true


### PR DESCRIPTION
Fixes #2075, supersedes #2939.

This adds the `precondition` that Rex had and conforms it to the RAC style.

Rex's didn't pass the (legitimate) test that was included. I think that's because termination events weren't sent on the passed-in scheduler.