### PR TITLE
Nullability Annotation for `RACCommand` and `RACSignal`.

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -2960,7 +2960,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -2975,7 +2974,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -2990,7 +2988,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3005,7 +3002,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3076,7 +3072,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=watchsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3091,7 +3086,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=watchsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3106,7 +3100,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=watchsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3121,7 +3114,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=watchsimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3233,8 +3225,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
@@ -3247,8 +3237,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
@@ -3336,8 +3324,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
@@ -3411,8 +3397,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D047263419E49FE8006002AA /* iOS-Framework.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphonesimulator*]" = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;

--- a/ReactiveCocoa/Objective-C/RACCommand.h
+++ b/ReactiveCocoa/Objective-C/RACCommand.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class RACSignal;
+NS_ASSUME_NONNULL_BEGIN
 
 /// The domain for errors originating within `RACCommand`.
 extern NSString * const RACCommandErrorDomain;
@@ -77,7 +78,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 @property (atomic, assign) BOOL allowsConcurrentExecution;
 
 /// Invokes -initWithEnabled:signalBlock: with a nil `enabledSignal`.
-- (id)initWithSignalBlock:(RACSignal * (^)(InputType input))signalBlock;
+- (id)initWithSignalBlock:(RACSignal * (^)(InputType _Nullable input))signalBlock;
 
 /// Initializes a command that is conditionally enabled.
 ///
@@ -92,7 +93,7 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 ///                 to a replay subject, sent on `executionSignals`, then
 ///                 subscribed to synchronously. Neither the block nor the
 ///                 returned signal may be nil.
-- (id)initWithEnabled:(RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(InputType input))signalBlock;
+- (id)initWithEnabled:(nullable RACSignal *)enabledSignal signalBlock:(RACSignal * (^)(InputType _Nullable input))signalBlock;
 
 /// If the receiver is enabled, this method will:
 ///
@@ -107,11 +108,13 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 /// Returns the multicasted signal, after subscription. If the receiver is not
 /// enabled, returns a signal that will send an error with code
 /// RACCommandErrorNotEnabled.
-- (RACSignal *)execute:(InputType)input;
+- (RACSignal *)execute:(nullable InputType)input;
 
+NS_ASSUME_NONNULL_END
 @end
 
 @interface RACCommand (Unavailable)
+NS_ASSUME_NONNULL_BEGIN
 
 @property (atomic, readonly) BOOL canExecute __attribute__((unavailable("Use the 'enabled' signal instead")));
 
@@ -120,4 +123,5 @@ extern NSString * const RACUnderlyingCommandErrorKey;
 - (id)initWithCanExecuteSignal:(RACSignal *)canExecuteSignal __attribute__((unavailable("Use -initWithEnabled:signalBlock: instead")));
 - (RACSignal *)addSignalBlock:(RACSignal * (^)(id value))signalBlock __attribute__((unavailable("Pass the signalBlock to -initWithSignalBlock: instead")));
 
+NS_ASSUME_NONNULL_END
 @end

--- a/ReactiveCocoa/Objective-C/RACSignal+Operations.h
+++ b/ReactiveCocoa/Objective-C/RACSignal+Operations.h
@@ -720,8 +720,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (RACDisposable *)toProperty:(NSString *)keyPath onObject:(NSObject *)object __attribute__((unavailable("Renamed to -setKeyPath:onObject:")));
 - (RACSignal *)ignoreElements __attribute__((unavailable("Renamed to -ignoreValues")));
 - (RACSignal *)sequenceNext:(RACSignal * (^)(void))block __attribute__((unavailable("Renamed to -then:")));
-- (RACSignal *)aggregateWithStart:(id)start combine:(id (^)(id running, id next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStart:reduce:")));
-- (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory combine:(id (^)(id running, id next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStartFactory:reduce:")));
+- (RACSignal *)aggregateWithStart:(nullable id)start combine:(id _Nullable (^)(id _Nullable running, id _Nullable next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStart:reduce:")));
+- (RACSignal *)aggregateWithStartFactory:(id _Nullable (^)(void))startFactory combine:(id _Nullable (^)(id _Nullable running, id _Nullable next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStartFactory:reduce:")));
 - (RACDisposable *)executeCommand:(RACCommand *)command __attribute__((unavailable("Use -flattenMap: or -subscribeNext: instead")));
 
 NS_ASSUME_NONNULL_END

--- a/ReactiveCocoa/Objective-C/RACSignal+Operations.h
+++ b/ReactiveCocoa/Objective-C/RACSignal+Operations.h
@@ -10,7 +10,7 @@
 #import "RACSignal.h"
 
 /// The domain for errors originating in RACSignal operations.
-extern NSString * const RACSignalErrorDomain;
+extern NSString * _Nonnull const RACSignalErrorDomain;
 
 /// The error code used with -timeout:.
 extern const NSInteger RACSignalErrorTimedOut;
@@ -29,14 +29,15 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 @protocol RACSubscriber;
 
 @interface RACSignal (Operations)
+NS_ASSUME_NONNULL_BEGIN
 
 /// Do the given block on `next`. This should be used to inject side effects into
 /// the signal.
-- (RACSignal *)doNext:(void (^)(id x))block;
+- (RACSignal *)doNext:(void (^)(id _Nullable x))block;
 
 /// Do the given block on `error`. This should be used to inject side effects
 /// into the signal.
-- (RACSignal *)doError:(void (^)(NSError *error))block;
+- (RACSignal *)doError:(void (^)(NSError * _Nonnull error))block;
 
 /// Do the given block on `completed`. This should be used to inject side effects
 /// into the signal.
@@ -79,7 +80,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns a signal which sends `next` events, throttled when `predicate`
 /// returns YES. Completion and errors are always forwarded immediately.
-- (RACSignal *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id next))predicate;
+- (RACSignal *)throttle:(NSTimeInterval)interval valuesPassingTest:(BOOL (^)(id _Nullable next))predicate;
 
 /// Forwards `next` and `completed` events after delaying for `interval` seconds
 /// on the current scheduler (on which the events were delivered).
@@ -326,7 +327,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///            object is set to `nil`).
 ///
 /// Returns a disposable which can be used to terminate the binding.
-- (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object nilValue:(id)nilValue;
+- (RACDisposable *)setKeyPath:(NSString *)keyPath onObject:(NSObject *)object nilValue:(nullable id)nilValue;
 
 /// Sends NSDate.date every `interval` seconds.
 ///
@@ -375,7 +376,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 - (RACSignal *)takeUntilReplacement:(RACSignal *)replacement;
 
 /// Subscribes to the returned signal when an error occurs.
-- (RACSignal *)catch:(RACSignal * (^)(NSError *error))catchBlock;
+- (RACSignal *)catch:(RACSignal * (^)(NSError * _Nonnull error))catchBlock;
 
 /// Subscribes to the given signal when an error occurs.
 - (RACSignal *)catchTo:(RACSignal *)signal;
@@ -413,7 +414,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which passes through all the values of the receiver. If
 /// `tryBlock` fails for any value, the returned signal will error using the
 /// `NSError` passed out from the block.
-- (RACSignal *)try:(BOOL (^)(id value, NSError **errorPtr))tryBlock;
+- (RACSignal *)try:(BOOL (^)(id _Nullable value, NSError **errorPtr))tryBlock;
 
 /// Runs `mapBlock` against each of the receiver's values, mapping values until
 /// `mapBlock` returns nil, or the receiver completes.
@@ -433,21 +434,21 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// Returns a signal which transforms all the values of the receiver. If
 /// `mapBlock` returns nil for any value, the returned signal will error using
 /// the `NSError` passed out from the block.
-- (RACSignal *)tryMap:(id (^)(id value, NSError **errorPtr))mapBlock;
+- (RACSignal *)tryMap:(id (^)(id _Nullable value, NSError **errorPtr))mapBlock;
 
 /// Returns the first `next`. Note that this is a blocking call.
-- (id)first;
+- (nullable id)first;
 
 /// Returns the first `next` or `defaultValue` if the signal completes or errors
 /// without sending a `next`. Note that this is a blocking call.
-- (id)firstOrDefault:(id)defaultValue;
+- (nullable id)firstOrDefault:(nullable id)defaultValue;
 
 /// Returns the first `next` or `defaultValue` if the signal completes or errors
 /// without sending a `next`. If an error occurs success will be NO and error
 /// will be populated. Note that this is a blocking call.
 ///
 /// Both success and error may be NULL.
-- (id)firstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error;
+- (nullable id)firstOrDefault:(nullable id)defaultValue success:(nullable BOOL *)success error:(NSError * _Nullable * _Nullable)error;
 
 /// Blocks the caller and waits for the signal to complete.
 ///
@@ -455,7 +456,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 ///
 /// Returns whether the signal completed successfully. If NO, `error` will be set
 /// to the error that occurred.
-- (BOOL)waitUntilCompleted:(NSError **)error;
+- (BOOL)waitUntilCompleted:(NSError * _Nullable * _Nullable)error;
 
 /// Defers creation of a signal until the signal's actually subscribed to.
 ///
@@ -489,7 +490,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// the signals in `cases` or `defaultSignal`, and sends `completed` when both
 /// `signal` and the last used signal complete. If no `defaultSignal` is given,
 /// an unmatched `next` will result in an error on the returned signal.
-+ (RACSignal *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(RACSignal *)defaultSignal;
++ (RACSignal *)switch:(RACSignal *)signal cases:(NSDictionary *)cases default:(nullable RACSignal *)defaultSignal;
 
 /// Switches between `trueSignal` and `falseSignal` based on the latest value
 /// sent by `boolSignal`.
@@ -513,7 +514,7 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// that behavior instead.
 ///
 /// Returns the array of `next` values, or nil if an error occurs.
-- (NSArray *)toArray;
+- (nullable NSArray *)toArray;
 
 /// Adds every `next` to a sequence. Nils are represented by NSNulls.
 ///
@@ -605,10 +606,10 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// with the object. If `transformBlock` is nil, it sends the original object.
 ///
 /// The returned signal is a signal of RACGroupedSignal.
-- (RACSignal *)groupBy:(id<NSCopying> (^)(id object))keyBlock transform:(id (^)(id object))transformBlock;
+- (RACSignal *)groupBy:(id<NSCopying> _Nullable (^)(id _Nullable object))keyBlock transform:(nullable id _Nullable (^)(id _Nullable object))transformBlock;
 
 /// Calls -[RACSignal groupBy:keyBlock transform:nil].
-- (RACSignal *)groupBy:(id<NSCopying> (^)(id object))keyBlock;
+- (RACSignal *)groupBy:(id<NSCopying> _Nullable (^)(id _Nullable object))keyBlock;
 
 /// Sends an [NSNumber numberWithBool:YES] if the receiving signal sends any
 /// objects.
@@ -618,13 +619,13 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// objects that pass `predicateBlock`.
 ///
 /// predicateBlock - cannot be nil.
-- (RACSignal *)any:(BOOL (^)(id object))predicateBlock;
+- (RACSignal *)any:(BOOL (^)(id _Nullable object))predicateBlock;
 
 /// Sends an [NSNumber numberWithBool:YES] if all the objects the receiving 
 /// signal sends pass `predicateBlock`.
 ///
 /// predicateBlock - cannot be nil.
-- (RACSignal *)all:(BOOL (^)(id object))predicateBlock;
+- (RACSignal *)all:(BOOL (^)(id _Nullable object))predicateBlock;
 
 /// Resubscribes to the receiving signal if an error occurs, up until it has
 /// retried the given number of times.
@@ -703,9 +704,11 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 /// to the remaining elements.
 - (RACSignal *)reduceApply;
 
+NS_ASSUME_NONNULL_END
 @end
 
 @interface RACSignal (UnavailableOperations)
+NS_ASSUME_NONNULL_BEGIN
 
 - (RACSignal *)windowWithStart:(RACSignal *)openSignal close:(RACSignal * (^)(RACSignal *start))closeBlock __attribute__((unavailable("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
 - (RACSignal *)buffer:(NSUInteger)bufferCount __attribute__((unavailable("See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/587")));
@@ -721,4 +724,5 @@ extern const NSInteger RACSignalErrorNoMatchingCase;
 - (RACSignal *)aggregateWithStartFactory:(id (^)(void))startFactory combine:(id (^)(id running, id next))combineBlock __attribute__((unavailable("Renamed to -aggregateWithStartFactory:reduce:")));
 - (RACDisposable *)executeCommand:(RACCommand *)command __attribute__((unavailable("Use -flattenMap: or -subscribeNext: instead")));
 
+NS_ASSUME_NONNULL_END
 @end

--- a/ReactiveCocoa/Objective-C/RACSignal.h
+++ b/ReactiveCocoa/Objective-C/RACSignal.h
@@ -15,6 +15,7 @@
 @protocol RACSubscriber;
 
 @interface RACSignal : RACStream
+NS_ASSUME_NONNULL_BEGIN
 
 /// Creates a new signal. This is the preferred way to create a new signal
 /// operation or behavior.
@@ -44,10 +45,10 @@
 /// subscribes. Any side effects within the block will thus execute once for each
 /// subscription, not necessarily on one thread, and possibly even
 /// simultaneously!
-+ (RACSignal *)createSignal:(RACDisposable * (^)(id<RACSubscriber> subscriber))didSubscribe;
++ (RACSignal *)createSignal:(RACDisposable * _Nullable (^)(id<RACSubscriber> subscriber))didSubscribe;
 
 /// Returns a signal that immediately sends the given error.
-+ (RACSignal *)error:(NSError *)error;
++ (RACSignal *)error:(nullable NSError *)error;
 
 /// Returns a signal that never completes.
 + (RACSignal *)never;
@@ -87,7 +88,7 @@
 @interface RACSignal (RACStream)
 
 /// Returns a signal that immediately sends the given value and then completes.
-+ (RACSignal *)return:(id)value;
++ (RACSignal *)return:(nullable id)value;
 
 /// Returns a signal that immediately completes.
 + (RACSignal *)empty;
@@ -133,18 +134,18 @@
 /// Convenience method to subscribe to the `next` event.
 ///
 /// This corresponds to `IObserver<T>.OnNext` in Rx.
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock;
+- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock;
 
 /// Convenience method to subscribe to the `next` and `completed` events.
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock completed:(void (^)(void))completedBlock;
+- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to the `next`, `completed`, and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock;
+- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nonnull error))errorBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `error` events.
 ///
 /// This corresponds to the `IObserver<T>.OnError` in Rx.
-- (RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock;
+- (RACDisposable *)subscribeError:(void (^)(NSError * _Nonnull error))errorBlock;
 
 /// Convenience method to subscribe to `completed` events.
 ///
@@ -152,10 +153,10 @@
 - (RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `next` and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(id x))nextBlock error:(void (^)(NSError *error))errorBlock;
+- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nonnull error))errorBlock;
 
 /// Convenience method to subscribe to `error` and `completed` events.
-- (RACDisposable *)subscribeError:(void (^)(NSError *error))errorBlock completed:(void (^)(void))completedBlock;
+- (RACDisposable *)subscribeError:(void (^)(NSError * _Nonnull error))errorBlock completed:(void (^)(void))completedBlock;
 
 @end
 
@@ -195,7 +196,7 @@
 ///
 /// Returns the first value received, or `defaultValue` if no value is received
 /// before the signal finishes or the method times out.
-- (id)asynchronousFirstOrDefault:(id)defaultValue success:(BOOL *)success error:(NSError **)error;
+- (nullable id)asynchronousFirstOrDefault:(nullable id)defaultValue success:(nullable BOOL *)success error:(NSError * _Nullable * _Nullable)error;
 
 /// Spins the main run loop for a short while, waiting for the receiver to complete.
 ///
@@ -206,14 +207,17 @@
 ///
 /// Returns whether the signal completed successfully before timing out. If NO,
 /// `error` will be set to any error that occurred.
-- (BOOL)asynchronouslyWaitUntilCompleted:(NSError **)error;
+- (BOOL)asynchronouslyWaitUntilCompleted:(NSError * _Nullable * _Nullable)error;
 
+NS_ASSUME_NONNULL_END
 @end
 
 @interface RACSignal (Unavailable)
+NS_ASSUME_NONNULL_BEGIN
 
 + (RACSignal *)start:(id (^)(BOOL *success, NSError **error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 + (RACSignal *)startWithScheduler:(RACScheduler *)scheduler subjectBlock:(void (^)(RACSubject *subject))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 + (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError **error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 
+NS_ASSUME_NONNULL_END
 @end

--- a/ReactiveCocoa/Objective-C/RACSignal.h
+++ b/ReactiveCocoa/Objective-C/RACSignal.h
@@ -140,12 +140,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to the `next`, `completed`, and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nonnull error))errorBlock completed:(void (^)(void))completedBlock;
+- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `error` events.
 ///
 /// This corresponds to the `IObserver<T>.OnError` in Rx.
-- (RACDisposable *)subscribeError:(void (^)(NSError * _Nonnull error))errorBlock;
+- (RACDisposable *)subscribeError:(void (^)(NSError * _Nullable error))errorBlock;
 
 /// Convenience method to subscribe to `completed` events.
 ///
@@ -153,10 +153,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (RACDisposable *)subscribeCompleted:(void (^)(void))completedBlock;
 
 /// Convenience method to subscribe to `next` and `error` events.
-- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nonnull error))errorBlock;
+- (RACDisposable *)subscribeNext:(void (^)(id _Nullable x))nextBlock error:(void (^)(NSError * _Nullable error))errorBlock;
 
 /// Convenience method to subscribe to `error` and `completed` events.
-- (RACDisposable *)subscribeError:(void (^)(NSError * _Nonnull error))errorBlock completed:(void (^)(void))completedBlock;
+- (RACDisposable *)subscribeError:(void (^)(NSError * _Nullable error))errorBlock completed:(void (^)(void))completedBlock;
 
 @end
 
@@ -215,9 +215,9 @@ NS_ASSUME_NONNULL_END
 @interface RACSignal (Unavailable)
 NS_ASSUME_NONNULL_BEGIN
 
-+ (RACSignal *)start:(id (^)(BOOL *success, NSError **error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
++ (RACSignal *)start:(id (^)(BOOL *success, NSError * _Nullable * _Nullable error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 + (RACSignal *)startWithScheduler:(RACScheduler *)scheduler subjectBlock:(void (^)(RACSubject *subject))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
-+ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError **error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
++ (RACSignal *)startWithScheduler:(RACScheduler *)scheduler block:(id (^)(BOOL *success, NSError * _Nullable * _Nullable error))block __attribute__((unavailable("Use +startEagerlyWithScheduler:block: instead")));
 
 NS_ASSUME_NONNULL_END
 @end

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -198,7 +198,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				enabledSubject = RACSubject()
 				results = []
 
-				command = RACCommand(enabled: enabledSubject) { (input: AnyObject?) -> RACSignal! in
+				command = RACCommand(enabled: enabledSubject) { (input: AnyObject?) -> RACSignal in
 					let inputNumber = input as! Int
 					return RACSignal.`return`(inputNumber + 1)
 				}


### PR DESCRIPTION
Per @ikesyo's suggestions, these are cherry-picked from the `swift3.0` branch. They were meant to wipe all surprising optionals away from `ObjectiveCBridging.swift`.

_(Feel free to take over and progress on it. :-].)_