### PR TITLE
Add Lifetime to enable observation of object deallocation in Swift

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -11,6 +11,13 @@
 		02D2602B1C1D6DB8003ACC61 /* SignalLifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */; };
 		314304171ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		314304181ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */; };
+		4A0E10FF1D2A92720065D310 /* Lifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E10FE1D2A92720065D310 /* Lifetime.swift */; };
+		4A0E11001D2A92720065D310 /* Lifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E10FE1D2A92720065D310 /* Lifetime.swift */; };
+		4A0E11011D2A92720065D310 /* Lifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E10FE1D2A92720065D310 /* Lifetime.swift */; };
+		4A0E11021D2A92720065D310 /* Lifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E10FE1D2A92720065D310 /* Lifetime.swift */; };
+		4A0E11041D2A95200065D310 /* LifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E11031D2A95200065D310 /* LifetimeSpec.swift */; };
+		4A0E11051D2A95200065D310 /* LifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E11031D2A95200065D310 /* LifetimeSpec.swift */; };
+		4A0E11061D2A95200065D310 /* LifetimeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0E11031D2A95200065D310 /* LifetimeSpec.swift */; };
 		579504331BB8A34200A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		579504341BB8A34300A5E482 /* BagSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C312EF19EF2A7700984962 /* BagSpec.swift */; };
 		57A4D1B11BA13D7A00F7D4B1 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = D871D69E1B3B29A40070F16C /* Optional.swift */; };
@@ -901,6 +908,8 @@
 		02D260291C1D6DAF003ACC61 /* SignalLifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalLifetimeSpec.swift; sourceTree = "<group>"; };
 		314304151ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MKAnnotationView+RACSignalSupport.h"; sourceTree = "<group>"; };
 		314304161ACA8B1E00595017 /* MKAnnotationView+RACSignalSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MKAnnotationView+RACSignalSupport.m"; sourceTree = "<group>"; };
+		4A0E10FE1D2A92720065D310 /* Lifetime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lifetime.swift; sourceTree = "<group>"; };
+		4A0E11031D2A95200065D310 /* LifetimeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifetimeSpec.swift; sourceTree = "<group>"; };
 		57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A4D2441BA13F9700F7D4B1 /* tvOS-Application.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Application.xcconfig"; sourceTree = "<group>"; };
 		57A4D2451BA13F9700F7D4B1 /* tvOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -1607,6 +1616,7 @@
 				C7142DBB1CDEA167009F402D /* CocoaAction.swift */,
 				CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */,
 				D85C65291C0D84C7005A77AD /* Flatten.swift */,
+				4A0E10FE1D2A92720065D310 /* Lifetime.swift */,
 				D08C54B01A69A2AC00AD8286 /* Property.swift */,
 				D08C54B11A69A2AC00AD8286 /* Signal.swift */,
 				D08C54B21A69A2AC00AD8286 /* SignalProducer.swift */,
@@ -1794,6 +1804,7 @@
 				D0C312F019EF2A7700984962 /* DisposableSpec.swift */,
 				CA6F284F1C52626B001879D2 /* FlattenSpec.swift */,
 				D8170FC01B100EBC004192AD /* FoundationExtensionsSpec.swift */,
+				4A0E11031D2A95200065D310 /* LifetimeSpec.swift */,
 				D0A226101A72F30B00D33B74 /* ObjectiveCBridgingSpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* PropertySpec.swift */,
 				D0C312F219EF2A7700984962 /* SchedulerSpec.swift */,
@@ -2386,6 +2397,7 @@
 				57A4D1E11BA13D7A00F7D4B1 /* RACEagerSequence.m in Sources */,
 				C79B64801CD52E4E003F2376 /* EventLogger.swift in Sources */,
 				57D4768D1C42063C00EFE697 /* UIControl+RACSignalSupport.m in Sources */,
+				4A0E11021D2A92720065D310 /* Lifetime.swift in Sources */,
 				57A4D1E21BA13D7A00F7D4B1 /* RACEmptySequence.m in Sources */,
 				57A4D1E31BA13D7A00F7D4B1 /* RACEmptySignal.m in Sources */,
 				57A4D1E41BA13D7A00F7D4B1 /* RACErrorSignal.m in Sources */,
