### PR TITLE
Update organization to ReactiveCocoa

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -2220,7 +2220,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0710;
-				ORGANIZATIONNAME = GitHub;
+				ORGANIZATIONNAME = ReactiveCocoa;
 				TargetAttributes = {
 					7DFBED021CDB8C9500EE435B = {
 						CreatedOnToolsVersion = 7.3.1;


### PR DESCRIPTION
Thought I'd follow the "PR's are preferable to Issues" mantra on this one.

Not sure if you wanted to lose the GH reference in the organization name, it cropped up while I was proofreading the documentation updates by @eimantas
