### PR TITLE
Deprecated startWithNext/observeNext and exposed only for Error == NoError. Added startWithResult/observeResult

### DIFF
--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -667,8 +667,8 @@ scopedExample("`retry`") {
             }
         }
         .retry(1)
-        .startWithNext { value in
-            print(value)
+        .startWithResult { result in
+            print(result)
         }
 }
 
@@ -755,7 +755,7 @@ scopedExample("`flatMap(.Latest)`") {
  */
 scopedExample("`flatMapError`") {
     SignalProducer<Int, NSError>(error: NSError(domain: "flatMapError", code: 42, userInfo: nil))
-        .flatMapError { SignalProducer<Int, NSError>(value: $0.code) }
+        .flatMapError { SignalProducer<Int, NoError>(value: $0.code) }
         .startWithNext { value in
             print(value)
         }

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -181,9 +181,9 @@ extension SignalType {
 		return observe(Observer(action))
 	}
 
-	@available(*, unavailable, message="This Signal may emit errors which must be handled explicitly, or observed using observeResult:")
+	@available(*, deprecated, message="This Signal may emit errors which must be handled explicitly, or observed using observeResult:")
 	public func observeNext(next: Value -> Void) -> Disposable? {
-		fatalError("Unavailable method")
+		return observe(Observer(next: next))
 	}
 
 	/// Observes the Signal by invoking the given callback when

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -181,6 +181,21 @@ extension SignalType {
 		return observe(Observer(action))
 	}
 
+	/// Observes the Signal by invoking the given callback when
+	/// `next` or `failed` event are received.
+	///
+	/// Returns a Disposable which can be used to stop the invocation of the
+	/// callback. Disposing of the Disposable will have no effect on the Signal
+	/// itself.
+	public func observeResult(result: (Result<Value, Error>) -> Void) -> Disposable? {
+		return observe(
+			Observer(
+				next: { result(.Success($0)) },
+				failed: { result(.Failure($0)) }
+			)
+		)
+	}
+
 	/// Observes the Signal by invoking the given callback when a `completed` event is
 	/// received.
 	///

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -181,6 +181,11 @@ extension SignalType {
 		return observe(Observer(action))
 	}
 
+	@available(*, unavailable, message="This Signal may emit errors which must be handled explicitly, or observed using observeResult:")
+	public func observeNext(next: Value -> Void) -> Disposable? {
+		fatalError("Unavailable method")
+	}
+
 	/// Observes the Signal by invoking the given callback when
 	/// `next` or `failed` event are received.
 	///

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -181,16 +181,6 @@ extension SignalType {
 		return observe(Observer(action))
 	}
 
-	/// Observes the Signal by invoking the given callback when `next` events are
-	/// received.
-	///
-	/// Returns a Disposable which can be used to stop the invocation of the
-	/// callbacks. Disposing of the Disposable will have no effect on the Signal
-	/// itself.
-	public func observeNext(next: Value -> Void) -> Disposable? {
-		return observe(Observer(next: next))
-	}
-
 	/// Observes the Signal by invoking the given callback when a `completed` event is
 	/// received.
 	///
@@ -221,7 +211,21 @@ extension SignalType {
 	public func observeInterrupted(interrupted: () -> Void) -> Disposable? {
 		return observe(Observer(interrupted: interrupted))
 	}
+}
 
+extension SignalType where Error == NoError {
+	/// Observes the Signal by invoking the given callback when `next` events are
+	/// received.
+	///
+	/// Returns a Disposable which can be used to stop the invocation of the
+	/// callbacks. Disposing of the Disposable will have no effect on the Signal
+	/// itself.
+	public func observeNext(next: Value -> Void) -> Disposable? {
+		return observe(Observer(next: next))
+	}
+}
+
+extension SignalType {
 	/// Maps each value in the signal to a new value.
 	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func map<U>(transform: Value -> U) -> Signal<U, Error> {

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -361,9 +361,9 @@ extension SignalProducerType {
 		return start(Observer(observerAction))
 	}
 
-	@available(*, unavailable, message="This SignalProducer may emit errors which must be handled explicitly, or observed using startWithResult:")
+	@available(*, deprecated, message="This SignalProducer may emit errors which must be handled explicitly, or observed using startWithResult:")
 	public func startWithNext(next: Value -> Void) -> Disposable {
-		fatalError("Unavailable method")
+		return start(Observer(next: next))
 	}
 
 	/// Creates a Signal from the producer, then adds an observer to

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -362,16 +362,6 @@ extension SignalProducerType {
 	}
 
 	/// Creates a Signal from the producer, then adds exactly one observer to
-	/// the Signal, which will invoke the given callback when `next` events are
-	/// received.
-	///
-	/// Returns a Disposable which can be used to interrupt the work associated
-	/// with the Signal, and prevent any future callbacks from being invoked.
-	public func startWithNext(next: Value -> Void) -> Disposable {
-		return start(Observer(next: next))
-	}
-
-	/// Creates a Signal from the producer, then adds exactly one observer to
 	/// the Signal, which will invoke the given callback when a `completed` event is
 	/// received.
 	///
@@ -400,7 +390,21 @@ extension SignalProducerType {
 	public func startWithInterrupted(interrupted: () -> Void) -> Disposable {
 		return start(Observer(interrupted: interrupted))
 	}
+}
 
+extension SignalProducerType where Error == NoError {
+	/// Creates a Signal from the producer, then adds exactly one observer to
+	/// the Signal, which will invoke the given callback when `next` events are
+	/// received.
+	///
+	/// Returns a Disposable which can be used to interrupt the work associated
+	/// with the Signal, and prevent any future callbacks from being invoked.
+	public func startWithNext(next: Value -> Void) -> Disposable {
+		return start(Observer(next: next))
+	}
+}
+
+extension SignalProducerType {
 	/// Lifts an unary Signal operator to operate upon SignalProducers instead.
 	///
 	/// In other words, this will create a new SignalProducer which will apply

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -361,6 +361,11 @@ extension SignalProducerType {
 		return start(Observer(observerAction))
 	}
 
+	@available(*, unavailable, message="This SignalProducer may emit errors which must be handled explicitly, or observed using startWithResult:")
+	public func startWithNext(next: Value -> Void) -> Disposable {
+		fatalError("Unavailable method")
+	}
+
 	/// Creates a Signal from the producer, then adds an observer to
 	/// the Signal, which will invoke the given callback when `next` or `failed` 
 	/// events are received.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -361,6 +361,21 @@ extension SignalProducerType {
 		return start(Observer(observerAction))
 	}
 
+	/// Creates a Signal from the producer, then adds an observer to
+	/// the Signal, which will invoke the given callback when `next` or `failed` 
+	/// events are received.
+	///
+	/// Returns a Disposable which can be used to interrupt the work associated
+	/// with the Signal, and prevent any future callbacks from being invoked.
+	public func startWithResult(result: Result<Value, Error> -> Void) -> Disposable {
+		return start(
+			Observer(
+				next: { result(.Success($0)) },
+				failed: { result(.Failure($0)) }
+			)
+		)
+	}
+
 	/// Creates a Signal from the producer, then adds exactly one observer to
 	/// the Signal, which will invoke the given callback when a `completed` event is
 	/// received.

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -90,9 +90,11 @@ class ActionSpec: QuickSpec {
 				it("should execute successfully") {
 					var receivedValue: String?
 
-					action.apply(0).startWithNext {
-						receivedValue = $0
-					}
+					action.apply(0)
+						.assumeNoErrors()
+						.startWithNext {
+							receivedValue = $0
+						}
 
 					expect(executionCount) == 1
 					expect(action.executing.value) == true

--- a/ReactiveCocoaTests/Swift/FlattenSpec.swift
+++ b/ReactiveCocoaTests/Swift/FlattenSpec.swift
@@ -107,6 +107,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -126,6 +127,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -164,6 +166,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -183,6 +186,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -202,6 +206,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -240,6 +245,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -450,6 +456,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -469,6 +476,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -507,6 +515,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -526,6 +535,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -545,6 +555,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}
@@ -583,6 +594,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.observeNext { value in
 						observed = value
 					}

--- a/ReactiveCocoaTests/Swift/FlattenSpec.swift
+++ b/ReactiveCocoaTests/Swift/FlattenSpec.swift
@@ -276,6 +276,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -295,6 +296,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -333,6 +335,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -352,6 +355,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -371,6 +375,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -409,6 +414,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatten(.Latest)
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -598,6 +604,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -617,6 +624,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -655,6 +663,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -674,6 +683,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -693,6 +703,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}
@@ -731,6 +742,7 @@ class FlattenSpec: QuickSpec {
 				var observed: Int? = nil
 				outer
 					.flatMap(.Latest) { _ in inner }
+					.assumeNoErrors()
 					.startWithNext { value in
 						observed = value
 					}

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -1254,7 +1254,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send values for Next events") {
 				var result: [Int] = []
-				dematerialized.startWithNext { result.append($0) }
+				dematerialized
+					.assumeNoErrors()
+					.startWithNext { result.append($0) }
 				
 				expect(result).to(beEmpty())
 				
@@ -1297,7 +1299,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 			
 			it("should send the last N values upon completion") {
 				var result: [Int] = []
-				lastThree.startWithNext { result.append($0) }
+				lastThree
+					.assumeNoErrors()
+					.startWithNext { result.append($0) }
 				
 				observer.sendNext(1)
 				observer.sendNext(2)
@@ -1311,7 +1315,9 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			it("should send less than N values if not enough were received") {
 				var result: [Int] = []
-				lastThree.startWithNext { result.append($0) }
+				lastThree
+					.assumeNoErrors()
+					.startWithNext { result.append($0) }
 				
 				observer.sendNext(1)
 				observer.sendNext(2)
@@ -1417,9 +1423,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var current: Int?
-				producer.startWithNext { value in
-					current = value
-				}
+				producer
+					.assumeNoErrors()
+					.startWithNext { value in
+						current = value
+					}
 				
 				for value in 1...5 {
 					observer.sendNext(value)
@@ -1451,9 +1459,11 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 				
 				var even: Bool?
-				producer.startWithNext { value in
-					even = value
-				}
+				producer
+					.assumeNoErrors()
+					.startWithNext { value in
+						even = value
+					}
 				
 				observer.sendNext(1)
 				expect(even) == false

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -702,6 +702,24 @@ class SignalProducerSpec: QuickSpec {
 					expect(values) == [1, 2, 3]
 				}
 
+				// TODO: remove when the method is marked unavailable.
+				it("receives next values with erroring signal") {
+					let (producer, observer) = SignalProducer<Int, TestError>.pipe()
+
+					var values = [Int]()
+					producer.startWithNext { next in
+						values.append(next)
+					}
+
+					observer.sendNext(1)
+					observer.sendNext(2)
+					observer.sendNext(3)
+
+					observer.sendCompleted()
+
+					expect(values) == [1, 2, 3]
+				}
+
 				it("receives results") {
 					let (producer, observer) = SignalProducer<Int, TestError>.pipe()
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1934,7 +1934,10 @@ class SignalProducerSpec: QuickSpec {
 				it("emits new values") {
 					var last: Int?
 
-					replayedProducer.startWithNext { last = $0 }
+					replayedProducer
+						.assumeNoErrors()
+						.startWithNext { last = $0 }
+					
 					expect(last).to(beNil())
 
 					observer.sendNext(1)
@@ -1966,6 +1969,7 @@ class SignalProducerSpec: QuickSpec {
 					var last: Int?
 
 					replayedProducer
+						.assumeNoErrors()
 						.startWithNext { last = $0 }
 					expect(last) == 1
 				}
@@ -1997,6 +2001,7 @@ class SignalProducerSpec: QuickSpec {
 					var values: [Int] = []
 
 					disposable = replayedProducer
+						.assumeNoErrors()
 						.startWithNext { values.append($0) }
 					expect(values) == [ 3, 4 ]
 
@@ -2007,6 +2012,7 @@ class SignalProducerSpec: QuickSpec {
 					values = []
 
 					replayedProducer
+						.assumeNoErrors()
 						.startWithNext { values.append($0) }
 					expect(values) == [ 4, 5 ]
 				}
@@ -2191,7 +2197,9 @@ class SignalProducerSpec: QuickSpec {
 					let logger = TestLogger(expectations: expectations)
 					
 					let (producer, observer) = SignalProducer<Int, TestError>.pipe()
-					producer.logEvents(logger: logger.logEvent).startWithNext { _ in }
+					producer
+						.logEvents(logger: logger.logEvent)
+						.start()
 					
 					observer.sendNext(1)
 					observer.sendCompleted()

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -701,6 +701,26 @@ class SignalProducerSpec: QuickSpec {
 
 					expect(values) == [1, 2, 3]
 				}
+
+				it("receives results") {
+					let (producer, observer) = SignalProducer<Int, TestError>.pipe()
+
+					var results: [Result<Int, TestError>] = []
+					producer.startWithResult { results.append($0) }
+
+					observer.sendNext(1)
+					observer.sendNext(2)
+					observer.sendNext(3)
+					observer.sendFailed(.Default)
+
+					observer.sendCompleted()
+
+					expect(results).to(haveCount(4))
+					expect(results[0].value) == 1
+					expect(results[1].value) == 2
+					expect(results[2].value) == 3
+					expect(results[3].error) == .Default
+				}
 			}
 		}
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -313,6 +313,26 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(1)
 				expect(values) == [1]
 			}
+
+			it("receives results") {
+				let (signal, observer) = Signal<Int, TestError>.pipe()
+
+				var results: [Result<Int, TestError>] = []
+				signal.observeResult { results.append($0) }
+
+				observer.sendNext(1)
+				observer.sendNext(2)
+				observer.sendNext(3)
+				observer.sendFailed(.Default)
+
+				observer.sendCompleted()
+
+				expect(results).to(haveCount(4))
+				expect(results[0].value) == 1
+				expect(results[1].value) == 2
+				expect(results[2].value) == 3
+				expect(results[3].error) == .Default
+			}
 		}
 
 		describe("map") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1701,7 +1701,9 @@ class SignalSpec: QuickSpec {
 			
 			it("should send values for Next events") {
 				var result: [Int] = []
-				dematerialized.observeNext { result.append($0) }
+				dematerialized
+					.assumeNoErrors()
+					.observeNext { result.append($0) }
 				
 				expect(result).to(beEmpty())
 				
@@ -1744,7 +1746,9 @@ class SignalSpec: QuickSpec {
 
 			it("should send the last N values upon completion") {
 				var result: [Int] = []
-				lastThree.observeNext { result.append($0) }
+				lastThree
+					.assumeNoErrors()
+					.observeNext { result.append($0) }
 				
 				observer.sendNext(1)
 				observer.sendNext(2)
@@ -1758,7 +1762,9 @@ class SignalSpec: QuickSpec {
 
 			it("should send less than N values if not enough were received") {
 				var result: [Int] = []
-				lastThree.observeNext { result.append($0) }
+				lastThree
+					.assumeNoErrors()
+					.observeNext { result.append($0) }
 				
 				observer.sendNext(1)
 				observer.sendNext(2)
@@ -1864,9 +1870,11 @@ class SignalSpec: QuickSpec {
 				}
 				
 				var current: Int?
-				signal.observeNext { value in
-					current = value
-				}
+				signal
+					.assumeNoErrors()
+					.observeNext { value in
+						current = value
+					}
 				
 				for value in 1...5 {
 					observer.sendNext(value)
@@ -1898,9 +1906,11 @@ class SignalSpec: QuickSpec {
 				}
 				
 				var even: Bool?
-				signal.observeNext { value in
-					even = value
-				}
+				signal
+					.assumeNoErrors()
+					.observeNext { value in
+						even = value
+					}
 				
 				observer.sendNext(1)
 				expect(even) == false

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -314,6 +314,19 @@ class SignalSpec: QuickSpec {
 				expect(values) == [1]
 			}
 
+			//  TODO: remove when the method is marked unavailable
+			it("receives next values with erroring signal") {
+				var values = [Int]()
+				let (signal, observer) = Signal<Int, TestError>.pipe()
+
+				signal.observeNext { next in
+					values.append(next)
+				}
+
+				observer.sendNext(1)
+				expect(values) == [1]
+			}
+
 			it("receives results") {
 				let (signal, observer) = Signal<Int, TestError>.pipe()
 

--- a/ReactiveCocoaTests/Swift/TestError.swift
+++ b/ReactiveCocoaTests/Swift/TestError.swift
@@ -24,10 +24,20 @@ internal extension SignalProducerType {
 	/// This is useful in tests to be able to just use `startWithNext`
 	/// in cases where we know that an error won't be emitted.
 	func assumeNoErrors() -> SignalProducer<Value, NoError> {
-		return self.flatMapError { error in
+		return self.lift { $0.assumeNoErrors() }
+	}
+}
+
+internal extension SignalType {
+	/// Halts if an error is emitted in the receiver signal.
+	/// This is useful in tests to be able to just use `startWithNext`
+	/// in cases where we know that an error won't be emitted.
+	func assumeNoErrors() -> Signal<Value, NoError> {
+		return self.mapError { error in
 			fatalError("Unexpected error: \(error)")
 
 			()
 		}
 	}
 }
+

--- a/ReactiveCocoaTests/Swift/TestError.swift
+++ b/ReactiveCocoaTests/Swift/TestError.swift
@@ -6,6 +6,9 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
+import ReactiveCocoa
+import Result
+
 enum TestError: Int {
 	case Default = 0
 	case Error1 = 1
@@ -13,4 +16,18 @@ enum TestError: Int {
 }
 
 extension TestError: ErrorType {
+}
+
+
+internal extension SignalProducerType {
+	/// Halts if an error is emitted in the receiver signal.
+	/// This is useful in tests to be able to just use `startWithNext`
+	/// in cases where we know that an error won't be emitted.
+	func assumeNoErrors() -> SignalProducer<Value, NoError> {
+		return self.flatMapError { error in
+			fatalError("Unexpected error: \(error)")
+
+			()
+		}
+	}
 }


### PR DESCRIPTION
Fixes #3010 

<img width="411" alt="screen shot 2016-06-28 at 12 47 31" src="https://cloud.githubusercontent.com/assets/685609/16430085/b22315da-3d2e-11e6-895e-588c6f47778f.png">
