### PR TITLE
Atomic value for PropertyType

### DIFF
--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -35,22 +35,22 @@ public final class PosixThreadMutex: MutexType {
 	
 	public init() {
 		let result = pthread_mutex_init(&mutex, nil)
-		assert(result == 0, "Failed to initialize mutex with error \(result).")
+		precondition(result == 0, "Failed to initialize mutex with error \(result).")
 	}
 	
 	deinit {
 		let result = pthread_mutex_destroy(&mutex)
-		assert(result == 0, "Failed to destroy mutex with error \(result).")
+		precondition(result == 0, "Failed to destroy mutex with error \(result).")
 	}
 	
 	public func lock() {
 		let result = pthread_mutex_lock(&mutex)
-		assert(result == 0, "Failed to lock \(self) with error \(result).")
+		precondition(result == 0, "Failed to lock \(self) with error \(result).")
 	}
 	
 	public func unlock() {
 		let result = pthread_mutex_unlock(&mutex)
-		assert(result == 0, "Failed to unlock \(self) with error \(result).")
+		precondition(result == 0, "Failed to unlock \(self) with error \(result).")
 	}
 }
 

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -8,9 +8,56 @@
 
 import Foundation
 
+public protocol MutexType {
+	func lock()
+	func unlock()
+}
+
+public final class RecursiveLock: MutexType {
+	private var _lock: NSRecursiveLock
+
+	public init(_ name: String) {
+		_lock = NSRecursiveLock()
+		_lock.name = name
+	}
+
+	public func lock() {
+		_lock.lock()
+	}
+
+	public func unlock() {
+		_lock.unlock()
+	}
+}
+
+public final class PosixThreadMutex: MutexType {
+	private var mutex = pthread_mutex_t()
+	
+	public init() {
+		let result = pthread_mutex_init(&mutex, nil)
+		assert(result == 0, "Failed to initialize mutex with error \(result).")
+	}
+	
+	deinit {
+		let result = pthread_mutex_destroy(&mutex)
+		assert(result == 0, "Failed to destroy mutex with error \(result).")
+	}
+	
+	public func lock() {
+		let result = pthread_mutex_lock(&mutex)
+		assert(result == 0, "Failed to lock \(self) with error \(result).")
+	}
+	
+	public func unlock() {
+		let result = pthread_mutex_unlock(&mutex)
+		assert(result == 0, "Failed to unlock \(self) with error \(result).")
+	}
+}
+
 /// An atomic variable.
 public final class Atomic<Value> {
-	private var mutex = pthread_mutex_t()
+
+	private var _mutex: MutexType
 	private var _value: Value
 	
 	/// Atomically gets or sets the value of the variable.
@@ -25,25 +72,17 @@ public final class Atomic<Value> {
 	}
 	
 	/// Initializes the variable with the given initial value.
-	public init(_ value: Value) {
+	public init(_ value: Value, mutex: MutexType = PosixThreadMutex()) {
 		_value = value
-		let result = pthread_mutex_init(&mutex, nil)
-		assert(result == 0, "Failed to initialize mutex with error \(result).")
-	}
-
-	deinit {
-		let result = pthread_mutex_destroy(&mutex)
-		assert(result == 0, "Failed to destroy mutex with error \(result).")
+		_mutex = mutex
 	}
 
 	private func lock() {
-		let result = pthread_mutex_lock(&mutex)
-		assert(result == 0, "Failed to lock \(self) with error \(result).")
+		_mutex.lock()
 	}
 	
 	private func unlock() {
-		let result = pthread_mutex_unlock(&mutex)
-		assert(result == 0, "Failed to unlock \(self) with error \(result).")
+		_mutex.unlock()
 	}
 	
 	/// Atomically replaces the contents of the variable.
@@ -57,8 +96,16 @@ public final class Atomic<Value> {
 	///
 	/// Returns the old value.
 	public func modify(@noescape action: (Value) throws -> Value) rethrows -> Value {
+		return try modify(action, completion: { _ in })
+	}
+
+	/// Atomically modifies the variable.
+	///
+	/// Returns the old value.
+	public func modify(@noescape action: (Value) throws -> Value, @noescape completion: (Value) -> ()) rethrows -> Value {
 		return try withValue { value in
 			_value = try action(value)
+			completion(_value)
 			return value
 		}
 	}
@@ -72,5 +119,49 @@ public final class Atomic<Value> {
 		defer { unlock() }
 
 		return try action(_value)
+	}
+}
+
+public struct AnyAtomic<Value> {
+	private let _state: AnyAtomicState<Value>
+
+	init(value: Value) {
+		_state = AnyAtomicState(value: value)
+	}
+
+	init(atomic: Atomic<Value>) {
+		_state = AnyAtomicState(atomic: atomic)
+	}
+
+	/// Atomically performs an arbitrary action using the current value of the
+	/// variable.
+	///
+	/// Returns the result of the action.
+	public func withValue<Result>(@noescape action: (Value) throws -> Result) rethrows -> Result {
+		return try _state.withValue(action)
+	}
+}
+
+private enum AnyAtomicState<Value> {
+	case Constant(Value)
+	case Atomic(ReactiveCocoa.Atomic<Value>)
+
+	init(value: Value) {
+		self = .Constant(value)
+	}
+
+	init(atomic: ReactiveCocoa.Atomic<Value>) {
+		self = .Atomic(atomic)
+	}
+
+	/// Atomically performs an arbitrary action using the current value of the
+	/// variable.
+	///
+	/// Returns the result of the action.
+	func withValue<Result>(@noescape action: (Value) throws -> Result) rethrows -> Result {
+		switch self {
+		case let .Constant(value): return try action(value)
+		case let .Atomic(atomic): return try atomic.withValue(action)
+		}
 	}
 }

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -27,6 +27,10 @@ import enum Result.NoError
 		}
 	}
 