@@ -2455,6 +2467,7 @@
 				7DFBED391CDB8DE300EE435B /* NSObjectRACPropertySubscribingSpec.m in Sources */,
 				7DFBED3A1CDB8DE300EE435B /* NSObjectRACSelectorSignalSpec.m in Sources */,
 				7DFBED3B1CDB8DE300EE435B /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,
+				4A0E11061D2A95200065D310 /* LifetimeSpec.swift in Sources */,
 				7DFBED3D1CDB8DE300EE435B /* NSUserDefaultsRACSupportSpec.m in Sources */,
 				7DFBED3E1CDB8DE300EE435B /* RACBlockTrampolineSpec.m in Sources */,
 				7DFBED401CDB8DE300EE435B /* RACChannelExamples.m in Sources */,
@@ -2576,6 +2589,7 @@
 				A9B3159C1B3940750001CB9C /* RACStringSequence.m in Sources */,
 				CD0C45E01CC9A288009F5BF0 /* DynamicProperty.swift in Sources */,
 				A9B3159D1B3940750001CB9C /* RACSubject.m in Sources */,
+				4A0E11011D2A92720065D310 /* Lifetime.swift in Sources */,
 				A9B3159E1B3940750001CB9C /* RACSubscriber.m in Sources */,
 				A9B3159F1B3940750001CB9C /* RACSubscriptingAssignmentTrampoline.m in Sources */,
 				A9B315A01B3940750001CB9C /* RACSubscriptionScheduler.m in Sources */,
@@ -2660,6 +2674,7 @@
 				D037659419EDA41200A782A9 /* RACImmediateScheduler.m in Sources */,
 				7A7065811A3F88B8001E8354 /* RACKVOProxy.m in Sources */,
 				D037651619EDA41200A782A9 /* NSObject+RACDeallocating.m in Sources */,
+				4A0E10FF1D2A92720065D310 /* Lifetime.swift in Sources */,
 				D0C312E719EF2A5800984962 /* Scheduler.swift in Sources */,
 				D0C312CD19EF2A5800984962 /* Atomic.swift in Sources */,
 				D037658419EDA41200A782A9 /* RACEmptySignal.m in Sources */,
@@ -2717,6 +2732,7 @@
 				CA6F28501C52626B001879D2 /* FlattenSpec.swift in Sources */,
 				D037670119EDA60000A782A9 /* RACSubclassObject.m in Sources */,
 				D03766CD19EDA60000A782A9 /* NSStringRACKeyPathUtilitiesSpec.m in Sources */,
+				4A0E11041D2A95200065D310 /* LifetimeSpec.swift in Sources */,
 				D037671519EDA60000A782A9 /* RACTupleSpec.m in Sources */,
 				D03766C519EDA60000A782A9 /* NSObjectRACLiftingSpec.m in Sources */,
 				D03766D119EDA60000A782A9 /* NSURLConnectionRACSupportSpec.m in Sources */,
@@ -2811,6 +2827,7 @@
 				D037665F19EDA41200A782A9 /* UITextField+RACSignalSupport.m in Sources */,
 				D037650F19EDA41200A782A9 /* NSNotificationCenter+RACSupport.m in Sources */,
 				D03765FB19EDA41200A782A9 /* RACSubscriptionScheduler.m in Sources */,
+				4A0E11001D2A92720065D310 /* Lifetime.swift in Sources */,
 				D037658119EDA41200A782A9 /* RACEmptySequence.m in Sources */,
 				D0C312E019EF2A5800984962 /* ObjectiveCBridging.swift in Sources */,
 				D037654B19EDA41200A782A9 /* NSUserDefaults+RACSupport.m in Sources */,
@@ -2940,6 +2957,7 @@
 				D03766DA19EDA60000A782A9 /* RACChannelExamples.m in Sources */,
 				D03766F619EDA60000A782A9 /* RACSequenceExamples.m in Sources */,
 				CD8401841CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */,
