### PR TITLE
[5.0] Static Dispatch for the lock of `Atomic`.

### DIFF
--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -34,7 +34,7 @@ final class PosixThreadMutex: Locking {
 
 /// An atomic variable.
 public final class Atomic<Value>: AtomicProtocol {
-	private var lock: PosixThreadMutex
+	private let lock: PosixThreadMutex
 	private var _value: Value
 
 	/// Initialize the variable with the given initial value.
@@ -78,7 +78,7 @@ public final class Atomic<Value>: AtomicProtocol {
 
 /// An atomic variable which uses a recursive lock.
 internal final class RecursiveAtomic<Value>: AtomicProtocol {
-	private var lock: RecursiveLock
+	private let lock: RecursiveLock
 	private var _value: Value
 	private let didSetObserver: ((Value) -> Void)?
 

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -33,94 +33,28 @@ final class PosixThreadMutex: Locking {
 }
 
 /// An atomic variable.
-public final class Atomic<Value>: _AtomicBase<Value, PosixThreadMutex> {
-	/// Initialize the variable with the given initial value.
-	/// 
-	/// - parameters:
-	///   - value: Initial value for `self`.
-	public convenience init(_ value: Value) {
-		self.init(value, mutex: PosixThreadMutex())
-	}
-}
-
-/// An atomic variable which uses a recursive lock.
-internal final class RecursiveAtomic<Value>: _AtomicBase<Value, RecursiveLock> {
-	/// Initialize the variable with the given initial value.
-	/// 
-	/// - parameters:
-	///   - value: Initial value for `self`.
-	///   - name: An optional name used to create the recursive lock.
-	internal convenience init(_ value: Value, name: StaticString? = nil) {
-		let lock = RecursiveLock()
-		lock.name = name.map { String($0) }
-		self.init(value, mutex: lock)
-	}
-}
-
-/// The base class of an atomic variable.
-public class _AtomicBase<Value, Lock: Locking> {
-	private var _mutex: Lock
+public final class Atomic<Value>: AtomicProtocol {
+	private var lock: PosixThreadMutex
 	private var _value: Value
-	
-	/// Atomically get or set the value of the variable.
-	public var value: Value {
-		get {
-			return withValue { $0 }
-		}
-	
-		set(newValue) {
-			swap(newValue)
-		}
-	}
 
-	/// Initializes the variable with the given initial value.
-	internal init(_ value: Value, mutex: Lock) {
+	/// Initialize the variable with the given initial value.
+	/// 
+	/// - parameters:
+	///   - value: Initial value for `self`.
+	public init(_ value: Value) {
 		_value = value
-		_mutex = mutex
-	}
-
-	private func lock() {
-		_mutex.lock()
-	}
-	
-	private func unlock() {
-		_mutex.unlock()
-	}
-	
-	/// Atomically replace the contents of the variable.
-	///
-	/// - parameters:
-	///   - newValue: A new value for the variable.
-	///
-	/// - returns: The old value.
-	@discardableResult
-	public func swap(_ newValue: Value) -> Value {
-		return modify { $0 = newValue }
-	}
-
-	/// Atomically modify the variable.
-	///
-	/// - parameters:
-	///   - action: A closure that takes the current value.
-	///
-	/// - returns: The old value.
-	@discardableResult
-	public func modify(_ action: @noescape (inout Value) throws -> Void) rethrows -> Value {
-		return try modify(action, completion: nil)
+		lock = PosixThreadMutex()
 	}
 
 	/// Atomically modifies the variable.
 	///
 	/// - parameters:
 	///   - action: A closure that takes the current value.
-	///   - completion: An optional closure that would be executed after the
-	///                 returned value from `action` has been written back.
 	///
 	/// Returns the old value.
-	public func modify(_ action: @noescape (inout Value) throws -> Void, completion: (@noescape (Value) -> ())?) rethrows -> Value {
+	public func modify(_ action: @noescape (inout Value) throws -> Void) rethrows -> Value {
 		return try withValue { value in
 			try action(&_value)
-			completion?(_value)
 			return value
 		}
 	}
@@ -134,9 +68,94 @@ public class _AtomicBase<Value, Lock: Locking> {
 	/// - returns: The result of the action.
 	@discardableResult
 	public func withValue<Result>(_ action: @noescape (Value) throws -> Result) rethrows -> Result {
-		lock()
-		defer { unlock() }
+		lock.lock()
+		defer { lock.unlock() }
 
 		return try action(_value)
+	}
+}
+
+
+/// An atomic variable which uses a recursive lock.
+internal final class RecursiveAtomic<Value>: AtomicProtocol {
+	private var lock: RecursiveLock
+	private var _value: Value
+	private let didSetObserver: ((Value) -> Void)?
+
+	/// Initialize the variable with the given initial value.
+	/// 
+	/// - parameters:
+	///   - value: Initial value for `self`.
+	///   - name: An optional name used to create the recursive lock.
+	internal init(_ value: Value, name: StaticString? = nil, didSet action: ((Value) -> Void)? = nil) {
+		_value = value
+
+		lock = RecursiveLock()
+		lock.name = name.map { String($0) }
+		didSetObserver = action
+	}
+
+	/// Atomically modifies the variable.
+	///
+	/// - parameters:
+	///   - action: A closure that takes the current value.
+	///
+	/// Returns the old value.
+	@discardableResult
+	func modify(_ action: @noescape (inout Value) throws -> Void) rethrows -> Value {
+		return try withValue { value in
+			try action(&_value)
+			didSetObserver?(_value)
+			return value
+		}
+	}
+	
+	/// Atomically perform an arbitrary action using the current value of the
+	/// variable.
+	///
+	/// - parameters:
+	///   - action: A closure that takes the current value.
+	///
+	/// - returns: The result of the action.
+	@discardableResult
+	func withValue<Result>(_ action: @noescape (Value) throws -> Result) rethrows -> Result {
+		lock.lock()
+		defer { lock.unlock() }
+
+		return try action(_value)
+	}
+}
+
+public protocol AtomicProtocol: class {
+	associatedtype Value
+
+	@discardableResult
+	func withValue<Result>(_ action: @noescape (Value) throws -> Result) rethrows -> Result
+
+	@discardableResult
+	func modify(_ action: @noescape (inout Value) throws -> Void) rethrows -> Value
+}
+
+extension AtomicProtocol {	
+	/// Atomically get or set the value of the variable.
+	public var value: Value {
+		get {
+			return withValue { $0 }
+		}
+	
+		set(newValue) {
+			swap(newValue)
+		}
+	}
+
+	/// Atomically replace the contents of the variable.
+	///
+	/// - parameters:
+	///   - newValue: A new value for the variable.
+	///
+	/// - returns: The old value.
+	@discardableResult
+	public func swap(_ newValue: Value) -> Value {
+		return modify { $0 = newValue }
 	}
 }

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -9,25 +9,25 @@
 import Foundation
 
 final class PosixThreadMutex: Locking {
-	private var _mutex = pthread_mutex_t()
+	private var mutex = pthread_mutex_t()
 
 	init() {
-		let result = pthread_mutex_init(&_mutex, nil)
+		let result = pthread_mutex_init(&mutex, nil)
 		precondition(result == 0, "Failed to initialize mutex with error \(result).")
 	}
 
 	deinit {
-		let result = pthread_mutex_destroy(&_mutex)
+		let result = pthread_mutex_destroy(&mutex)
 		precondition(result == 0, "Failed to destroy mutex with error \(result).")
 	}
 
 	func lock() {
-		let result = pthread_mutex_lock(&_mutex)
+		let result = pthread_mutex_lock(&mutex)
 		precondition(result == 0, "Failed to lock \(self) with error \(result).")
 	}
 
 	func unlock() {
-		let result = pthread_mutex_unlock(&_mutex)
+		let result = pthread_mutex_unlock(&mutex)
 		precondition(result == 0, "Failed to unlock \(self) with error \(result).")
 	}
 }

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -52,6 +52,7 @@ public final class Atomic<Value>: AtomicProtocol {
 	///   - action: A closure that takes the current value.
 	///
 	/// Returns the old value.
+	@discardableResult
 	public func modify(_ action: @noescape (inout Value) throws -> Void) rethrows -> Value {
 		return try withValue { value in
 			try action(&_value)
@@ -87,11 +88,12 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	/// - parameters:
 	///   - value: Initial value for `self`.
 	///   - name: An optional name used to create the recursive lock.
+	///   - action: An optional closure which would be invoked every time the
+	///             value of `self` is mutated.
 	internal init(_ value: Value, name: StaticString? = nil, didSet action: ((Value) -> Void)? = nil) {
 		_value = value
-
 		lock = RecursiveLock()
-		lock.name = name.map { String($0) }
+		lock.name = name.map(String.init(_:))
 		didSetObserver = action
 	}
 

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -586,8 +586,8 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 		/// `value`. Note that recursive sets will still deadlock because the
 		/// underlying producer prevents sending recursive events.
 		_atomic = RecursiveAtomic(initialValue,
-															name: "org.reactivecocoa.ReactiveCocoa.MutableProperty",
-															didSet: observer.sendNext)
+		                          name: "org.reactivecocoa.ReactiveCocoa.MutableProperty",
+		                          didSet: observer.sendNext)
 	}
 
 	/// Atomically replaces the contents of the variable.

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -538,7 +538,7 @@ public final class Property<Value>: PropertyProtocol {
 public final class MutableProperty<Value>: MutablePropertyProtocol {
 	private let observer: Signal<Value, NoError>.Observer
 
-	private let _atomic: Atomic<Value>
+	private let _atomic: RecursiveAtomic<Value>
 
 	/// The current value of the property.
 	///
@@ -583,9 +583,7 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 		/// Need a recursive lock around `value` to allow recursive access to
 		/// `value`. Note that recursive sets will still deadlock because the
 		/// underlying producer prevents sending recursive events.
-		let lock = RecursiveLock()
-		lock.name = "org.reactivecocoa.ReactiveCocoa.MutableProperty"
-		_atomic = Atomic(initialValue, mutex: lock)
+		_atomic = RecursiveAtomic(initialValue, name: "org.reactivecocoa.ReactiveCocoa.MutableProperty")
 
 		(signal, observer) = Signal.pipe()
 	}


### PR DESCRIPTION
Justification: #3076

This branch uses type erasure, and adds an internal `RecursiveAtomic` for `MutableProperty`. The downside is that `_AtomicBase` would be leaked to the public API.

An alternative would be a parameterised `Atomic` with the lock type. e.g. `Atomic<Value, PosixThreadMutex>`.