### PR TITLE
Handle the case when throttle: previous date is newer than current da…

### DIFF
--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -452,12 +452,12 @@ public final class TestScheduler: DateSchedulerType {
 		advanceToDate(NSDate.distantFuture())
 	}
 	
-	/// Retreats the virtualized clock by the given interval.
+	/// Rewinds the virtualized clock by the given interval.
 	/// This simulates that user changes device date.
 	///
 	/// - parameters:
 	///   - interval: Interval by which the current date will be retreated.
-	public func retreatCurrentDateByInterval(interval: NSTimeInterval) {
+	public func rewindByInterval(interval: NSTimeInterval) {
 		lock.lock()
 		
 		let newDate = currentDate.dateByAddingTimeInterval(-interval)

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -451,4 +451,20 @@ public final class TestScheduler: DateSchedulerType {
 	public func run() {
 		advanceToDate(NSDate.distantFuture())
 	}
+	
+	/// Retreats the virtualized clock by the given interval.
+	/// This simulates that user changes device date.
+	///
+	/// - parameters:
+	///   - interval: Interval by which the current date will be retreated.
+	public func retreatCurrentDateByInterval(interval: NSTimeInterval) {
+		lock.lock()
+		
+		let newDate = currentDate.dateByAddingTimeInterval(-interval)
+		assert(currentDate.compare(newDate) != .OrderedAscending)
+		_currentDate = newDate
+		
+		lock.unlock()
+		
+	}
 }

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1452,7 +1452,13 @@ extension SignalType {
 					var state = state
 					state.pendingValue = value
 
-					let proposedScheduleDate = state.previousDate?.dateByAddingTimeInterval(interval) ?? scheduler.currentDate
+					let proposedScheduleDate: NSDate
+					if let previousDate = state.previousDate where previousDate.compare(scheduler.currentDate) == .OrderedAscending {
+						proposedScheduleDate = previousDate.dateByAddingTimeInterval(interval)
+					} else {
+						proposedScheduleDate = scheduler.currentDate
+					}
+					
 					scheduleDate = proposedScheduleDate.laterDate(scheduler.currentDate)
 
 					return state

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1422,6 +1422,10 @@ extension SignalType {
 	///         that value will be discarded and the returned signal will 
 	///         terminate immediately.
 	///
+	/// - note: If the device time changed backwords before previous date while
+	///         a value is being throttled, and if there is a new value sent,
+	///         the new value will be passed anyway.
+	///
 	/// - parameters:
 	///   - interval: Number of seconds to wait between sent values.
 	///   - scheduler: A scheduler to deliver events on.
@@ -1453,12 +1457,11 @@ extension SignalType {
 					state.pendingValue = value
 
 					let proposedScheduleDate: NSDate
-					if let previousDate = state.previousDate where previousDate.compare(scheduler.currentDate) == .OrderedAscending {
+					if let previousDate = state.previousDate where previousDate.compare(scheduler.currentDate) != .OrderedDescending {
 						proposedScheduleDate = previousDate.dateByAddingTimeInterval(interval)
 					} else {
 						proposedScheduleDate = scheduler.currentDate
 					}
-					
 					scheduleDate = proposedScheduleDate.laterDate(scheduler.currentDate)
 
 					return state

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -899,7 +899,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3 ]
 
-				scheduler.retreatCurrentDateByInterval(2)
+				scheduler.rewindByInterval(2)
 				expect(values) == [ 0, 2, 3 ]
 				
 				observer.sendNext(6)

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -899,8 +899,20 @@ class SignalProducerLiftingSpec: QuickSpec {
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3 ]
 
+				scheduler.retreatCurrentDateByInterval(2)
+				expect(values) == [ 0, 2, 3 ]
+				
+				observer.sendNext(6)
+				scheduler.advance()
+				expect(values) == [ 0, 2, 3, 6 ]
+				
+				observer.sendNext(7)
+				observer.sendNext(8)
+				scheduler.advance()
+				expect(values) == [ 0, 2, 3, 6 ]
+				
 				scheduler.run()
-				expect(values) == [ 0, 2, 3, 5 ]
+				expect(values) == [ 0, 2, 3, 6, 8 ]
 			}
 
 			it("should schedule completion immediately") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1293,7 +1293,7 @@ class SignalSpec: QuickSpec {
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3 ]
 				
-				scheduler.retreatCurrentDateByInterval(2)
+				scheduler.rewindByInterval(2)
 				expect(values) == [ 0, 2, 3 ]
 				
 				observer.sendNext(6)

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1292,9 +1292,21 @@ class SignalSpec: QuickSpec {
 				observer.sendNext(5)
 				scheduler.advance()
 				expect(values) == [ 0, 2, 3 ]
+				
+				scheduler.retreatCurrentDateByInterval(2)
+				expect(values) == [ 0, 2, 3 ]
+				
+				observer.sendNext(6)
+				scheduler.advance()
+				expect(values) == [ 0, 2, 3, 6 ]
+				
+				observer.sendNext(7)
+				observer.sendNext(8)
+				scheduler.advance()
+				expect(values) == [ 0, 2, 3, 6 ]
 
 				scheduler.run()
-				expect(values) == [ 0, 2, 3, 5 ]
+				expect(values) == [ 0, 2, 3, 6, 8 ]
 			}
 
 			it("should schedule completion immediately") {


### PR DESCRIPTION
…te. For example, previous date is 5 mins ahead of the standard time, adjust the device time 5 mins back to the standard time and trigger the signal again, the scheduleDate is (5 mins + interval) later.