### PR TITLE
[5.0] Changes to producer- and signal-sourced `AnyProperty`s.

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -366,17 +366,15 @@ public struct AnyProperty<Value>: PropertyType {
 	/// Initializes a property that first takes on `initialValue`, then each value
 	/// sent on a signal created by `producer`.
 	public init(initialValue: Value, producer: SignalProducer<Value, NoError>) {
-		let mutableProperty = MutableProperty(initialValue)
-		mutableProperty <~ producer
-		self.init(mutableProperty)
+		self.init(propertyProducer: SignalProducer(value: initialValue).concat(producer),
+		          capturing: [])
 	}
 
 	/// Initializes a property that first takes on `initialValue`, then each value
 	/// sent on `signal`.
 	public init(initialValue: Value, signal: Signal<Value, NoError>) {
-		let mutableProperty = MutableProperty(initialValue)
-		mutableProperty <~ signal
-		self.init(mutableProperty)
+		self.init(propertyProducer: SignalProducer(value: initialValue).concat(SignalProducer(signal: signal)),
+		          capturing: [])
 	}
 
 	/// Initializes a property by applying the unary `SignalProducer` transform on

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -366,14 +366,14 @@ public struct AnyProperty<Value>: PropertyType {
 	/// Initializes a property that first takes on `initialValue`, then each value
 	/// sent on a signal created by `producer`.
 	public init(initialValue: Value, producer: SignalProducer<Value, NoError>) {
-		self.init(propertyProducer: SignalProducer(value: initialValue).concat(producer),
+		self.init(propertyProducer: producer.prefix(value: initialValue),
 		          capturing: [])
 	}
 
 	/// Initializes a property that first takes on `initialValue`, then each value
 	/// sent on `signal`.
 	public init(initialValue: Value, signal: Signal<Value, NoError>) {
-		self.init(propertyProducer: SignalProducer(value: initialValue).concat(SignalProducer(signal: signal)),
+		self.init(propertyProducer: SignalProducer(signal: signal).prefix(value: initialValue),
 		          capturing: [])
 	}
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -438,14 +438,20 @@ class PropertySpec: QuickSpec {
 					var signalInterrupted = false
 
 					let (signal, observer) = Signal<Int, NoError>.pipe()
-					let property = AnyProperty(initialValue: 1, producer: SignalProducer(signal: signal))
-					property.signal.observeCompleted { signalCompleted = true }
-					property.producer.startWithCompleted { producerCompleted = true }
+					var property = Optional(AnyProperty(initialValue: 1, producer: SignalProducer(signal: signal)))
+					let propertySignal = property!.signal
 
-					expect(property.value) == 1
+					propertySignal.observeCompleted { signalCompleted = true }
+					property!.producer.startWithCompleted { producerCompleted = true }
+
+					expect(property!.value) == 1
 
 					observer.sendNext(2)
-					expect(property.value) == 2
+					expect(property!.value) == 2
+					expect(producerCompleted) == false
+					expect(signalCompleted) == false
+
+					property = nil
 					expect(producerCompleted) == false
 					expect(signalCompleted) == false
 
@@ -453,7 +459,7 @@ class PropertySpec: QuickSpec {
 					expect(producerCompleted) == true
 					expect(signalCompleted) == true
 
-					property.signal.observeInterrupted { signalInterrupted = true }
+					propertySignal.observeInterrupted { signalInterrupted = true }
 					expect(signalInterrupted) == true
 				}
 			}
@@ -480,14 +486,20 @@ class PropertySpec: QuickSpec {
 					var signalInterrupted = false
 
 					let (signal, observer) = Signal<Int, NoError>.pipe()
-					let property = AnyProperty(initialValue: 1, signal: signal)
-					property.signal.observeCompleted { signalCompleted = true }
-					property.producer.startWithCompleted { producerCompleted = true }
+					var property = Optional(AnyProperty(initialValue: 1, signal: signal))
+					let propertySignal = property!.signal
 
-					expect(property.value) == 1
+					propertySignal.observeCompleted { signalCompleted = true }
+					property!.producer.startWithCompleted { producerCompleted = true }
+
+					expect(property!.value) == 1
 
 					observer.sendNext(2)
-					expect(property.value) == 2
+					expect(property!.value) == 2
+					expect(producerCompleted) == false
+					expect(signalCompleted) == false
+
+					property = nil
 					expect(producerCompleted) == false
 					expect(signalCompleted) == false
 
@@ -495,7 +507,7 @@ class PropertySpec: QuickSpec {
 					expect(producerCompleted) == true
 					expect(signalCompleted) == true
 
-					property.signal.observeInterrupted { signalInterrupted = true }
+					propertySignal.observeInterrupted { signalInterrupted = true }
 					expect(signalInterrupted) == true
 				}
 			}


### PR DESCRIPTION
Since now we have property composition operators creating properties that respect the lifetime of their ultimate source(s), IMO producer/signal-sourced `AnyProperty`s should be treated the same way for consistency.

It would be a breaking change though, as currently the producers and signals of these `AnyProperty`s terminates when the property (note: not the source) are deinitialised.