+	public var atomic: AnyAtomic<Value> {
+		return self.property?.atomic ?? AnyAtomic(value: nil)
+	}
+	
 	/// A producer that will create a Key-Value Observer for the given object,
 	/// send its initial value then all changes over time, and then complete
 	/// when the observed object has deallocated.

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -5,8 +5,8 @@ import enum Result.NoError
 public protocol PropertyType {
 	associatedtype Value
 
-	/// The current value of the property.
-	var value: Value { get }
+	/// The atomic value of the property.
+	var atomic: AnyAtomic<Value> { get }
 
 	/// A producer for Signals that will send the property's current value,
 	/// followed by all changes over time.
@@ -16,16 +16,32 @@ public protocol PropertyType {
 	var signal: Signal<Value, NoError> { get }
 }
 
+public extension PropertyType {
+	/// Atomically performs an arbitrary action using the current value of the
+	/// property.
+	///
+	/// Returns the result of the action.
+	public func withValue<Result>(@noescape action: (Value) throws -> Result) rethrows -> Result {
+		return try self.atomic.withValue(action)
+	}
+}
+
+public extension PropertyType {
+	/// The current value of the property.
+	var value: Value {
+		return self.withValue { $0 }
+	}
+}
+
 /// A read-only property that allows observation of its changes.
 public struct AnyProperty<Value>: PropertyType {
 
-	private let _value: () -> Value
+	private let _atomic: () -> AnyAtomic<Value>
 	private let _producer: () -> SignalProducer<Value, NoError>
 	private let _signal: () -> Signal<Value, NoError>
 
-
-	public var value: Value {
-		return _value()
+	public var atomic: AnyAtomic<Value> {
+		return _atomic()
 	}
 
 	public var producer: SignalProducer<Value, NoError> {
@@ -35,10 +51,10 @@ public struct AnyProperty<Value>: PropertyType {
 	public var signal: Signal<Value, NoError> {
 		return _signal()
 	}
-	
+
 	/// Initializes a property as a read-only view of the given property.
 	public init<P: PropertyType where P.Value == Value>(_ property: P) {
-		_value = { property.value }
+		_atomic = { property.atomic }
 		_producer = { property.producer }
 		_signal = { property.signal }
 	}
@@ -74,13 +90,13 @@ extension PropertyType {
 /// A property that never changes.
 public struct ConstantProperty<Value>: PropertyType {
 
-	public let value: Value
+	public let atomic: AnyAtomic<Value>
 	public let producer: SignalProducer<Value, NoError>
 	public let signal: Signal<Value, NoError>
 
 	/// Initializes the property to have the given value.
 	public init(_ value: Value) {
-		self.value = value
+		self.atomic = AnyAtomic(value: value)
 		self.producer = SignalProducer(value: value)
 		self.signal = .empty
 	}
@@ -104,14 +120,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// Need a recursive lock around `value` to allow recursive access to
 	/// `value`. Note that recursive sets will still deadlock because the
 	/// underlying producer prevents sending recursive events.
-	private let lock: NSRecursiveLock
-
-	/// The getter of the underlying storage, which may outlive the property
-	/// if a returned producer is being retained.
-	private let getter: () -> Value
-
-	/// The setter of the underlying storage.
-	private let setter: Value -> Void
+	private var _value: Atomic<Value>
 
 	/// The current value of the property.
 	///
@@ -127,6 +136,10 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		}
 	}
 
+	public var atomic: AnyAtomic<Value> {
+		return AnyAtomic(atomic: _value)
+	}
+
 	/// A signal that will send the property's changes over time,
 	/// then complete when the property has deinitialized.
 	public let signal: Signal<Value, NoError>
@@ -135,7 +148,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// followed by all changes over time, then complete when the property has
 	/// deinitialized.
 	public var producer: SignalProducer<Value, NoError> {
-		return SignalProducer { [getter, weak self] producerObserver, producerDisposable in
+		return SignalProducer { [_value, weak self] producerObserver, producerDisposable in
 			if let strongSelf = self {
 				strongSelf.withValue { value in
 					producerObserver.sendNext(value)
@@ -144,7 +157,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 			} else {
 				/// As the setter would have been deinitialized with the property,
 				/// the underlying storage would be immutable, and locking is no longer necessary.
-				producerObserver.sendNext(getter())
+				producerObserver.sendNext(_value.value)
 				producerObserver.sendCompleted()
 			}
 		}
@@ -152,14 +165,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 
 	/// Initializes the property with the given value to start.
 	public init(_ initialValue: Value) {
-		var value = initialValue
-
-		lock = NSRecursiveLock()
-		lock.name = "org.reactivecocoa.ReactiveCocoa.MutableProperty"
-
-		getter = { value }
-		setter = { newValue in value = newValue }
-
+		_value = Atomic(initialValue, mutex: RecursiveLock("org.reactivecocoa.ReactiveCocoa.MutableProperty"))
 		(signal, observer) = Signal.pipe()
 	}
 
@@ -174,23 +180,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	///
 	/// Returns the old value.
 	public func modify(@noescape action: (Value) throws -> Value) rethrows -> Value {
-		return try withValue { value in
-			let newValue = try action(value)
-			setter(newValue)
-			observer.sendNext(newValue)
-			return value
-		}
-	}
-
-	/// Atomically performs an arbitrary action using the current value of the
-	/// variable.
-	///
-	/// Returns the result of the action.
-	public func withValue<Result>(@noescape action: (Value) throws -> Result) rethrows -> Result {
-		lock.lock()
-		defer { lock.unlock() }
-
-		return try action(getter())
+		return try _value.modify(action, completion: observer.sendNext)
 	}
 
 	deinit {


### PR DESCRIPTION
1. Separates `Mutex` implementation and `Atomic` value storage
2. Reduces code duplication and maintainability in `MutableProperty` by reusing higher level `Atomic` API instead of ad-hoc reimplementation.
