### PR TITLE
[5.0] Property = ConstantProperty + AnyProperty

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -32,14 +32,14 @@ public final class Action<Input, Output, Error: ErrorProtocol> {
 
 	/// Whether the action is currently executing.
 	public var isExecuting: Property<Bool> {
-		return Property(reflecting: _isExecuting)
+		return Property(_isExecuting)
 	}
 
 	private let _isExecuting: MutableProperty<Bool> = MutableProperty(false)
 
 	/// Whether the action is currently enabled.
 	public var isEnabled: Property<Bool> {
-		return Property(reflecting: _isEnabled)
+		return Property(_isEnabled)
 	}
 
 	private let _isEnabled: MutableProperty<Bool> = MutableProperty(false)
@@ -61,7 +61,7 @@ public final class Action<Input, Output, Error: ErrorProtocol> {
 	/// SignalProducer for each input.
 	public init<P: PropertyProtocol where P.Value == Bool>(enabling property: P, _ execute: (Input) -> SignalProducer<Output, Error>) {
 		executeClosure = execute
-		isUserEnabled = Property(reflecting: property)
+		isUserEnabled = Property(property)
 
 		(events, eventsObserver) = Signal<Event<Output, Error>, NoError>.pipe()
 
@@ -76,7 +76,7 @@ public final class Action<Input, Output, Error: ErrorProtocol> {
 	/// Initializes an action that will be enabled by default, and create a
 	/// SignalProducer for each input.
 	public convenience init(_ execute: (Input) -> SignalProducer<Output, Error>) {
-		self.init(enabling: Property(true), execute)
+		self.init(enabling: Property(constant: true), execute)
 	}
 
 	deinit {

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -76,7 +76,7 @@ public final class Action<Input, Output, Error: ErrorProtocol> {
 	/// Initializes an action that will be enabled by default, and create a
 	/// SignalProducer for each input.
 	public convenience init(_ execute: (Input) -> SignalProducer<Output, Error>) {
-		self.init(enabling: Property(constant: true), execute)
+		self.init(enabling: Property(value: true), execute)
 	}
 
 	deinit {

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -31,21 +31,21 @@ public final class Action<Input, Output, Error: ErrorProtocol> {
 	public let errors: Signal<Error, NoError>
 
 	/// Whether the action is currently executing.
-	public var isExecuting: AnyProperty<Bool> {
-		return AnyProperty(reflecting: _isExecuting)
+	public var isExecuting: Property<Bool> {
+		return Property(reflecting: _isExecuting)
 	}
 
 	private let _isExecuting: MutableProperty<Bool> = MutableProperty(false)
 
 	/// Whether the action is currently enabled.
-	public var isEnabled: AnyProperty<Bool> {
-		return AnyProperty(reflecting: _isEnabled)
+	public var isEnabled: Property<Bool> {
+		return Property(reflecting: _isEnabled)
 	}
 
 	private let _isEnabled: MutableProperty<Bool> = MutableProperty(false)
 
 	/// Whether the instantiator of this action wants it to be enabled.
-	private let isUserEnabled: AnyProperty<Bool>
+	private let isUserEnabled: Property<Bool>
 
 	/// This queue is used for read-modify-write operations on the `_executing`
 	/// property.
@@ -61,7 +61,7 @@ public final class Action<Input, Output, Error: ErrorProtocol> {
 	/// SignalProducer for each input.
 	public init<P: PropertyProtocol where P.Value == Bool>(enabling property: P, _ execute: (Input) -> SignalProducer<Output, Error>) {
 		executeClosure = execute
-		isUserEnabled = AnyProperty(reflecting: property)
+		isUserEnabled = Property(reflecting: property)
 
 		(events, eventsObserver) = Signal<Event<Output, Error>, NoError>.pipe()
 
@@ -76,7 +76,7 @@ public final class Action<Input, Output, Error: ErrorProtocol> {
 	/// Initializes an action that will be enabled by default, and create a
 	/// SignalProducer for each input.
 	public convenience init(_ execute: (Input) -> SignalProducer<Output, Error>) {
-		self.init(enabling: ConstantProperty(true), execute)
+		self.init(enabling: Property(true), execute)
 	}
 
 	deinit {
@@ -130,7 +130,7 @@ public protocol ActionProtocol {
 	associatedtype Error: ErrorProtocol
 
 	/// Whether the action is currently enabled.
-	var isEnabled: AnyProperty<Bool> { get }
+	var isEnabled: Property<Bool> { get }
 
 	/// Extracts an action from the receiver.
 	var action: Action<Input, Output, Error> { get }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -295,7 +295,26 @@ extension PropertyProtocol {
 	}
 }
 
-/// A read-only, type-erased view of a property.
+/// A read-only property that can be observed for its changes over time. There are
+/// three categories of read-only property:
+///
+/// # Constant property
+/// Created by `Property(value:)`, the producer and signal of a constant
+/// property would complete immediately when it is initialized.
+///
+/// # Existential property
+/// Created by `Property(_:)`, an existential property passes through the
+/// behavior of the wrapped property.
+///
+/// # Composed property
+/// Created by either the compositional operators in `PropertyProtocol`, or
+/// `Property(initial:followingBy:)`, a composed property presents a
+/// composed view of its source, which can be a set of properties,
+/// a producer, or a signal.
+///
+/// A composed property respects the lifetime of its source rather than its own.
+/// In other words, its producer and signal can outlive the property itself, if
+/// its source outlives it too.
 public struct Property<Value>: PropertyProtocol {
 	private let sources: [Any]
 	private let disposable: Disposable?
@@ -309,22 +328,20 @@ public struct Property<Value>: PropertyProtocol {
 		return _value()
 	}
 
-	/// A producer for Signals that will send the wrapped property's current value,
-	/// followed by all changes over time, then complete when the wrapped property has
-	/// deinitialized.
+	/// A producer that sends the property's current value, followed by all changes
+	/// over time.
 	public var producer: SignalProducer<Value, NoError> {
 		return _producer()
 	}
 
-	/// A signal that will send the wrapped property's changes over time, then complete
-	/// when the wrapped property has deinitialized.
+	/// A signal that sends the property's changes over time.
 	///
-	/// It is strongly discouraged to use `signal` on any transformed property.
+	/// - Warning: It is strongly discouraged to use `signal` on any composed properties.
 	public var signal: Signal<Value, NoError> {
 		return _signal()
 	}
 
-	/// Initializes a property as a read-only view of the given property.
+	/// Initializes an existential property.
 	public init<P: PropertyProtocol where P.Value == Value>(_ property: P) {
 		sources = Property.capturing(property)
 		disposable = nil
@@ -343,28 +360,28 @@ public struct Property<Value>: PropertyProtocol {
 		_signal = { Signal.empty }
 	}
 
-	/// Initializes a property that first takes on `initial`, then each value
+	/// Initializes a composed property that first takes on `initial`, then each value
 	/// sent on a signal created by `producer`.
 	public init(initial: Value, followingBy producer: SignalProducer<Value, NoError>) {
 		self.init(sourcingFrom: producer.prefix(value: initial),
 		          capturing: [])
 	}
 
-	/// Initializes a property that first takes on `initial`, then each value
+	/// Initializes a composed property that first takes on `initial`, then each value
 	/// sent on `signal`.
 	public init(initial: Value, followingBy signal: Signal<Value, NoError>) {
 		self.init(sourcingFrom: SignalProducer(signal: signal).prefix(value: initial),
 		          capturing: [])
 	}
 
-	/// Initializes a property by applying the unary `SignalProducer` transform on
+	/// Initializes a composed property by applying the unary `SignalProducer` transform on
 	/// `property`. The resulting property captures `property`.
 	private init<P: PropertyProtocol>(sourcingFrom property: P, transform: @noescape (SignalProducer<P.Value, NoError>) -> SignalProducer<Value, NoError>) {
 		self.init(sourcingFrom: transform(property.producer),
 		          capturing: Property.capturing(property))
 	}
 
-	/// Initializes a property by applying the binary `SignalProducer` transform on
+	/// Initializes a composed property by applying the binary `SignalProducer` transform on
 	/// `properties.first` and `properties.second`. The resulting property captures
 	/// the two property sources.
 	private init<P1: PropertyProtocol, P2: PropertyProtocol>(sourcingFrom properties: (first: P1, second: P2), transform: @noescape (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
@@ -372,7 +389,7 @@ public struct Property<Value>: PropertyProtocol {
 		          capturing: Property.capturing(properties.first) + Property.capturing(properties.second))
 	}
 
-	/// Initializes a property from a producer that promises to send at least one
+	/// Initializes a composed property from a producer that promises to send at least one
 	/// value synchronously in its start handler before sending any subsequent event.
 	/// If the producer fails its promise, a fatal error would be raised.
 	///

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -37,31 +37,31 @@ public protocol MutablePropertyProtocol: class, PropertyProtocol {
 /// any intermediate property during the composition.
 extension PropertyProtocol {
 	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol instead.
-	private func lift<U>( _ transform: @noescape (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> AnyProperty<U> {
-		return AnyProperty(sourcingFrom: self, transform: transform)
+	private func lift<U>( _ transform: @noescape (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> Property<U> {
+		return Property(sourcingFrom: self, transform: transform)
 	}
 
 	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol instead.
-	private func lift<P: PropertyProtocol, U>(_ transform: @noescape (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> @noescape (P) -> AnyProperty<U> {
+	private func lift<P: PropertyProtocol, U>(_ transform: @noescape (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> @noescape (P) -> Property<U> {
 		return { otherProperty in
-			return AnyProperty(sourcingFrom: (self, otherProperty), transform: transform)
+			return Property(sourcingFrom: (self, otherProperty), transform: transform)
 		}
 	}
 
 	/// Maps the current value and all subsequent values to a new property.
-	public func map<U>(_ transform: (Value) -> U) -> AnyProperty<U> {
+	public func map<U>(_ transform: (Value) -> U) -> Property<U> {
 		return lift { $0.map(transform) }
 	}
 
 	/// Combines the current value and the subsequent values of two `Property`s in
 	/// the manner described by `Signal.combineLatestWith:`.
-	public func combineLatest<P: PropertyProtocol>(with other: P) -> AnyProperty<(Value, P.Value)> {
+	public func combineLatest<P: PropertyProtocol>(with other: P) -> Property<(Value, P.Value)> {
 		return lift(SignalProducer.combineLatest(with:))(other)
 	}
 
 	/// Zips the current value and the subsequent values of two `Property`s in
 	/// the manner described by `Signal.zipWith`.
-	public func zip<P: PropertyProtocol>(with other: P) -> AnyProperty<(Value, P.Value)> {
+	public func zip<P: PropertyProtocol>(with other: P) -> Property<(Value, P.Value)> {
 		return lift(SignalProducer.zip(with:))(other)
 	}
 
@@ -69,13 +69,13 @@ extension PropertyProtocol {
 	/// are a tuple whose first member is the previous value and whose second member
 	/// is the current value. `initial` is supplied as the first member of the first
 	/// tuple.
-	public func combinePrevious(initial: Value) -> AnyProperty<(Value, Value)> {
+	public func combinePrevious(initial: Value) -> Property<(Value, Value)> {
 		return lift { $0.combinePrevious(initial: initial) }
 	}
 
 	/// Forwards only those values from `self` which do not pass `isRepeat` with
 	/// respect to the previous value. The first value is always forwarded.
-	public func skipRepeats(_ isRepeat: (Value, Value) -> Bool) -> AnyProperty<Value> {
+	public func skipRepeats(_ isRepeat: (Value, Value) -> Bool) -> Property<Value> {
 		return lift { $0.skipRepeats(isRepeat) }
 	}
 }
@@ -83,7 +83,7 @@ extension PropertyProtocol {
 extension PropertyProtocol where Value: Equatable {
 	/// Forwards only those values from `self` which is not equal to the previous
 	/// value. The first value is always forwarded.
-	public func skipRepeats() -> AnyProperty<Value> {
+	public func skipRepeats() -> Property<Value> {
 		return lift { $0.skipRepeats() }
 	}
 }
@@ -91,7 +91,7 @@ extension PropertyProtocol where Value: Equatable {
 extension PropertyProtocol where Value: PropertyProtocol {
 	/// Flattens the inner properties sent upon `self` (into a single property),
 	/// according to the semantics of the given strategy.
-	public func flatten(_ strategy: FlattenStrategy) -> AnyProperty<Value.Value> {
+	public func flatten(_ strategy: FlattenStrategy) -> Property<Value.Value> {
 		return lift { $0.flatMap(strategy) { $0.producer } }
 	}
 }
@@ -100,7 +100,7 @@ extension PropertyProtocol {
 	/// Maps each property from `self` to a new property, then flattens the
 	/// resulting properties (into a single property), according to the
 	/// semantics of the given strategy.
-	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: (Value) -> P) -> AnyProperty<P.Value> {
+	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: (Value) -> P) -> Property<P.Value> {
 		return lift { $0.flatMap(strategy) { transform($0).producer } }
 	}
 
@@ -108,7 +108,7 @@ extension PropertyProtocol {
 	/// all values that have been seen.
 	///
 	/// Note: This causes the identities to be retained to check for uniqueness.
-	public func uniqueValues<Identity: Hashable>(_ transform: (Value) -> Identity) -> AnyProperty<Value> {
+	public func uniqueValues<Identity: Hashable>(_ transform: (Value) -> Identity) -> Property<Value> {
 		return lift { $0.uniqueValues(transform) }
 	}
 }
@@ -120,7 +120,7 @@ extension PropertyProtocol where Value: Hashable {
 	/// Note: This causes the values to be retained to check for uniqueness. Providing
 	/// a function that returns a unique value for each sent value can help you reduce
 	/// the memory footprint.
-	public func uniqueValues() -> AnyProperty<Value> {
+	public func uniqueValues() -> Property<Value> {
 		return lift { $0.uniqueValues() }
 	}
 }
@@ -128,13 +128,13 @@ extension PropertyProtocol where Value: Hashable {
 extension PropertyProtocol {
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B) -> AnyProperty<(A.Value, B.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B) -> Property<(A.Value, B.Value)> {
 		return a.combineLatest(with: b)
 	}
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C) -> AnyProperty<(A.Value, B.Value, C.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C) -> Property<(A.Value, B.Value, C.Value)> {
 		return combineLatest(a, b)
 			.combineLatest(with: c)
 			.map(repack)
@@ -142,7 +142,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D) -> Property<(A.Value, B.Value, C.Value, D.Value)> {
 		return combineLatest(a, b, c)
 			.combineLatest(with: d)
 			.map(repack)
@@ -150,7 +150,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value)> {
 		return combineLatest(a, b, c, d)
 			.combineLatest(with: e)
 			.map(repack)
@@ -158,7 +158,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> {
 		return combineLatest(a, b, c, d, e)
 			.combineLatest(with: f)
 			.map(repack)
@@ -166,7 +166,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> {
 		return combineLatest(a, b, c, d, e, f)
 			.combineLatest(with: g)
 			.map(repack)
@@ -174,7 +174,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> {
 		return combineLatest(a, b, c, d, e, f, g)
 			.combineLatest(with: h)
 			.map(repack)
@@ -182,7 +182,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> {
 		return combineLatest(a, b, c, d, e, f, g, h)
 			.combineLatest(with: i)
 			.map(repack)
@@ -190,7 +190,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described by
 	/// `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> {
 		return combineLatest(a, b, c, d, e, f, g, h, i)
 			.combineLatest(with: j)
 			.map(repack)
@@ -198,7 +198,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`. Returns nil if the sequence is empty.
-	public static func combineLatest<S: Sequence where S.Iterator.Element: PropertyProtocol>(_ properties: S) -> AnyProperty<[S.Iterator.Element.Value]>? {
+	public static func combineLatest<S: Sequence where S.Iterator.Element: PropertyProtocol>(_ properties: S) -> Property<[S.Iterator.Element.Value]>? {
 		var generator = properties.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }
@@ -212,13 +212,13 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B) -> AnyProperty<(A.Value, B.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B) -> Property<(A.Value, B.Value)> {
 		return a.zip(with: b)
 	}
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C) -> AnyProperty<(A.Value, B.Value, C.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C) -> Property<(A.Value, B.Value, C.Value)> {
 		return zip(a, b)
 			.zip(with: c)
 			.map(repack)
@@ -226,7 +226,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D) -> Property<(A.Value, B.Value, C.Value, D.Value)> {
 		return zip(a, b, c)
 			.zip(with: d)
 			.map(repack)
@@ -234,7 +234,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value)> {
 		return zip(a, b, c, d)
 			.zip(with: e)
 			.map(repack)
@@ -242,7 +242,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> {
 		return zip(a, b, c, d, e)
 			.zip(with: f)
 			.map(repack)
@@ -250,7 +250,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> {
 		return zip(a, b, c, d, e, f)
 			.zip(with: g)
 			.map(repack)
@@ -258,7 +258,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> {
 		return zip(a, b, c, d, e, f, g)
 			.zip(with: h)
 			.map(repack)
@@ -266,7 +266,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> {
 		return zip(a, b, c, d, e, f, g, h)
 			.zip(with: i)
 			.map(repack)
@@ -274,7 +274,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> AnyProperty<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> {
 		return zip(a, b, c, d, e, f, g, h, i)
 			.zip(with: j)
 			.map(repack)
@@ -282,7 +282,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`. Returns nil if the sequence is empty.
-	public static func zip<S: Sequence where S.Iterator.Element: PropertyProtocol>(_ properties: S) -> AnyProperty<[S.Iterator.Element.Value]>? {
+	public static func zip<S: Sequence where S.Iterator.Element: PropertyProtocol>(_ properties: S) -> Property<[S.Iterator.Element.Value]>? {
 		var generator = properties.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }
@@ -296,7 +296,7 @@ extension PropertyProtocol {
 }
 
 /// A read-only, type-erased view of a property.
-public struct AnyProperty<Value>: PropertyProtocol {
+public struct Property<Value>: PropertyProtocol {
 	private let sources: [Any]
 	private let disposable: Disposable?
 
@@ -326,11 +326,21 @@ public struct AnyProperty<Value>: PropertyProtocol {
 
 	/// Initializes a property as a read-only view of the given property.
 	public init<P: PropertyProtocol where P.Value == Value>(reflecting property: P) {
-		sources = AnyProperty.capturing(property)
+		sources = Property.capturing(property)
 		disposable = nil
 		_value = { property.value }
 		_producer = { property.producer }
 		_signal = { property.signal }
+	}
+
+	/// Initializes a constant property.
+	/// Its producer and signal would complete immediately at initialization.
+	public init(_ value: Value) {
+		sources = []
+		disposable = nil
+		_value = { value }
+		_producer = { SignalProducer(value: value) }
+		_signal = { Signal.empty }
 	}
 
 	/// Initializes a property that first takes on `initial`, then each value
@@ -351,7 +361,7 @@ public struct AnyProperty<Value>: PropertyProtocol {
 	/// `property`. The resulting property captures `property`.
 	private init<P: PropertyProtocol>(sourcingFrom property: P, transform: @noescape (SignalProducer<P.Value, NoError>) -> SignalProducer<Value, NoError>) {
 		self.init(sourcingFrom: transform(property.producer),
-		          capturing: AnyProperty.capturing(property))
+		          capturing: Property.capturing(property))
 	}
 
 	/// Initializes a property by applying the binary `SignalProducer` transform on
@@ -359,7 +369,7 @@ public struct AnyProperty<Value>: PropertyProtocol {
 	/// the two property sources.
 	private init<P1: PropertyProtocol, P2: PropertyProtocol>(sourcingFrom properties: (first: P1, second: P2), transform: @noescape (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
 		self.init(sourcingFrom: transform(properties.first.producer)(properties.second.producer),
-		          capturing: AnyProperty.capturing(properties.first) + AnyProperty.capturing(properties.second))
+		          capturing: Property.capturing(properties.first) + Property.capturing(properties.second))
 	}
 
 	/// Initializes a property from a producer that promises to send at least one
@@ -404,26 +414,11 @@ public struct AnyProperty<Value>: PropertyProtocol {
 	/// using a closure. Returns that closure if it does. Otherwise, returns a closure
 	/// which captures `property`.
 	private static func capturing<P: PropertyProtocol>(_ property: P) -> [Any] {
-		if let property = property as? AnyProperty<P.Value> {
+		if let property = property as? Property<P.Value> {
 			return property.sources
 		} else {
 			return [property]
 		}
-	}
-}
-
-/// A property that never changes.
-public struct ConstantProperty<Value>: PropertyProtocol {
-
-	public let value: Value
-	public let producer: SignalProducer<Value, NoError>
-	public let signal: Signal<Value, NoError>
-
-	/// Initializes the property to have the given value.
-	public init(_ value: Value) {
-		self.value = value
-		self.producer = SignalProducer(value: value)
-		self.signal = .empty
 	}
 }
 

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -335,7 +335,7 @@ public struct Property<Value>: PropertyProtocol {
 
 	/// Initializes a constant property.
 	/// Its producer and signal would complete immediately at initialization.
-	public init(constant value: Value) {
+	public init(value: Value) {
 		sources = []
 		disposable = nil
 		_value = { value }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -325,7 +325,7 @@ public struct Property<Value>: PropertyProtocol {
 	}
 
 	/// Initializes a property as a read-only view of the given property.
-	public init<P: PropertyProtocol where P.Value == Value>(reflecting property: P) {
+	public init<P: PropertyProtocol where P.Value == Value>(_ property: P) {
 		sources = Property.capturing(property)
 		disposable = nil
 		_value = { property.value }
@@ -335,7 +335,7 @@ public struct Property<Value>: PropertyProtocol {
 
 	/// Initializes a constant property.
 	/// Its producer and signal would complete immediately at initialization.
-	public init(_ value: Value) {
+	public init(constant value: Value) {
 		sources = []
 		disposable = nil
 		_value = { value }

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -251,13 +251,13 @@ class PropertySpec: QuickSpec {
 		describe("Property") {
 			describe("from a constant") {
 				it("should have the value given at initialization") {
-					let constantProperty = Property(constant: initialPropertyValue)
+					let constantProperty = Property(value: initialPropertyValue)
 
 					expect(constantProperty.value) == initialPropertyValue
 				}
 
 				it("should yield a signal that interrupts observers without emitting any value.") {
-					let constantProperty = Property(constant: initialPropertyValue)
+					let constantProperty = Property(value: initialPropertyValue)
 
 					var signalInterrupted = false
 					var hasUnexpectedEventsEmitted = false
@@ -276,7 +276,7 @@ class PropertySpec: QuickSpec {
 				}
 
 				it("should yield a producer that sends the current value then completes") {
-					let constantProperty = Property(constant: initialPropertyValue)
+					let constantProperty = Property(value: initialPropertyValue)
 
 					var sentValue: String?
 					var signalCompleted = false
@@ -299,7 +299,7 @@ class PropertySpec: QuickSpec {
 
 			describe("from a PropertyProtocol") {
 				it("should pass through behaviors of the input property") {
-					let constantProperty = Property(constant: initialPropertyValue)
+					let constantProperty = Property(value: initialPropertyValue)
 					let property = Property(constantProperty)
 
 					var sentValue: String?
@@ -371,7 +371,7 @@ class PropertySpec: QuickSpec {
 					}
 
 					it("should transform property from a property that has a terminated producer") {
-						let property = Property(constant: 1)
+						let property = Property(value: 1)
 						let transformedProperty = property.map { $0 + 1 }
 
 						expect(transformedProperty.value) == 2
@@ -1385,7 +1385,7 @@ class PropertySpec: QuickSpec {
 
 			describe("from another property") {
 				it("should take the source property's current value") {
-					let sourceProperty = Property(constant: initialPropertyValue)
+					let sourceProperty = Property(value: initialPropertyValue)
 
 					let destinationProperty = MutableProperty("")
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -251,13 +251,13 @@ class PropertySpec: QuickSpec {
 		describe("Property") {
 			describe("from a constant") {
 				it("should have the value given at initialization") {
-					let constantProperty = Property(initialPropertyValue)
+					let constantProperty = Property(constant: initialPropertyValue)
 
 					expect(constantProperty.value) == initialPropertyValue
 				}
 
 				it("should yield a signal that interrupts observers without emitting any value.") {
-					let constantProperty = Property(initialPropertyValue)
+					let constantProperty = Property(constant: initialPropertyValue)
 
 					var signalInterrupted = false
 					var hasUnexpectedEventsEmitted = false
@@ -276,7 +276,7 @@ class PropertySpec: QuickSpec {
 				}
 
 				it("should yield a producer that sends the current value then completes") {
-					let constantProperty = Property(initialPropertyValue)
+					let constantProperty = Property(constant: initialPropertyValue)
 
 					var sentValue: String?
 					var signalCompleted = false
@@ -299,8 +299,8 @@ class PropertySpec: QuickSpec {
 
 			describe("from a PropertyProtocol") {
 				it("should pass through behaviors of the input property") {
-					let constantProperty = Property(initialPropertyValue)
-					let property = Property(reflecting: constantProperty)
+					let constantProperty = Property(constant: initialPropertyValue)
+					let property = Property(constantProperty)
 
 					var sentValue: String?
 					var signalSentValue: String?
@@ -371,7 +371,7 @@ class PropertySpec: QuickSpec {
 					}
 
 					it("should transform property from a property that has a terminated producer") {
-						let property = Property(1)
+						let property = Property(constant: 1)
 						let transformedProperty = property.map { $0 + 1 }
 
 						expect(transformedProperty.value) == 2
@@ -1385,7 +1385,7 @@ class PropertySpec: QuickSpec {
 
 			describe("from another property") {
 				it("should take the source property's current value") {
-					let sourceProperty = Property(initialPropertyValue)
+					let sourceProperty = Property(constant: initialPropertyValue)
 
 					let destinationProperty = MutableProperty("")
 


### PR DESCRIPTION
~~Well, a self-explanatory title.~~

Both `AnyProperty` and `ConstantProperty` are read-only entities. This PR proposes to unify them into a single type `Property`, and constant properties can be created using `Property(value:)` instead.

###### Before
```
		name = AnyProperty(ConstantProperty("undefined"))
		postingDate = AnyProperty(ConstantProperty(Date.distantFuture))
```

###### After
```
		name = Property(value: "undefined")
		postingDate = Property(value: Date.distantFuture)
```