+				4A0E11051D2A95200065D310 /* LifetimeSpec.swift in Sources */,
 				02D2602A1C1D6DAF003ACC61 /* SignalLifetimeSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactiveCocoa/Swift/Lifetime.swift
+++ b/ReactiveCocoa/Swift/Lifetime.swift
@@ -24,6 +24,9 @@ private var lifetimeKey: UInt8 = 0
 extension NSObject {
 	/// Returns a lifetime that ends when the receiver is deallocated.
 	@nonobjc public var rac_lifetime: Lifetime {
+		objc_sync_enter(self)
+		defer { objc_sync_exit(self) }
+
 		if let lifetime = objc_getAssociatedObject(self, &lifetimeKey) as! Lifetime? {
 			return lifetime
 		}

--- a/ReactiveCocoa/Swift/Lifetime.swift
+++ b/ReactiveCocoa/Swift/Lifetime.swift
@@ -1,0 +1,36 @@
+import enum Result.NoError
+
+/// Provides a signal that completes when the lifetime object is deinitialized.
+///
+/// When assigned to a property of another object, provides a hook to
+/// observe when that object goes out of scope.
+public final class Lifetime {
+	/// A signal that sends a Completed event when the lifetime ends.
+	public let ended: Signal<(), NoError>
+
+	private let endedObserver: Signal<(), NoError>.Observer
+
+	public init() {
+		(ended, endedObserver) = Signal.pipe()
+	}
+
+	deinit {
+		endedObserver.sendCompleted()
+	}
+}
+
+private var lifetimeKey: UInt8 = 0
+
+extension NSObject {
+	/// Returns a lifetime that ends when the receiver is deallocated.
+	@nonobjc public var rac_lifetime: Lifetime {
+		if let lifetime = objc_getAssociatedObject(self, &lifetimeKey) as! Lifetime? {
+			return lifetime
+		}
+
+		let lifetime = Lifetime()
+		objc_setAssociatedObject(self, &lifetimeKey, lifetime, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+		return lifetime
+	}
+}

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -958,6 +958,19 @@ extension SignalType {
 			.map { $0.0 }
 	}
 
+	/// Forwards events from `self` until `lifetime` ends, at which point the
+	/// returned signal will complete.
+	///
+	/// - parameters:
+	///   - lifetime: A lifetime whose `ended` signal will cause the returned
+	///               signal to complete.
+	///
+	/// - returns: A signal that will deliver events until `lifetime` ends.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func takeDuring(lifetime: Lifetime) -> Signal<Value, Error> {
+		return takeUntil(lifetime.ended)
+	}
+
 	/// Forward events from `self` until `trigger` sends a `Next` or
 	/// `Completed` event, at which point the returned signal will complete.
 	///
@@ -986,7 +999,7 @@ extension SignalType {
 			return disposable
 		}
 	}
-	
+
 	/// Do not forward any values from `self` until `trigger` sends a `Next` or
 	/// `Completed` event, at which point the returned signal behaves exactly
 	/// like `signal`.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -988,6 +988,19 @@ extension SignalProducerType {
 		return lift(Signal.sampleOn)(sampler)
 	}
 
+	/// Forwards events from `self` until `lifetime` ends, at which point the
+	/// returned producer will complete.
+	///
+	/// - parameters:
+	///   - lifetime: A lifetime whose `ended` signal will cause the returned
+	///               producer to complete.
+	///
+	/// - returns: A producer that will deliver events until `lifetime` ends.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func takeDuring(lifetime: Lifetime) -> SignalProducer<Value, Error> {
+		return takeUntil(lifetime.ended)
+	}
+
 	/// Forward events from `self` until `trigger` sends a `Next` or `Completed`
 	/// event, at which point the returned producer will complete.
 	///

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1942,10 +1942,10 @@ extension SignalProducerType {
 		// out of scope. This lets us know when we're supposed to dispose the
 		// underlying producer. This is necessary because `struct`s don't have
 		// `deinit`.
-		let token = DeallocationToken()
+		let lifetime = Lifetime()
 
 		return SignalProducer { observer, disposable in
-			var token: DeallocationToken? = token
+			var lifetime: Lifetime? = lifetime
 			let initializedProducer: SignalProducer<Value, Error>
 			let initializedObserver: SignalProducer<Value, Error>.ProducedSignal.Observer
 			let shouldStartUnderlyingProducer: Bool
@@ -1968,21 +1968,13 @@ extension SignalProducerType {
 			disposable += {
 				// Don't dispose of the original producer until all observers
 				// have terminated.
-				token = nil
+				lifetime = nil
 			}
 
 			if shouldStartUnderlyingProducer {
-				self.takeUntil(token!.deallocSignal)
+				self.takeDuring(lifetime!)
 					.start(initializedObserver)
 			}
 		}
-	}
-}
-
-private final class DeallocationToken {
-	let (deallocSignal, observer) = Signal<(), NoError>.pipe()
-
-	deinit {
-		observer.sendCompleted()
 	}
 }

--- a/ReactiveCocoaTests/Swift/LifetimeSpec.swift
+++ b/ReactiveCocoaTests/Swift/LifetimeSpec.swift
@@ -1,0 +1,80 @@
+import Quick
+import Nimble
+import ReactiveCocoa
+import Result
+
+final class LifetimeSpec: QuickSpec {
+	override func spec() {
+		describe("take during") {
+			it("completes a signal when the lifetime ends") {
+				let (signal, observer) = Signal<Int, NoError>.pipe()
+				let object = MutableReference(TestObject())
+
+				let output = signal.takeDuring(object.value!.lifetime)
+
+				var results: [Int] = []
+				output.observeNext { results.append($0) }
+
+				observer.sendNext(1)
+				observer.sendNext(2)
+				object.value = nil
+				observer.sendNext(3)
+
+				expect(results) == [1, 2]
+			}
+
+			it("completes a signal producer when the lifetime ends") {
+				let (producer, observer) = SignalProducer<Int, NoError>.buffer(1)
+				let object = MutableReference(TestObject())
+
+				let output = producer.takeDuring(object.value!.lifetime)
+
+				var results: [Int] = []
+				output.startWithNext { results.append($0) }
+
+				observer.sendNext(1)
+				observer.sendNext(2)
+				object.value = nil
+				observer.sendNext(3)
+
+				expect(results) == [1, 2]
+			}
+		}
+
+		describe("NSObject lifetime") {
+			it("ends when the object is deallocated") {
+				let object = MutableReference(TestObject())
+
+				var events: [String] = []
+
+				object.value!.lifetime.ended.observe { event in
+					switch event {
+					case .Next:
+						events.append("next")
+					case .Completed:
+						events.append("completed")
+					case .Failed:
+						events.append("failed")
+					case .Interrupted:
+						events.append("interrupted")
+					}
+				}
+
+				object.value = nil
+
+				expect(events) == ["completed"]
+			}
+		}
+	}
+}
+
+private final class MutableReference<Value: AnyObject> {
+	var value: Value?
+	init(_ value: Value?) {
+		self.value = value
+	}
+}
+
+private final class TestObject {
+	let lifetime = Lifetime()
+}


### PR DESCRIPTION
Because `rac_willDeallocSignal` doesn't have a native Swift equivalent yet, I've implemented it myself a few times in my projects. It's always felt a little complicated, and it only works for Objective-C objects.

I had an idea for a much simpler API, which works for Swift objects (and Objective-C ones), and is much simpler than `rac_willDeallocSignal`. I've seen other examples of this pattern in the wild — using `Signal.pipe()` to send a completed event on `deinit`. This PR is my take on that pattern, giving it the name `Lifetime`.

I've added a `lifetime` property to all `NSObject`s in a public extension that uses associated objects for storage.

I also added a new operator, `takeWithin`, that allows you to say the inverse of _take until this signal triggers_ — instead you can phrase it as _take within this object's lifetime_.

I'd love to know what you think!