### PR TITLE
Fix TestScheduler not having correct `currentDate` while advancing

### DIFF
--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -316,16 +316,19 @@ public final class TestScheduler: DateSchedulerType {
 		lock.lock()
 
 		assert(currentDate.compare(newDate) != .OrderedDescending)
-		_currentDate = newDate
 
 		while scheduledActions.count > 0 {
 			if newDate.compare(scheduledActions[0].date) == .OrderedAscending {
 				break
 			}
 
+			_currentDate = scheduledActions[0].date
+
 			let scheduledAction = scheduledActions.removeAtIndex(0)
 			scheduledAction.action()
 		}
+
+		_currentDate = newDate
 
 		lock.unlock()
 	}

--- a/ReactiveCocoaTests/Swift/SchedulerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SchedulerSpec.swift
@@ -236,14 +236,16 @@ class SchedulerSpec: QuickSpec {
 			it("should run actions when advanced past the target date") {
 				var string = ""
 
-				scheduler.scheduleAfter(15) {
+				scheduler.scheduleAfter(15) { [weak scheduler] in
 					string += "bar"
 					expect(NSThread.isMainThread()) == true
+					expect(scheduler?.currentDate).to(beCloseTo(startDate.dateByAddingTimeInterval(15), within: dateComparisonDelta))
 				}
 
-				scheduler.scheduleAfter(5) {
+				scheduler.scheduleAfter(5) { [weak scheduler] in
 					string += "foo"
 					expect(NSThread.isMainThread()) == true
+					expect(scheduler?.currentDate).to(beCloseTo(startDate.dateByAddingTimeInterval(5), within: dateComparisonDelta))
 				}
 
 				expect(string) == ""

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -866,6 +866,11 @@ class SignalProducerSpec: QuickSpec {
 				let scheduler = TestScheduler()
 				let producer = timer(1, onScheduler: scheduler, withLeeway: 0)
 
+				let startDate = scheduler.currentDate
+				let tick1 = startDate.dateByAddingTimeInterval(1)
+				let tick2 = startDate.dateByAddingTimeInterval(2)
+				let tick3 = startDate.dateByAddingTimeInterval(3)
+
 				var dates: [NSDate] = []
 				producer.startWithNext { dates.append($0) }
 
@@ -873,18 +878,16 @@ class SignalProducerSpec: QuickSpec {
 				expect(dates) == []
 
 				scheduler.advanceByInterval(1)
-				let firstTick = scheduler.currentDate
-				expect(dates) == [firstTick]
+				expect(dates) == [tick1]
 
 				scheduler.advance()
-				expect(dates) == [firstTick]
+				expect(dates) == [tick1]
 
 				scheduler.advanceByInterval(0.2)
-				let secondTick = scheduler.currentDate
-				expect(dates) == [firstTick, secondTick]
+				expect(dates) == [tick1, tick2]
 
 				scheduler.advanceByInterval(1)
-				expect(dates) == [firstTick, secondTick, scheduler.currentDate]
+				expect(dates) == [tick1, tick2, tick3]
 			}
 
 			it("should release the signal when disposed") {


### PR DESCRIPTION
Bug repro is well-illustrated in @bricklife's tweets (thanks!):

-  [RAC code](https://twitter.com/ooba/status/741099929427312640) (bad)
-  [RxSwift code](https://twitter.com/ooba/status/741100653351604225) (good)

We can normally work around this RAC issue by calling `testScheduler.advanceByInterval(delta)` multiple times in test codes, but many people would get stuck with this behavior (today's me :sob:),
so I would like to get this PR applied.