### PR TITLE
Signal and SignalProducer: added timeoutWithError overloads for NoError

### DIFF
--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1821,4 +1821,31 @@ extension SignalType where Error == NoError {
 			}
 		}
 	}
+
+	/// Forward events from `self` until `interval`. Then if signal isn't
+	/// completed yet, fails with `error` on `scheduler`.
+	///
+	/// - note: If the interval is 0, the timeout will be scheduled immediately.
+	///         The signal must complete synchronously (or on a faster
+	///         scheduler) to avoid the timeout.
+	///
+	/// - parameters:
+	///   - error: Error to send with `Failed` event if `self` is not completed
+	///            when `interval` passes.
+	///   - interval: Number of seconds to wait for `self` to complete.
+	///   - scheudler: A scheduler to deliver error on.
+	///
+	/// - returns: A signal that sends events for at most `interval` seconds,
+	///            then, if not `Completed` - sends `error` with `Failed` event
+	///            on `scheduler`.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
+	public func timeoutWithError<NewError: ErrorType>(
+		error: NewError,
+		afterInterval interval: NSTimeInterval,
+		onScheduler scheduler: DateSchedulerType
+	) -> Signal<Value, NewError> {
+		return self
+			.promoteErrors(NewError.self)
+			.timeoutWithError(error, afterInterval: interval, onScheduler: scheduler)
+	}
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1356,6 +1356,31 @@ extension SignalProducerType where Error == NoError {
 	public func promoteErrors<F: ErrorType>(_: F.Type) -> SignalProducer<Value, F> {
 		return lift { $0.promoteErrors(F) }
 	}
+
+	/// Forward events from `self` until `interval`. Then if producer isn't
+	/// completed yet, fails with `error` on `scheduler`.
+	///
+	/// - note: If the interval is 0, the timeout will be scheduled immediately.
+	///         The producer must complete synchronously (or on a faster
+	///         scheduler) to avoid the timeout.
+	///
+	/// - parameters:
+	///   - error: Error to send with `Failed` event if `self` is not completed
+	///            when `interval` passes.
+	///   - interval: Number of seconds to wait for `self` to complete.
+	///   - scheudler: A scheduler to deliver error on.
+	///
+	/// - returns: A producer that sends events for at most `interval` seconds,
+	///            then, if not `Completed` - sends `error` with `Failed` event
+	///            on `scheduler`.
+	@warn_unused_result(message="Did you forget to call `start` on the producer?")
+	public func timeoutWithError<NewError: ErrorType>(
+		error: NewError,
+		afterInterval interval: NSTimeInterval,
+		onScheduler scheduler: DateSchedulerType
+	) -> SignalProducer<Value, NewError> {
+		return lift { $0.timeoutWithError(error, afterInterval: interval, onScheduler: scheduler) }
+	}
 }
 
 extension SignalProducerType where Value: Equatable {

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -1413,6 +1413,13 @@ class SignalProducerLiftingSpec: QuickSpec {
 				expect(completed) == false
 				expect(errored) == true
 			}
+
+			it("should be available for NoError") {
+				let producer: SignalProducer<Int, TestError> = SignalProducer<Int, NoError>.never
+					.timeoutWithError(TestError.Default, afterInterval: 2, onScheduler: testScheduler)
+
+				_ = producer
+			}
 		}
 
 		describe("attempt") {

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -1893,6 +1893,13 @@ class SignalSpec: QuickSpec {
 				expect(completed) == false
 				expect(errored) == true
 			}
+
+			it("should be available for NoError") {
+				let signal: Signal<Int, TestError> = Signal<Int, NoError>.never
+					.timeoutWithError(TestError.Default, afterInterval: 2, onScheduler: testScheduler)
+
+				_ = signal
+			}
 		}
 
 		describe("attempt") {


### PR DESCRIPTION
Fixes #3083.

This is similar to the overloads introduced in #2542.