### PR TITLE
Update then() to forward interruptions on the original producer

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1331,12 +1331,12 @@ extension SignalProducerType {
 	}
 
 	/// Waits for completion of `producer`, *then* forwards all events from
-	/// `replacement`. Any failure sent from `producer` is forwarded immediately, in
-	/// which case `replacement` will not be started, and none of its events will be
-	/// be forwarded. All values sent from `producer` are ignored.
+	/// `replacement`. Any failure or interruption sent from `producer` is forwarded
+	/// immediately, in which case `replacement` will not be started, and none of its
+	/// events will be be forwarded. All values sent from `producer` are ignored.
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func then<U>(replacement: SignalProducer<U, Error>) -> SignalProducer<U, Error> {
-		let relay = SignalProducer<U, Error> { observer, observerDisposable in
+		return SignalProducer<U, Error> { observer, observerDisposable in
 			self.startWithSignal { signal, signalDisposable in
 				observerDisposable.addDisposable(signalDisposable)
 
@@ -1345,7 +1345,7 @@ extension SignalProducerType {
 					case let .Failed(error):
 						observer.sendFailed(error)
 					case .Completed:
-						observer.sendCompleted()
+						observerDisposable += replacement.start(observer)
 					case .Interrupted:
 						observer.sendInterrupted()
 					case .Next:
@@ -1354,8 +1354,6 @@ extension SignalProducerType {
 				}
 			}
 		}
-
-		return relay.concat(replacement)
 	}
 
 	/// Starts the producer, then blocks, waiting for the first value.

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1688,6 +1688,25 @@ class SignalProducerSpec: QuickSpec {
 				expect(result?.error) == TestError.Default
 			}
 
+			it("should forward interruptions from the original producer") {
+				let (original, observer) = SignalProducer<Int, NoError>.pipe()
+
+				var subsequentStarted = false
+				let subsequent = SignalProducer<Int, NoError> { observer, _ in
+					subsequentStarted = true
+				}
+
+				var interrupted = false
+				let producer = original.then(subsequent)
+				producer.startWithInterrupted {
+					interrupted = true
+				}
+				expect(subsequentStarted) == false
+
+				observer.sendInterrupted()
+				expect(interrupted) == true
+			}
+
 			it("should complete when both inputs have completed") {
 				let (original, originalObserver) = SignalProducer<Int, NoError>.pipe()
 				let (subsequent, subsequentObserver) = SignalProducer<String, NoError>.pipe()


### PR DESCRIPTION
The `then()` operator is documented as waiting until completion of the first producer, before subscribing to the subsequent producer. The behaviour for Interrupted events was not explicitly documented, and because of the semantics of `concat()` was being treated the same was a Completed event.

This behaviour caught me by surprise! For example, I was scratching my head for some time as to why this didn't behave the way I expected:

```swift
// Upon completion of the upload, sends the NSURL and then completes.
func uploadImage(data: NSData, to url: NSURL) -> SignalProducer<NSURL, NSError> {
  let upload = UploadRequest(data: data, type: "image/jpeg", url: NSURL)

  // Even if `api.perform(upload)` is interrupted internally, the URL is passed
  // through anyway and the producer completes!
  return api.perform(upload).then(SignalProducer(value: url))
}
```

I'm proposing this change to make the semantics of Interrupted events explicit, and hopefully it's in the spirit of the way `then()` is intended to be used. Would love to hear if you think this is a worthwhile change!