### PR TITLE
[Bugfix] Property composition operator.

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -401,16 +401,15 @@ public struct AnyProperty<Value>: PropertyType {
 	/// The producer and the signal of the created property would complete only
 	/// when the `propertyProducer` completes.
 	private init(propertyProducer: SignalProducer<Value, NoError>, capturing sources: [Any]) {
-		var observerDisposable: Disposable?
 		var value: Value!
 
-		observerDisposable = propertyProducer.start { event in
+		let observerDisposable = propertyProducer.start { event in
 			switch event {
 			case let .Next(newValue):
 				value = newValue
 
 			case .Completed, .Interrupted:
-				observerDisposable?.dispose()
+				break
 
 			case let .Failed(error):
 				fatalError("Receive unexpected error from a producer of `NoError` type: \(error)")
@@ -418,7 +417,7 @@ public struct AnyProperty<Value>: PropertyType {
 		}
 
 		if value != nil {
-			disposable = observerDisposable.map(ScopedDisposable.init)
+			disposable = ScopedDisposable(observerDisposable)
 			self.sources = sources
 
 			_value = { value }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -401,7 +401,7 @@ public struct AnyProperty<Value>: PropertyType {
 	/// The producer and the signal of the created property would complete only
 	/// when the `propertyProducer` completes.
 	private init(propertyProducer: SignalProducer<Value, NoError>, capturing sources: [Any]) {
-		var observerDisposable: Disposable!
+		var observerDisposable: Disposable?
 		var value: Value!
 
 		observerDisposable = propertyProducer.start { event in
@@ -410,7 +410,7 @@ public struct AnyProperty<Value>: PropertyType {
 				value = newValue
 
 			case .Completed, .Interrupted:
-				observerDisposable.dispose()
+				observerDisposable?.dispose()
 
 			case let .Failed(error):
 				fatalError("Receive unexpected error from a producer of `NoError` type: \(error)")
@@ -418,7 +418,7 @@ public struct AnyProperty<Value>: PropertyType {
 		}
 
 		if value != nil {
-			disposable = ScopedDisposable(observerDisposable)
+			disposable = observerDisposable.map(ScopedDisposable.init)
 			self.sources = sources
 
 			_value = { value }

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -370,6 +370,13 @@ class PropertySpec: QuickSpec {
 						expect(weakProperty).to(beNil())
 					}
 
+					it("should transform property from a property that has a terminated producer") {
+						let property = ConstantProperty(1)
+						let transformedProperty = property.map { $0 + 1 }
+
+						expect(transformedProperty.value) == 2
+					}
+
 					describe("signal lifetime and producer lifetime") {
 						it("should return a producer and a signal which respect the lifetime of the source property instead of the read-only view itself") {
 							var signalCompleted = 0


### PR DESCRIPTION
When working on #2964, I caught a bug that can crash the composition operators. It would affect `ConstantProperty`s in the current RAC5 branch.

A perfect counter example of IUO.
:-[