### PR TITLE
Pre- and post-start hooks in `SignalProducer.on`.

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1497,7 +1497,6 @@ extension SignalProducerType {
 	@warn_unused_result(message="Did you forget to call `start` on the producer?")
 	public func on(started started: (() -> Void)? = nil, event: (Event<Value, Error> -> Void)? = nil, failed: (Error -> Void)? = nil, completed: (() -> Void)? = nil, interrupted: (() -> Void)? = nil, terminated: (() -> Void)? = nil, disposed: (() -> Void)? = nil, next: (Value -> Void)? = nil) -> SignalProducer<Value, Error> {
 		return SignalProducer { observer, compositeDisposable in
-			started?()
 			self.startWithSignal { signal, disposable in
 				compositeDisposable += disposable
 				compositeDisposable += signal
@@ -1512,6 +1511,8 @@ extension SignalProducerType {
 					)
 					.observe(observer)
 			}
+
+			started?()
 		}
 	}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1000,6 +1000,20 @@ class SignalProducerSpec: QuickSpec {
 				disposable.dispose()
 				expect(disposed) == true
 			}
+
+			it("should invoke the `started` action of the inner producer first") {
+				let (baseProducer, _) = SignalProducer<Int, TestError>.pipe()
+
+				var numbers = [Int]()
+
+				let producer = baseProducer
+					.on(started: { numbers.append(1) })
+					.on(started: { numbers.append(2) })
+					.on(started: { numbers.append(3) })
+					.start()
+
+				expect(numbers) == [1, 2, 3]
+			}
 		}
 
 		describe("startOn") {


### PR DESCRIPTION
Fix #3095.