### PR TITLE
Correctly teardown MutableProperty binding when it is disposed.

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -240,14 +240,16 @@ public func <~ <P: MutablePropertyType>(property: P, signal: Signal<P.Value, NoE
 public func <~ <P: MutablePropertyType>(property: P, producer: SignalProducer<P.Value, NoError>) -> Disposable {
 	let disposable = CompositeDisposable()
 
-	producer.startWithSignal { signal, signalDisposable in
-		property <~ signal
-		disposable += signalDisposable
+	producer
+		.on(completed: { disposable.dispose() })
+		.startWithSignal { signal, signalDisposable in
+			disposable += property <~ signal
+			disposable += signalDisposable
 
-		disposable += property.producer.startWithCompleted {
-			disposable.dispose()
+			disposable += property.producer.startWithCompleted {
+				disposable.dispose()
+			}
 		}
-	}
 
 	return disposable
 }

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -599,24 +599,26 @@ class PropertySpec: QuickSpec {
 				}
 
 				it("should tear down the binding when disposed") {
-					let signalValues = [initialPropertyValue, subsequentPropertyValue]
-					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
+					let (signalProducer, observer) = SignalProducer<String, NoError>.pipe()
 
 					let mutableProperty = MutableProperty(initialPropertyValue)
 					let disposable = mutableProperty <~ signalProducer
 
 					disposable.dispose()
-					// TODO: Assert binding was torn down?
+
+					observer.sendNext(subsequentPropertyValue)
+					expect(mutableProperty.value) == initialPropertyValue
 				}
 
 				it("should tear down the binding when bound signal is completed") {
 					let (signalProducer, observer) = SignalProducer<String, NoError>.pipe()
 
 					let mutableProperty = MutableProperty(initialPropertyValue)
-					mutableProperty <~ signalProducer
+					let disposable = mutableProperty <~ signalProducer
 
 					observer.sendCompleted()
-					// TODO: Assert binding was torn down?
+
+					expect(disposable.disposed) == true
 				}
 
 				it("should tear down the binding when the property deallocates") {


### PR DESCRIPTION
Fixed memory leak when dispose binding of MutablePropertyType to a SignalProducer.
Added unit tests and updated existing ones that were without assertions. Unit tests required some way to know if Signal has any observers. After binding is disposed signal from MutableProperty should not have observers. That is why I've added internal property to Signal.