### PR TITLE
Introduce `withMutableValue`.

### DIFF
--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -77,7 +77,7 @@ public final class CompositeDisposable: Disposable {
 		/// that are no longer needed.
 		public func remove() {
 			if let token = bagToken.swap(nil) {
-				disposable?.disposables.modify { bag in
+				disposable?.disposables.withMutableValue { bag in
 					bag?.removeValueForToken(token)
 				}
 			}
@@ -126,11 +126,9 @@ public final class CompositeDisposable: Disposable {
 			return DisposableHandle.empty
 		}
 
-		var handle: DisposableHandle? = nil
-		disposables.modify { ds in
-			if let token = ds?.insert(d) {
-				handle = DisposableHandle(bagToken: token, disposable: self)
-			}
+		let handle = disposables.withMutableValue { ds -> DisposableHandle? in
+			let token = ds?.insert(d)
+			return token.map { DisposableHandle(bagToken: $0, disposable: self) }
 		}
 
 		if let handle = handle {

--- a/ReactiveCocoa/Swift/Flatten.swift
+++ b/ReactiveCocoa/Swift/Flatten.swift
@@ -427,7 +427,7 @@ private final class ConcatState<Value, Error: ErrorType> {
 
 		var shouldStart = true
 
-		queuedSignalProducers.modify { queue in
+		queuedSignalProducers.withMutableValue { queue in
 			// An empty queue means the concat is idle, ready & waiting to start
 			// the next producer.
 			shouldStart = queue.isEmpty
@@ -446,7 +446,7 @@ private final class ConcatState<Value, Error: ErrorType> {
 
 		var nextSignalProducer: SignalProducer<Value, Error>?
 
-		queuedSignalProducers.modify { queue in
+		queuedSignalProducers.withMutableValue { queue in
 			// Active producers remain in the queue until completed. Since
 			// dequeueing happens at completion of the active producer, the
 			// first producer in the queue can be removed.
@@ -507,7 +507,7 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 			switch event {
 			case let .Next(producer):
 				producer.startWithSignal { innerSignal, innerDisposable in
-					inFlight.modify { $0 += 1 }
+					inFlight.withMutableValue { $0 += 1 }
 					let handle = disposable.addDisposable(innerDisposable)
 
 					innerSignal.observe { event in
@@ -617,7 +617,7 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 			switch event {
 			case let .Next(innerProducer):
 				innerProducer.startWithSignal { innerSignal, innerDisposable in
-					state.modify { state in
+					state.withMutableValue { state in
 						// When we replace the disposable below, this prevents the
 						// generated Interrupted event from doing any work.
 						state.replacingInnerSignal = true
@@ -625,7 +625,7 @@ extension SignalType where Value: SignalProducerType, Error == Value.Error {
 
 					latestInnerDisposable.innerDisposable = innerDisposable
 
-					state.modify { state in
+					state.withMutableValue { state in
 						state.replacingInnerSignal = false
 						state.innerSignalComplete = false
 					}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -170,7 +170,7 @@ public struct SignalProducer<Value, Error: ErrorType> {
 
 			if let token = token {
 				disposable += {
-					state.modify { state in
+					state.withMutableValue { state in
 						state.observers?.removeValueForToken(token)
 					}
 				}

--- a/ReactiveCocoaTests/Swift/AtomicSpec.swift
+++ b/ReactiveCocoaTests/Swift/AtomicSpec.swift
@@ -40,5 +40,14 @@ class AtomicSpec: QuickSpec {
 			expect(result) == true
 			expect(atomic.value) == 1
 		}
+
+		it("should perform an action with the value, and reflect the changes made within the action") {
+			let result: Bool = atomic.withMutableValue {
+				$0 += 1
+				return $0 == 2
+			}
+			expect(result) == true
+			expect(atomic.value) == 2
+		}
 	}
 }

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -236,6 +236,18 @@ class PropertySpec: QuickSpec {
 				expect(property.value) == initialPropertyValue
 			}
 
+			it("should perform an action with the value, and reflect the changes made in the action") {
+				let property = MutableProperty(initialPropertyValue)
+
+				let result: Bool = property.withMutableValue {
+					$0 = subsequentPropertyValue
+					return $0.isEmpty
+				}
+
+				expect(result) == false
+				expect(property.value) == subsequentPropertyValue
+			}
+
 			it("should not deadlock on recursive value access") {
 				let (producer, observer) = SignalProducer<Int, NoError>.pipe()
 				let property = MutableProperty(0)


### PR DESCRIPTION
The change is addictive. It simply adds `Atomic.withMutableValue(_:)` and `MutableProperty.withMutableValue(_:)`, and applies them in places where appropriate. The main difference from `modify(_:)` is that it **does not** copy and return the original value, and it was able to replace many previous uses of `modify` in the ReactiveSwift codebase that discards the returned value.

The benchmark this time uses an `Atomic` containing a struct of **eight** `Int`s to amplify the effect.

[Benchmark Source](https://gist.github.com/andersio/1c7a08b77075acc188ac3f62a13ee8fc)

##### Reading: pass-by-value (withValue) vs `inout` (withMutableValue)
| Iterations | Pass-by-value | Using `inout` |
| ---------- |  ------- | ----------- |
| 10000 | 0.004 sec<sup>(14% SD)</sup> | 0.003 sec<sup>(21% SD)</sup> |
| 500000 | 0.184 sec<sup>(6% SD)</sup> | 0.120 sec<sup>(8% SD)</sup> |
| 5000000 | 1.864 sec<sup>(2% SD)</sup> | 1.183 sec<sup>(1% SD)</sup> |

##### Mutating: `modify` vs `withMutableValue` (only for cases that the old value is discardable)
| Iterations | `modify` | `withMutableValue ` |
| ---------- |  ------- | ----------- |
| 10000 | 0.004 sec<sup>(10% SD)</sup> | 0.002 sec<sup>(21% SD)</sup> |
| 500000 | 0.194 sec<sup>(22% SD)</sup> | 0.106 sec<sup>(8% SD)</sup> |
| 5000000 | 1.752 sec<sup>(2% SD)</sup> | 1.096 sec<sup>(4% SD)</sup> |