### PR TITLE
Adopt `inout` parameter in `Atomic.modify`.

### DIFF
--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -20,7 +20,7 @@ public final class Atomic<Value> {
 		}
 	
 		set(newValue) {
-			modify { _ in newValue }
+			swap(newValue)
 		}
 	}
 	
@@ -50,15 +50,15 @@ public final class Atomic<Value> {
 	///
 	/// Returns the old value.
 	public func swap(newValue: Value) -> Value {
-		return modify { _ in newValue }
+		return modify { $0 = newValue }
 	}
 
 	/// Atomically modifies the variable.
 	///
 	/// Returns the old value.
-	public func modify(@noescape action: (Value) throws -> Value) rethrows -> Value {
+	public func modify(@noescape action: (inout Value) throws -> Void) rethrows -> Value {
 		return try withValue { value in
-			_value = try action(value)
+			try action(&_value)
 			return value
 		}
 	}

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -78,12 +78,7 @@ public final class CompositeDisposable: Disposable {
 		public func remove() {
 			if let token = bagToken.swap(nil) {
 				disposable?.disposables.modify { bag in
-					guard var bag = bag else {
-						return nil
-					}
-
-					bag.removeValueForToken(token)
-					return bag
+					bag?.removeValueForToken(token)
 				}
 			}
 		}
@@ -133,14 +128,9 @@ public final class CompositeDisposable: Disposable {
 
 		var handle: DisposableHandle? = nil
 		disposables.modify { ds in
-			guard var ds = ds else {
-				return nil
+			if let token = ds?.insert(d) {
+				handle = DisposableHandle(bagToken: token, disposable: self)
 			}
-
-			let token = ds.insert(d)
-			handle = DisposableHandle(bagToken: token, disposable: self)
-
-			return ds
 		}
 
 		if let handle = handle {
@@ -207,9 +197,7 @@ public final class SerialDisposable: Disposable {
 
 		set(d) {
 			let oldState = state.modify { state in
-				var state = state
 				state.innerDisposable = d
-				return state
 			}
 
 			oldState.innerDisposable?.dispose()

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -141,24 +141,18 @@ public struct SignalProducer<Value, Error: ErrorType> {
 			var replayValues: [Value] = []
 			var replayToken: RemovalToken?
 			var next = state.modify { state in
-				var state = state
-
 				replayValues = state.values
 				if replayValues.isEmpty {
 					token = state.observers?.insert(observer)
 				} else {
 					replayToken = state.replayBuffers.insert(replayBuffer)
 				}
-
-				return state
 			}
 
 			while !replayValues.isEmpty {
 				replayValues.forEach(observer.sendNext)
 
 				next = state.modify { state in
-					var state = state
-
 					replayValues = replayBuffer.values
 					replayBuffer.values = []
 					if replayValues.isEmpty {
@@ -167,8 +161,6 @@ public struct SignalProducer<Value, Error: ErrorType> {
 						}
 						token = state.observers?.insert(observer)
 					}
-
-					return state
 				}
 			}
 
@@ -179,9 +171,7 @@ public struct SignalProducer<Value, Error: ErrorType> {
 			if let token = token {
 				disposable += {
 					state.modify { state in
-						var state = state
 						state.observers?.removeValueForToken(token)
-						return state
 					}
 				}
 			}
@@ -189,8 +179,6 @@ public struct SignalProducer<Value, Error: ErrorType> {
 
 		let bufferingObserver: Signal<Value, Error>.Observer = Observer { event in
 			let originalState = state.modify { state in
-				var state = state
-
 				if let value = event.value {
 					state.addValue(value, upToCapacity: capacity)
 				} else {
@@ -199,8 +187,6 @@ public struct SignalProducer<Value, Error: ErrorType> {
 					state.terminationEvent = event
 					state.observers = nil
 				}
-
-				return state
 			}
 
 			originalState.observers?.forEach { $0.action(event) }

--- a/ReactiveCocoaTests/Swift/AtomicSpec.swift
+++ b/ReactiveCocoaTests/Swift/AtomicSpec.swift
@@ -31,7 +31,7 @@ class AtomicSpec: QuickSpec {
 		}
 
 		it("should modify the value atomically") {
-			expect(atomic.modify({ $0 + 1 })) == 1
+			expect(atomic.modify({ $0 += 1 })) == 1
 			expect(atomic.value) == 2
 		}
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -186,7 +186,7 @@ class PropertySpec: QuickSpec {
 			it("should modify the value atomically") {
 				let property = MutableProperty(initialPropertyValue)
 
-				expect(property.modify({ _ in subsequentPropertyValue })) == initialPropertyValue
+				expect(property.modify({ $0 = subsequentPropertyValue })) == initialPropertyValue
 				expect(property.value) == subsequentPropertyValue
 			}
 
@@ -199,7 +199,7 @@ class PropertySpec: QuickSpec {
 				}
 
 				expect(value) == initialPropertyValue
-				expect(property.modify({ _ in subsequentPropertyValue })) == initialPropertyValue
+				expect(property.modify({ $0 = subsequentPropertyValue })) == initialPropertyValue
 
 				expect(property.value) == subsequentPropertyValue
 				expect(value) == subsequentPropertyValue


### PR DESCRIPTION
~~Both~~ `modify` ~~and `withValue`~~ now expects an action closure that takes an inout parameter. ~~In other words, `withValue` can now mutate the value.~~

The motivation is to take advantage of the potential `inout` optimisation. Ideally with the optimisation in place, ~~`withValue` would enable in-place mutation with no copying at all, while~~ `modify` always makes a copy of the old value before any in-place mutation happens.

But this would likely be a trivial optimisation to the ReactiveSwift internals, since the growing data structures of most of the value type internal states are already CoW due to the use of stdlib collections.

-

Edit: Reduced the scope. Will create follow-up PRs if this is accepted.