### PR TITLE
[5.0] Remove Disposable from Signal.

### DIFF
--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -224,16 +224,16 @@ scopedExample("`startWithFailed`") {
  the Signal, which will invoke the given callback when an `interrupted` event 
  is received.
  
- Returns a Disposable which can be used to interrupt the work associated
+ Returns an `Interrupter` which can be used to interrupt the work associated
  with the Signal.
  */
 scopedExample("`startWithInterrupted`") {
-    let disposable = SignalProducer<Int, NoError>.never
+    let interrupter = SignalProducer<Int, NoError>.never
         .startWithInterrupted {
             print("interrupted called")
         }
     
-    disposable.dispose()
+    interrupter.interrupt()
 }
 
 

--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -233,7 +233,7 @@ scopedExample("`startWithInterrupted`") {
             print("interrupted called")
         }
     
-    interrupter.interrupt()
+    interrupter.dispose()
 }
 
 

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -32,6 +32,30 @@ public final class SimpleDisposable: Disposable {
 }
 
 /// A disposable that will run an action upon disposal.
+public final class MutableActionDisposable: Disposable {
+	private let action: Atomic<(() -> Void)?>
+
+	public var isDisposed: Bool {
+		return action.value == nil
+	}
+
+	public static func make(initial: () -> Void) -> (disposable: MutableActionDisposable, setter: (() -> Void) -> Void) {
+		let disposable = self.init(initial)
+		return (disposable, { disposable.action.value = $0 })
+	}
+
+	/// Initializes the disposable to run the given action upon disposal.
+	private init(_ action: () -> Void) {
+		self.action = Atomic(action)
+	}
+
+	public func dispose() {
+		let oldAction = action.swap(nil)
+		oldAction?()
+	}
+}
+
+/// A disposable that will run an action upon disposal.
 public final class ActionDisposable: Disposable {
 	private let action: Atomic<(() -> Void)?>
 

--- a/ReactiveCocoa/Swift/EventLogger.swift
+++ b/ReactiveCocoa/Swift/EventLogger.swift
@@ -11,10 +11,10 @@ import Foundation
 /// A namespace for logging event types.
 public enum LoggingEvent {
 	public enum Signal: String {
-		case next, completed, failed, terminated, disposed, interrupted
+		case next, completed, failed, terminated, interrupted
 
 		public static let allEvents: Set<Signal> = [
-			.next, .completed, .failed, .terminated, .disposed, .interrupted,
+			.next, .completed, .failed, .terminated, .interrupted,
 		]
 	}
 
@@ -48,7 +48,6 @@ extension SignalProtocol {
 			completed: log(.completed),
 			interrupted: log(.interrupted),
 			terminated: log(.terminated),
-			disposed: log(.disposed),
 			next: log(.next)
 		)
 	}

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -18,7 +18,7 @@ extension NotificationCenter {
 	public func rac_notifications(for name: Notification.Name?, object: AnyObject? = nil) -> SignalProducer<Notification, NoError> {
 		// We're weakly capturing an optional reference here, which makes destructuring awkward.
 		let objectWasNil = (object == nil)
-		return SignalProducer { [weak object] observer, disposable in
+		return SignalProducer { [weak object] observer, disposalTrigger in
 			guard object != nil || objectWasNil else {
 				observer.sendInterrupted()
 				return
@@ -28,7 +28,7 @@ extension NotificationCenter {
 				observer.sendNext(notification)
 			}
 
-			disposable += {
+			disposalTrigger.observeCompleted {
 				self.removeObserver(notificationObserver)
 			}
 		}
@@ -41,7 +41,7 @@ extension URLSession {
 	/// Returns a producer that will execute the given request once for each
 	/// invocation of start().
 	public func rac_dataWithRequest(_ request: URLRequest) -> SignalProducer<(Data, URLResponse), NSError> {
-		return SignalProducer { observer, disposable in
+		return SignalProducer { observer, disposalTrigger in
 			let task = self.dataTask(with: request) { data, response, error in
 				if let data = data, response = response {
 					observer.sendNext((data, response))
@@ -51,7 +51,7 @@ extension URLSession {
 				}
 			}
 
-			disposable += {
+			disposalTrigger.observeCompleted {
 				task.cancel()
 			}
 			task.resume()

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -137,7 +137,7 @@ extension SignalProducerProtocol where Value: OptionalType, Value.Wrapped: AnyOb
 			}
 
 			return RACDisposable {
-				interrupter.interrupt()
+				interrupter.dispose()
 			}
 		}
 	}

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -11,6 +11,8 @@ public protocol ObserverType {
 	associatedtype Value
 	associatedtype Error: ErrorProtocol
 
+	var action: (Event<Value, Error>) -> Void { get }
+
 	/// Puts a `Next` event into the given observer.
 	func sendNext(_ value: Value)
 

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -385,7 +385,7 @@ public struct AnyProperty<Value>: PropertyProtocol {
 		}
 
 		if value != nil {
-			disposable = ScopedDisposable(ActionDisposable { interrupter.interrupt() })
+			disposable = ScopedDisposable(ActionDisposable { interrupter.dispose() })
 			self.sources = sources
 
 			_value = { value }
@@ -573,7 +573,7 @@ public func <~ <P: MutablePropertyProtocol>(property: P, signal: Signal<P.Value,
 /// The binding will automatically terminate when the property is deinitialized,
 /// or when the created signal sends a `Completed` event.
 @discardableResult
-public func <~ <P: MutablePropertyProtocol>(property: P, producer: SignalProducer<P.Value, NoError>) -> Interrupter {
+public func <~ <P: MutablePropertyProtocol>(property: P, producer: SignalProducer<P.Value, NoError>) -> Disposable {
 	return producer.startWithSignal { signal, interrupter in
 		property <~ signal
 		return interrupter
@@ -586,12 +586,12 @@ public func <~ <P: MutablePropertyProtocol, S: SignalProtocol where P.Value == S
 }
 
 @discardableResult
-public func <~ <P: MutablePropertyProtocol, S: SignalProducerProtocol where P.Value == S.Value?, S.Error == NoError>(property: P, producer: S) -> Interrupter {
+public func <~ <P: MutablePropertyProtocol, S: SignalProducerProtocol where P.Value == S.Value?, S.Error == NoError>(property: P, producer: S) -> Disposable {
 	return property <~ producer.optionalize()
 }
 
 @discardableResult
-public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol where Destination.Value == Source.Value?>(destinationProperty: Destination, sourceProperty: Source) -> Interrupter {
+public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol where Destination.Value == Source.Value?>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }
 
@@ -600,6 +600,6 @@ public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol w
 /// The binding will automatically terminate when either property is
 /// deinitialized.
 @discardableResult
-public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol where Source.Value == Destination.Value>(destinationProperty: Destination, sourceProperty: Source) -> Interrupter {
+public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol where Source.Value == Destination.Value>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
 	return destinationProperty <~ sourceProperty.producer
 }

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -26,10 +26,6 @@ public final class Signal<Value, Error: ErrorProtocol> {
 
 	/// Initializes a Signal that will immediately invoke the given generator,
 	/// then forward events sent to the given observer.
-	///
-	/// The disposable returned from the closure will be automatically disposed
-	/// if a terminating event is sent to the observer. The Signal itself will
-	/// remain alive until the observer is released.
 	public init(_ generator: @noescape (Observer) throws -> Void) rethrows {
 
 		/// Used to ensure that events are serialized during delivery to observers.

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -261,9 +261,9 @@ extension SignalProtocol {
 
 	/// Observes the Signal by invoking the given interrupter when terminating events
 	/// are received.
-	public func observeTerminated(_ interruptor: Interrupter) {
+	public func observeTerminated(_ disposable: Disposable) {
 		observeTerminated {
-			interruptor.interrupt()
+			disposable.dispose()
 		}
 	}
 

--- a/ReactiveCocoaTests/Swift/FlattenSpec.swift
+++ b/ReactiveCocoaTests/Swift/FlattenSpec.swift
@@ -83,7 +83,7 @@ class FlattenSpec: QuickSpec {
 						.flatten(flattenStrategy)
 						.start()
 
-					interrupter.interrupt()
+					interrupter.dispose()
 					expect(disposed) == true
 				}
 			}

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -20,7 +20,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				let producer = center.rac_notifications(for: "rac_notifications_test" as Notification.Name)
 
 				var notif: NSNotification? = nil
-				let disposable = producer.startWithNext { notif = $0 }
+				let interrupter = producer.startWithNext { notif = $0 }
 
 				center.post(name: "some_other_notification" as Notification.Name, object: nil)
 				expect(notif).to(beNil())
@@ -29,7 +29,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				expect(notif?.name) == "rac_notifications_test" as Notification.Name
 
 				notif = nil
-				disposable.dispose()
+				interrupter.interrupt()
 
 				center.post(name: Notification.Name("rac_notifications_test"), object: nil)
 				expect(notif).to(beNil())
@@ -41,12 +41,12 @@ class FoundationExtensionsSpec: QuickSpec {
 				observedObject = nil
 
 				var interrupted = false
-				let disposable = producer.startWithInterrupted {
+				let interrupter = producer.startWithInterrupted {
 					interrupted = true
 				}
 				expect(interrupted) == true
 
-				disposable.dispose()
+				interrupter.interrupt()
 			}
 
 		}

--- a/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
+++ b/ReactiveCocoaTests/Swift/FoundationExtensionsSpec.swift
@@ -29,7 +29,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				expect(notif?.name) == "rac_notifications_test" as Notification.Name
 
 				notif = nil
-				interrupter.interrupt()
+				interrupter.dispose()
 
 				center.post(name: Notification.Name("rac_notifications_test"), object: nil)
 				expect(notif).to(beNil())
@@ -46,7 +46,7 @@ class FoundationExtensionsSpec: QuickSpec {
 				}
 				expect(interrupted) == true
 
-				interrupter.interrupt()
+				interrupter.dispose()
 			}
 
 		}

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -284,16 +284,27 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				let signal = command.execute(0)
 
 				do {
+					expect(enabled) == true
 					try signal.asynchronouslyWaitUntilCompleted()
 					expect(results) == [ "1" ]
+				} catch let e {
+					XCTFail("Error: \(e)")
+				}
 
+				do {
+					expect(enabled) == true
 					try signal.asynchronouslyWaitUntilCompleted()
 					expect(results) == [ "1" ]
+				} catch let e {
+					XCTFail("Error: \(e)")
+				}
 
+				do {
+					expect(enabled) == true
 					try command.execute(2).asynchronouslyWaitUntilCompleted()
 					expect(results) == [ "1", "3" ]
-				} catch {
-					XCTFail("Failed to wait for completion")
+				} catch let e {
+					XCTFail("Error: \(e)")
 				}
 			}
 		}

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -1358,7 +1358,7 @@ class PropertySpec: QuickSpec {
 					let mutableProperty = MutableProperty(initialPropertyValue)
 					let interrupter = mutableProperty <~ signalProducer
 
-					interrupter.interrupt()
+					interrupter.dispose()
 					// TODO: Assert binding was torn down?
 				}
 
@@ -1413,7 +1413,7 @@ class PropertySpec: QuickSpec {
 					let destinationProperty = MutableProperty("")
 
 					let interrupter = destinationProperty <~ sourceProperty.producer
-					interrupter.interrupt()
+					interrupter.dispose()
 
 					sourceProperty.value = subsequentPropertyValue
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -1302,6 +1302,7 @@ class PropertySpec: QuickSpec {
 					expect(mutableProperty.value) == subsequentPropertyValue
 				}
 
+				/**
 				it("should tear down the binding when disposed") {
 					let (signal, observer) = Signal<String, NoError>.pipe()
 
@@ -1335,7 +1336,7 @@ class PropertySpec: QuickSpec {
 
 					mutableProperty = nil
 					expect(bindingDisposable.isDisposed) == true
-				}
+				}**/
 			}
 
 			describe("from a SignalProducer") {
@@ -1355,9 +1356,9 @@ class PropertySpec: QuickSpec {
 					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
 
 					let mutableProperty = MutableProperty(initialPropertyValue)
-					let disposable = mutableProperty <~ signalProducer
+					let interrupter = mutableProperty <~ signalProducer
 
-					disposable.dispose()
+					interrupter.interrupt()
 					// TODO: Assert binding was torn down?
 				}
 
@@ -1376,10 +1377,11 @@ class PropertySpec: QuickSpec {
 					let signalProducer = SignalProducer<String, NoError>(values: signalValues)
 
 					var mutableProperty: MutableProperty<String>? = MutableProperty(initialPropertyValue)
-					let disposable = mutableProperty! <~ signalProducer
+					_ = mutableProperty! <~ signalProducer
 
 					mutableProperty = nil
-					expect(disposable.isDisposed) == true
+					///expect(disposable.isDisposed) == true
+					// TODO: Assert binding was torn down?
 				}
 			}
 
@@ -1410,8 +1412,8 @@ class PropertySpec: QuickSpec {
 
 					let destinationProperty = MutableProperty("")
 
-					let bindingDisposable = destinationProperty <~ sourceProperty.producer
-					bindingDisposable.dispose()
+					let interrupter = destinationProperty <~ sourceProperty.producer
+					interrupter.interrupt()
 
 					sourceProperty.value = subsequentPropertyValue
 
@@ -1432,10 +1434,10 @@ class PropertySpec: QuickSpec {
 					let sourceProperty = MutableProperty(initialPropertyValue)
 					var destinationProperty: MutableProperty<String>? = MutableProperty("")
 
-					let bindingDisposable = destinationProperty! <~ sourceProperty.producer
+					_ = destinationProperty! <~ sourceProperty.producer
 					destinationProperty = nil
 
-					expect(bindingDisposable.isDisposed) == true
+					//expect(bindingDisposable.isDisposed) == true
 				}
 			}
 

--- a/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalLifetimeSpec.swift
@@ -21,23 +21,24 @@ class SignalLifetimeSpec: QuickSpec {
 			}
 
 			it("should deallocate") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }
+				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in }
 
 				expect(signal).to(beNil())
 			}
 
 			it("should deallocate even if it has an observer") {
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
+					let signal: Signal<AnyObject, NoError> = Signal { _ in }
 					return signal
 				}()
 				expect(signal).to(beNil())
 			}
 
+			/**
 			it("should deallocate even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }
+					let signal: Signal<AnyObject, NoError> = Signal { _ in }
 					disposable = signal.observe(Observer())
 					return signal
 				}()
@@ -45,13 +46,13 @@ class SignalLifetimeSpec: QuickSpec {
 				disposable?.dispose()
 				expect(signal).to(beNil())
 			}
+			**/
 
 			it("should deallocate after erroring") {
 				weak var signal: Signal<AnyObject, TestError>? = Signal { observer in
 					testScheduler.schedule {
 						observer.sendFailed(TestError.default)
 					}
-					return nil
 				}
 
 				var errored = false
@@ -72,7 +73,6 @@ class SignalLifetimeSpec: QuickSpec {
 					testScheduler.schedule {
 						observer.sendCompleted()
 					}
-					return nil
 				}
 
 				var completed = false
@@ -93,8 +93,6 @@ class SignalLifetimeSpec: QuickSpec {
 					testScheduler.schedule {
 						observer.sendInterrupted()
 					}
-
-					return nil
 				}
 
 				var interrupted = false
@@ -184,24 +182,25 @@ class SignalLifetimeSpec: QuickSpec {
 
 		describe("testTransform") {
 			it("should deallocate") {
-				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in nil }.testTransform()
+				weak var signal: Signal<AnyObject, NoError>? = Signal { _ in }.testTransform()
 
 				expect(signal).to(beNil())
 			}
 
 			it("should deallocate even if it has an observer") {
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.testTransform()
+					let signal: Signal<AnyObject, NoError> = Signal { _ in }.testTransform()
 					signal.observe(Observer())
 					return signal
 				}()
 				expect(signal).to(beNil())
 			}
 
+			/**
 			it("should deallocate even if it has an observer with retained disposable") {
 				var disposable: Disposable? = nil
 				weak var signal: Signal<AnyObject, NoError>? = {
-					let signal: Signal<AnyObject, NoError> = Signal { _ in nil }.testTransform()
+					let signal: Signal<AnyObject, NoError> = Signal { _ in }.testTransform()
 					disposable = signal.observe(Observer())
 					return signal
 				}()
@@ -209,6 +208,7 @@ class SignalLifetimeSpec: QuickSpec {
 				disposable?.dispose()
 				expect(signal).to(beNil())
 			}
+			**/
 		}
 
 		describe("observe") {

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -384,7 +384,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(lastValue) == 2
 				expect(completed) == true
 			}
-			
+
 			it("should complete immediately after taking given number of values") {
 				let numbers = [ 1, 2, 4, 4, 5 ]
 				let testScheduler = TestScheduler()
@@ -587,6 +587,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
+			var hasUnexpectedEvents: Bool = false
 
 			beforeEach {
 				let (baseProducer, baseIncomingObserver) = SignalProducer<Int, NoError>.pipe()
@@ -598,6 +599,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				lastValue = nil
 				completed = false
+				hasUnexpectedEvents = false
 
 				producer.start { event in
 					switch event {
@@ -606,7 +608,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 					case .completed:
 						completed = true
 					case .failed, .interrupted:
-						break
+						hasUnexpectedEvents = true
 					}
 				}
 			}
@@ -623,6 +625,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == false
 				triggerObserver.sendNext(())
 				expect(completed) == true
+				expect(hasUnexpectedEvents) == false
 			}
 
 			it("should take values until the trigger completes") {
@@ -637,6 +640,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == false
 				triggerObserver.sendCompleted()
 				expect(completed) == true
+				expect(hasUnexpectedEvents) == false
 			}
 
 			it("should complete if the trigger fires immediately") {
@@ -647,6 +651,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 				expect(completed) == true
 				expect(lastValue).to(beNil())
+				expect(hasUnexpectedEvents) == false
 			}
 		}
 
@@ -1087,14 +1092,14 @@ class SignalProducerLiftingSpec: QuickSpec {
 				it("should free payload when interrupted after complete of incoming producer") {
 					var payloadFreed = false
 
-					let disposable = sampledProducer.start()
+					let interrupter = sampledProducer.start()
 
 					observer.sendNext(Payload { payloadFreed = true })
 					observer.sendCompleted()
 
 					expect(payloadFreed) == false
 
-					disposable.dispose()
+					interrupter.interrupt()
 					expect(payloadFreed) == true
 				}
 			}

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -1099,7 +1099,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 					expect(payloadFreed) == false
 
-					interrupter.interrupt()
+					interrupter.dispose()
 					expect(payloadFreed) == true
 				}
 			}

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -24,7 +24,6 @@ class SignalSpec: QuickSpec {
 				var didRunGenerator = false
 				_ = Signal<AnyObject, NoError> { observer in
 					didRunGenerator = true
-					return nil
 				}
 				
 				expect(didRunGenerator) == true
@@ -40,7 +39,6 @@ class SignalSpec: QuickSpec {
 						}
 						observer.sendCompleted()
 					}
-					return nil
 				}
 				
 				var fromSignal: [Int] = []
@@ -66,6 +64,7 @@ class SignalSpec: QuickSpec {
 				expect(fromSignal) == numbers
 			}
 
+			/**
 			it("should dispose of returned disposable upon error") {
 				let disposable = SimpleDisposable()
 				
@@ -135,6 +134,7 @@ class SignalSpec: QuickSpec {
 				expect(interrupted) == true
 				expect(disposable.isDisposed) == true
 			}
+			**/
 		}
 
 		describe("Signal.empty") {
@@ -196,9 +196,7 @@ class SignalSpec: QuickSpec {
 
 					for _ in 0..<50 {
 						autoreleasepool {
-							let disposable = signal.observe { _ in }
-
-							disposable!.dispose()
+							signal.observe { _ in }
 						}
 					}
 				}
@@ -213,8 +211,6 @@ class SignalSpec: QuickSpec {
 			}
 			
 			it("should stop forwarding events when disposed") {
-				let disposable = SimpleDisposable()
-				
 				let signal: Signal<Int, NoError> = Signal { observer in
 					testScheduler.schedule {
 						for number in [ 1, 2 ] {
@@ -223,7 +219,6 @@ class SignalSpec: QuickSpec {
 						observer.sendCompleted()
 						observer.sendNext(4)
 					}
-					return disposable
 				}
 				
 				var fromSignal: [Int] = []
@@ -231,12 +226,10 @@ class SignalSpec: QuickSpec {
 					fromSignal.append(number)
 				}
 				
-				expect(disposable.isDisposed) == false
 				expect(fromSignal).to(beEmpty())
 				
 				testScheduler.run()
 				
-				expect(disposable.isDisposed) == true
 				expect(fromSignal) == [ 1, 2 ]
 			}
 
@@ -244,7 +237,6 @@ class SignalSpec: QuickSpec {
 				var runCount = 0
 				let signal: Signal<(), NoError> = Signal { observer in
 					runCount += 1
-					return nil
 				}
 				
 				expect(runCount) == 1
@@ -762,7 +754,6 @@ class SignalSpec: QuickSpec {
 							observer.sendNext(number)
 						}
 					}
-					return nil
 				}
 				
 				var completed = false
@@ -785,7 +776,6 @@ class SignalSpec: QuickSpec {
 							observer.sendNext(number)
 						}
 					}
-					return nil
 				}
 
 				var result: [Int] = []
@@ -948,6 +938,7 @@ class SignalSpec: QuickSpec {
 
 			var lastValue: Int? = nil
 			var completed: Bool = false
+			var hasUnexpectedEvents: Bool = false
 
 			beforeEach {
 				let (baseSignal, incomingObserver) = Signal<Int, NoError>.pipe()
@@ -966,8 +957,8 @@ class SignalSpec: QuickSpec {
 						lastValue = value
 					case .completed:
 						completed = true
-					default:
-						break
+					case .failed, .interrupted:
+						hasUnexpectedEvents = true
 					}
 				}
 			}
@@ -984,6 +975,7 @@ class SignalSpec: QuickSpec {
 				expect(completed) == false
 				triggerObserver.sendNext(())
 				expect(completed) == true
+				expect(hasUnexpectedEvents) == false
 			}
 			
 			it("should take values until the trigger completes") {
@@ -998,6 +990,7 @@ class SignalSpec: QuickSpec {
 				expect(completed) == false
 				triggerObserver.sendCompleted()
 				expect(completed) == true
+				expect(hasUnexpectedEvents) == false
 			}
 
 			it("should complete if the trigger fires immediately") {
@@ -1008,6 +1001,7 @@ class SignalSpec: QuickSpec {
 
 				expect(completed) == true
 				expect(lastValue).to(beNil())
+				expect(hasUnexpectedEvents) == false
 			}
 		}
 
@@ -1159,7 +1153,6 @@ class SignalSpec: QuickSpec {
 						observer.sendNext(2)
 						observer.sendCompleted()
 					})
-					return nil
 				}
 				
 				var result: [Int] = []
@@ -1196,7 +1189,6 @@ class SignalSpec: QuickSpec {
 					testScheduler.schedule {
 						observer.sendFailed(TestError.default)
 					}
-					return nil
 				}
 				
 				var errored = false


### PR DESCRIPTION
##### Rationale

A working prototype ~~An attempt~~ of #2044.

In RAC 4, the signal operators would feed the signal generator with disposables that result from observing the upstream signal(s). This in turn allows a signal to clean up these subscription(s) at the time it terminates.

However in real practice, the termination of a signal is usually caused by the upstream signal (or an input observer). This means that the observer to the upstream should have already been disposed of. In other words, detaching an observer is only necessary for operators that take events from other signals.

On the other hand, despite being part of the public API, the disposable returned from signal observation `Signal.observe` is rarely used because of three main reasons:

1. the user has explicit control to the signal lifetime.

2. the user composes a signal via `takeUntil`, which ends the subscription upon events from a signal that the user has explicit control or has a deterministic lifetime.

3. A `SignalProducer` - which always propagates interruption to the upstream - is used.


In short, all these factors together render a "disposable" signal unnecessary. This PR proposes to remove it completely from `Signal`.

_(This is mutually exclusive to #2959, which alters the semantics to allow a signal to be disposed of when it is unreachable.)_

<br>

##### `Disposable` has a reduced responsibility.
Disposable is no longer used internally by `Signal` and `SignalProducer` to clean up resources on termination. It is now used only as cancellation tokens for:

1. cancelling a scheduled work in `SchedulerProtocol` types;
2. interrupting a started signal from `SignalProducer`; and
3. tearing down a property binding.

<br>

##### `Signal` is now `Disposable`-less.
`Signal.observe` no longer returns a `Disposable` for detaching an observer. Moreover, a signal no longer accepts a `Disposable` from its generator, which would be disposed of after the terminating event. 

```
/// Signal
    public init(_ generator: @noescape (Observer) throws -> Void) rethrows
    public func observe(_ observer: Observer)
```

The largest impact is the elimination of the chain of disposables created during signal composition. That is, a termination of a signal no longer dispose of its `generatorDisposable`, which usually holds a `disposable` that would detach the input observer from its upstream.

However, the ability for an observer to detach is crucial to `SignalProducer` that wraps a signal, and any operators that involve more than one signals. The `.interrupted` event alone is not enough, because it is just flowing from top to bottom, while the detachment happens in reverse.

Therefore, a new variation of `Signal.observe` which accepts a trigger signal is added. It would detach the observer on a `.next` or a `.completed` event sent upon the trigger signal, and optionally send an event after the detachment.
```
/// Signal
	public func observe(until trigger: Signal<(), NoError>, observer: Observer, endingEvent: Event<Value, Error>?)
```

<br>

##### `SignalProducer` no longer uses `CompositeDisposable`.
Constructing a producer now gives you a `disposalTrigger`, which can be observed for its completion to clean up resources.

```
let producer = SignalProducer<Int, NoError> { observer, disposalTrigger in
    disposalTrigger.observeCompleted { print("Disposing the resources.") }
}
```

Starting a producer ~~_now returns a very specific token `Interrupter`, which has only one method `Interrupter.interrupt`_~~ still returns a `Disposable` for interrupting the work. An overload is provided to conveniently attach a `Disposable` as an observer.

```
/// Labels are changed to `interrupter` to describe the role of the `Disposable`
/// instead of the type.
producer.startWithSignal { signal, interrupter in
    shouldInterrupt.signal.observeTerminated(interrupter)
}
```

@neilpa @NachoSoto @andymatuschak @jspahrsummers 