### PR TITLE
Generic `skip(until:)` and `take(until:)`.

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -793,7 +793,7 @@ extension SignalProtocol {
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned signal will complete.
-	public func take(until trigger: Signal<(), NoError>) -> Signal<Value, Error> {
+	public func take<U>(until trigger: Signal<U, NoError>) -> Signal<Value, Error> {
 		return Signal { observer in
 			let disposable = CompositeDisposable()
 			disposable += self.observe(observer)
@@ -815,7 +815,7 @@ extension SignalProtocol {
 	/// Does not forward any values from `self` until `trigger` sends a Next or
 	/// Completed event, at which point the returned signal behaves exactly like
 	/// `signal`.
-	public func skip(until trigger: Signal<(), NoError>) -> Signal<Value, Error> {
+	public func skip<U>(until trigger: Signal<U, NoError>) -> Signal<Value, Error> {
 		return Signal { observer in
 			let disposable = SerialDisposable()
 			

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -621,7 +621,7 @@ extension SignalProducerProtocol {
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned producer will complete.
-	public func take(until trigger: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
+	public func take<U>(until trigger: SignalProducer<U, NoError>) -> SignalProducer<Value, Error> {
 		// This should be the implementation of this method:
 		// return liftRight(Signal.takeUntil)(trigger)
 		//
@@ -645,19 +645,19 @@ extension SignalProducerProtocol {
 
 	/// Forwards events from `self` until `trigger` sends a Next or Completed
 	/// event, at which point the returned producer will complete.
-	public func take(until trigger: Signal<(), NoError>) -> SignalProducer<Value, Error> {
+	public func take<U>(until trigger: Signal<U, NoError>) -> SignalProducer<Value, Error> {
 		return lift(Signal.take(until:))(trigger)
 	}
 
 	/// Does not forward any values from `self` until `trigger` sends a Next or
 	/// Completed, at which point the returned signal behaves exactly like `signal`.
-	public func skip(until trigger: SignalProducer<(), NoError>) -> SignalProducer<Value, Error> {
+	public func skip<U>(until trigger: SignalProducer<U, NoError>) -> SignalProducer<Value, Error> {
 		return liftRight(Signal.skip(until:))(trigger)
 	}
 	
 	/// Does not forward any values from `self` until `trigger` sends a Next or
 	/// Completed, at which point the returned signal behaves exactly like `signal`.
-	public func skip(until trigger: Signal<(), NoError>) -> SignalProducer<Value, Error> {
+	public func skip<U>(until trigger: Signal<U, NoError>) -> SignalProducer<Value, Error> {
 		return lift(Signal.skip(until:))(trigger)
 	}
 	


### PR DESCRIPTION
This PR proposes to alter the signature of `skip(until:)` and `take(until:)` for both `Signal` and `SignalProducer` to:

```
func take<U>(until: Signal<U, NoError>) -> Signal<Value, Error>
func skip<U>(until: Signal<U, NoError>) -> Signal<Value, Error>
```

So that a trigger can be any arbitrary signals that never fails. These operators do not care about the actual value anyway, but only two specific types of events.

The changes are purely addictive.

An obvious use case would be accepting a zipped signal of `willDeallocSignal`, which is of type `((), ())` and is not accepted by the original signature:
```
NotificationCenter.default.rac_notifications(.aNotificationThatIAmInterestedIn, object: object)
    .take(until: self.willDeallocSignal.zip(with: another.willDeallocSignal))
    .startWithNext(process(_:))
```