### PR TITLE
Makes composed properties safe.

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -68,8 +68,8 @@ public final class Action<Input, Output, Error: ErrorType> {
 		values = events.map { $0.value }.ignoreNil()
 		errors = events.map { $0.error }.ignoreNil()
 
-		_enabled <~ enabledIf.producer
-			.combineLatestWith(_executing.producer)
+		_enabled <~ enabledIf.values
+			.combineLatestWith(_executing.values)
 			.map(Action.shouldBeEnabled)
 	}
 

--- a/ReactiveCocoa/Swift/CocoaAction.swift
+++ b/ReactiveCocoa/Swift/CocoaAction.swift
@@ -32,7 +32,7 @@ public final class CocoaAction: NSObject {
 		
 		super.init()
 		
-		disposable += action.enabled.producer
+		disposable += action.enabled.values
 			.observeOn(UIScheduler())
 			.startWithNext { [weak self] value in
 				self?.willChangeValueForKey("enabled")
@@ -40,7 +40,7 @@ public final class CocoaAction: NSObject {
 				self?.didChangeValueForKey("enabled")
 		}
 		
-		disposable += action.executing.producer
+		disposable += action.executing.values
 			.observeOn(UIScheduler())
 			.startWithNext { [weak self] value in
 				self?.willChangeValueForKey("executing")

--- a/ReactiveCocoa/Swift/Deprecations+Removals.swift
+++ b/ReactiveCocoa/Swift/Deprecations+Removals.swift
@@ -1,3 +1,5 @@
+import enum Result.NoError
+
 // MARK: Removed APIs in ReactiveCocoa 5.0.
 
 extension SignalType {
@@ -17,6 +19,18 @@ extension SignalProducer {
 extension SignalProducerType {
 	@available(*, unavailable, message="This SignalProducer may emit errors which must be handled explicitly, or observed using startWithResult:")
 	public func startWithNext(next: Value -> Void) -> Disposable {
+		fatalError()
+	}
+}
+
+extension PropertyType {
+	@available(*, unavailable, renamed="values")
+	public var producer: SignalProducer<Value, NoError> {
+		fatalError()
+	}
+
+	@available(*, unavailable, message="Use `PropertyType.changes` instead. `PropertyType.signal` is removed in RAC 5.0.")
+	public var signal: Signal<Value, NoError> {
 		fatalError()
 	}
 }

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -42,12 +42,12 @@ public final class DynamicProperty<Value>: MutablePropertyType {
 	///
 	/// By definition, this only works if the object given to init() is
 	/// KVO-compliant. Most UI controls are not!
-	public var producer: SignalProducer<Value?, NoError> {
-		return property?.producer ?? .empty
+	public var values: SignalProducer<Value?, NoError> {
+		return property?.values ?? .empty
 	}
 
-	public var signal: Signal<Value?, NoError> {
-		return property?.signal ?? .empty
+	public var changes: SignalProducer<Value?, NoError> {
+		return property?.values.skip(1) ?? .empty
 	}
 
 	/// Initializes a property that will observe and set the given key path of

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -229,7 +229,7 @@ extension RACCommand {
 
 extension ActionType {
 	private var commandEnabled: RACSignal {
-		return self.enabled.producer
+		return self.enabled.values
 			.map { $0 as NSNumber }
 			.toRACSignal()
 	}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -26,7 +26,7 @@ public protocol PropertyType: class {
 	/// By default, it returns `self` for all implementations except
 	/// `Property`, which would returns its ultimate sources so as to allow
 	/// intermediate properties to deinitialize after a composition.
-	var sources: [Any] { get }
+	var sources: [AnyObject] { get }
 }
 
 /// Represents an observable property that can be mutated directly.
@@ -43,7 +43,7 @@ public protocol MutablePropertyType: PropertyType {
 /// A transformed property would retain its ultimate source, but not
 /// any intermediate property during the composition.
 extension PropertyType {
-	public var sources: [Any] {
+	public var sources: [AnyObject] {
 		/// Generally, only `Property` would have non-`self` sources to be captured.
 		return [self]
 	}
@@ -409,7 +409,7 @@ public class AnyProperty<Value>: PropertyType {
 	///
 	/// The producer and the signal of the created property would complete only
 	/// when the `propertyProducer` completes.
-	private init(propertyProducer: SignalProducer<Value, NoError>, capturing propertySources: [Any]) {
+	private init(propertyProducer: SignalProducer<Value, NoError>, capturing propertySources: [AnyObject]) {
 		var value: Value!
 
 		disposable = propertyProducer.start { event in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -104,6 +104,14 @@ public struct SignalProducer<Value, Error: ErrorType> {
 		}
 	}
 
+	/// A producer for a Signal that will immediately interrupt without sending
+	/// any values.
+	public static var interrupted: SignalProducer {
+		return self.init { observer, disposable in
+			observer.sendInterrupted()
+		}
+	}
+
 	/// A producer for a Signal that never sends any events to its observers.
 	public static var never: SignalProducer {
 		return self.init { _ in return }

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -613,6 +613,35 @@ class PropertySpec: QuickSpec {
 					expect(result) == finalResult
 				}
 
+				it("should be consistent between its cached value and its values producer") {
+					var firstResult: String!
+					var secondResult: String!
+
+					let zippedProperty = property.zipWith(otherProperty)
+					zippedProperty.values.startWithNext { (left, right) in firstResult = left + right }
+
+					func getValue() -> String {
+						return zippedProperty.value.0 + zippedProperty.value.1
+					}
+
+					expect(getValue()) == initialPropertyValue + initialOtherPropertyValue
+					expect(firstResult) == initialPropertyValue + initialOtherPropertyValue
+
+					property.value = subsequentPropertyValue
+					expect(getValue()) == initialPropertyValue + initialOtherPropertyValue
+					expect(firstResult) == initialPropertyValue + initialOtherPropertyValue
+
+					// It should still be the tuple with initial property values,
+					// since `otherProperty` isn't changed yet.
+					zippedProperty.values.startWithNext { (left, right) in secondResult = left + right }
+					expect(secondResult) == initialPropertyValue + initialOtherPropertyValue
+
+					otherProperty.value = subsequentOtherPropertyValue
+					expect(getValue()) == subsequentPropertyValue + subsequentOtherPropertyValue
+					expect(firstResult) == subsequentPropertyValue + subsequentOtherPropertyValue
+					expect(secondResult) == subsequentPropertyValue + subsequentOtherPropertyValue
+				}
+
 				it("should complete its producer only when the source properties are deinitialized") {
 					var result: [String] = []
 					var completed = false

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -31,19 +31,19 @@ class PropertySpec: QuickSpec {
 			it("should yield a changes producer that completes without emitting any value.") {
 				let constantProperty = ConstantProperty(initialPropertyValue)
 
-				var isChangesCompleted = false
+				var isChangesInterrupted = false
 				var hasUnexpectedEventsEmitted = false
 
 				constantProperty.changes.start { event in
 					switch event {
-					case .Completed:
-						isChangesCompleted = true
-					case .Next, .Failed, .Interrupted:
+					case .Interrupted:
+						isChangesInterrupted = true
+					case .Next, .Failed, .Completed:
 						hasUnexpectedEventsEmitted = true
 					}
 				}
 
-				expect(isChangesCompleted) == true
+				expect(isChangesInterrupted) == true
 				expect(hasUnexpectedEventsEmitted) == false
 			}
 
@@ -305,7 +305,7 @@ class PropertySpec: QuickSpec {
 					var sentValue: String?
 					var changesSentValue: String?
 					var valuesCompleted = false
-					var changesCompleted = false
+					var changesInterrupted = false
 
 					property.values.start { event in
 						switch event {
@@ -322,9 +322,9 @@ class PropertySpec: QuickSpec {
 						switch event {
 						case let .Next(value):
 							changesSentValue = value
-						case .Completed:
-							changesCompleted = true
-						case .Failed, .Interrupted:
+						case .Interrupted:
+							changesInterrupted = true
+						case .Failed, .Completed:
 							break
 						}
 					}
@@ -332,7 +332,7 @@ class PropertySpec: QuickSpec {
 					expect(sentValue) == initialPropertyValue
 					expect(changesSentValue).to(beNil())
 					expect(valuesCompleted) == true
-					expect(changesCompleted) == true
+					expect(changesInterrupted) == true
 				}
 
 				describe("transformed properties") {
@@ -458,9 +458,9 @@ class PropertySpec: QuickSpec {
 					expect(isValuesCompleted) == true
 					expect(isChangesCompleted) == true
 
-					isChangesCompleted = false
-					propertyChangesProducer.startWithCompleted { isChangesCompleted = true }
-					expect(isChangesCompleted) == true
+					var isChangesInterrupted = false
+					propertyChangesProducer.startWithInterrupted { isChangesInterrupted = true }
+					expect(isChangesInterrupted) == true
 				}
 			}
 
@@ -506,9 +506,9 @@ class PropertySpec: QuickSpec {
 					expect(isValuesCompleted) == true
 					expect(changesCompleted) == true
 
-					changesCompleted = false
-					propertyChanges.startWithCompleted { changesCompleted = true }
-					expect(changesCompleted) == true
+					var isChangesInterrupted = false
+					propertyChanges.startWithInterrupted { isChangesInterrupted = true }
+					expect(isChangesInterrupted) == true
 				}
 			}
 		}


### PR DESCRIPTION
(Splitting PR, Rebasing)

##### Completed
As mentioned in #3040, `PropertyType.signal` is not safe on composed properties due to the potential silent leakage caused by the semantics of `Signal`. Currently, it was just denoted in the comments that the use of `signal` on composed properties is discouraged.

This PR proposes further to replace it with an interruptible `SignalProducer` - `PropertyType.changes`. Meanwhile, it proposes also to rename `PropertyType.producer` to `PropertyType.values`, which describes now its role rather than its type.

> https://swift.org/documentation/api-design-guidelines/#promote-clear-usage
>
> Name variables, parameters, and associated types according to their roles, rather than their type constraints.

P.S. The difference between `changes` and `values` is _still_ whether they emit the current value when started.