### PR TITLE
Fix memory leak when binding MutablePropertyType to a producer

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -238,14 +238,14 @@ public func <~ <P: MutablePropertyType>(property: P, signal: Signal<P.Value, NoE
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the created signal sends a `Completed` event.
 public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.Value, NoError>) -> Disposable {
-	var disposable: Disposable!
+	let disposable = CompositeDisposable()
 
 	producer.startWithSignal { signal, signalDisposable in
 		property <~ signal
-		disposable = signalDisposable
+		disposable += signalDisposable
 
-		property.producer.startWithCompleted {
-			signalDisposable.dispose()
+		disposable += property.producer.startWithCompleted {
+			disposable.dispose()
 		}
 	}
 


### PR DESCRIPTION
I've fixed a memory leak when binding a MutablePropertyType to a producer (`public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.Value, NoError>) -> Disposable`). The fix is similar to that already in place when binding a MutablePropertyType to a signal.