### PR TITLE
SignalProducer.combineLatest: removed no longer necessary workaround

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -659,25 +659,8 @@ extension SignalProducerProtocol {
 	/// - returns: A producer that, when started, will yield a tuple containing
 	///            values of `self` and given producer.
 	public func combineLatest<U>(with other: SignalProducer<U, Error>) -> SignalProducer<(Value, U), Error> {
-		// This should be the implementation of this method:
-		// return liftRight(Signal.combineLatestWith)(otherProducer)
-		//
-		// However, due to a Swift miscompilation (with `-O`) we need to inline `liftRight` here.
-		// See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2751 for more details.
-		//
-		// This can be reverted once tests with -O don't crash. 
-
-		return SignalProducer { observer, outerDisposable in
-			self.startWithSignal { signal, disposable in
-				outerDisposable.add(disposable)
-
-				other.startWithSignal { otherSignal, otherDisposable in
-					outerDisposable += otherDisposable
-
-					signal.combineLatest(with: otherSignal).observe(observer)
-				}
-			}
-		}
+		// TODO: change to liftLeft when rebasing (see #3096).
+		return liftRight(Signal.combineLatest)(other)
 	}
 
 	/// Combine the latest value of the receiver with the latest value from


### PR DESCRIPTION
This was originally introduced in #2751, but it's not necessary anymore. Tests pass with `-O` now!

This will have to be changed to `liftLeft` once rebasing #3096.