### PR TITLE
Introduce non-lazy replayed producers.

### DIFF
--- a/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa.playground/Pages/SignalProducer.xcplaygroundpage/Contents.swift
@@ -662,15 +662,20 @@ scopedExample("`then`") {
 }
 
 /*:
-### `replayLazily(upTo:)`
+### `replay(upTo:)` and `replay(upTo:startsLazily:)`
 Creates a new `SignalProducer` that will multicast values emitted by
 the underlying producer, up to `capacity`.
 This means that all clients of this `SignalProducer` will see the same version
 of the emitted values/errors.
 
-The underlying `SignalProducer` will not be started until `self` is started
-for the first time. When subscribing to this producer, all previous values
-(up to `capacity`) will be emitted, followed by any new values.
+By default, the underlying `SignalProducer` will not be started until
+`self` is started for the first time. When subscribing to this producer,
+all previous values (up to `capacity`) will be emitted, followed by any
+new values. You may specify `startLazily` to be `false` if you intend
+to have it started immediately.
+
+Note that the underlying producer would be retained until it is started
+for the first time.
 
 If you find yourself needing *the current value* (the last buffered value)
 you should consider using `PropertyType` instead, which, unlike this operator,
@@ -682,12 +687,10 @@ a `Signal` instead.
 
 This operator is only recommended when you absolutely need to introduce
 a layer of caching in front of another `SignalProducer`.
-
-This operator has the same semantics as `SignalProducer.buffer`.
 */
-scopedExample("`replayLazily(upTo:)`") {
+scopedExample("`replay(upTo:)`") {
 	let baseProducer = SignalProducer<Int, NoError>(values: [ 1, 2, 3, 4, 42 ])
-		.replayLazily(upTo: 2)
+		.replay(upTo: 2)
 
 	baseProducer.startWithNext { value in
 		print(value)

--- a/ReactiveCocoa/Swift/Deprecations+Removals.swift
+++ b/ReactiveCocoa/Swift/Deprecations+Removals.swift
@@ -210,6 +210,9 @@ extension SignalProducerProtocol {
 	@available(*, unavailable, renamed:"timeout(after:raising:on:)")
 	public func timeoutWithError(_ error: Error, afterInterval: TimeInterval, onScheduler: SchedulerProtocol) -> SignalProducer<Value, Error> { fatalError() }
 
+	@available(*, unavailable, renamed:"replay(upTo:)")
+	public func replayLazily(upTo capacity: Int) -> SignalProducer<Value, Error> { fatalError() }
+
 	@available(*, unavailable, message:"This SignalProducer may emit errors which must be handled explicitly, or observed using `startWithResult(_:)`.")
 	public func startWithNext(_ next: (Value) -> Void) -> Disposable { fatalError() }
 }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -484,7 +484,7 @@ public final class Property<Value>: PropertyProtocol {
 		// Share a replayed producer with `self.producer` and `self.signal` so
 		// they see a consistent view of the `self.value`.
 		// https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3042
-		let producer = unsafeProducer.replayLazily(upTo: 1)
+		let producer = unsafeProducer.replay(upTo: 1)
 		
 		// Verify that an initial is sent. This is friendlier than deadlocking
 		// in the event that one isn't.

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1669,7 +1669,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A caching producer that will hold up to last `capacity`
 	///            values.
-	public func replayLazily(upTo capacity: Int) -> SignalProducer<Value, Error> {
+	public func replay(upTo capacity: Int) -> SignalProducer<Value, Error> {
 		precondition(capacity >= 0, "Invalid capacity: \(capacity)")
 
 		// This will go "out of scope" when the returned `SignalProducer` goes

--- a/ReactiveCocoaTests/Swift/KeyValueObservingSpec.swift
+++ b/ReactiveCocoaTests/Swift/KeyValueObservingSpec.swift
@@ -290,7 +290,7 @@ class KeyValueObservingSpec: QuickSpec {
 						.map { $0 % 2 == 0 }
 						.observe(on: otherScheduler)
 						.take(until: teardown)
-						.replayLazily(upTo: 1)
+						.replay(upTo: 1)
 
 					replayProducer.start { _ in }
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1915,7 +1915,7 @@ class SignalProducerSpec: QuickSpec {
 				producer = producerTemp
 				observer = observerTemp
 
-				replayedProducer = producer.replayLazily(upTo: 2)
+				replayedProducer = producer.replay(upTo: 2)
 			}
 
 			context("subscribing to underlying producer") {
@@ -2015,7 +2015,7 @@ class SignalProducerSpec: QuickSpec {
 					expect(started) == false
 
 					let replayedProducer = producer
-						.replayLazily(upTo: 1)
+						.replay(upTo: 1)
 					expect(started) == false
 
 					replayedProducer.start()
@@ -2030,7 +2030,7 @@ class SignalProducerSpec: QuickSpec {
 					expect(startedTimes) == 0
 
 					let replayedProducer = producer
-						.replayLazily(upTo: 1)
+						.replay(upTo: 1)
 					expect(startedTimes) == 0
 
 					replayedProducer.start()
@@ -2047,7 +2047,7 @@ class SignalProducerSpec: QuickSpec {
 						.on(started: { startedTimes += 1 })
 
 					let replayedProducer = producer
-						.replayLazily(upTo: 1)
+						.replay(upTo: 1)
 
 					expect(startedTimes) == 0
 					replayedProducer.start().dispose()
@@ -2064,7 +2064,7 @@ class SignalProducerSpec: QuickSpec {
 					expect(startedTimes) == 0
 
 					let replayedProducer = producer
-						.replayLazily(upTo: 1)
+						.replay(upTo: 1)
 					expect(startedTimes) == 0
 
 					replayedProducer.start()
@@ -2083,7 +2083,7 @@ class SignalProducerSpec: QuickSpec {
 						.on(disposed: { disposed = true })
 
 					let replayedProducer = producer
-						.replayLazily(upTo: 1)
+						.replay(upTo: 1)
 
 					expect(disposed) == false
 					let disposable = replayedProducer.start()
@@ -2099,7 +2099,7 @@ class SignalProducerSpec: QuickSpec {
 					let producer = SignalProducer<Int, NoError>.never
 						.on(disposed: { disposed = true })
 
-					var replayedProducer = ImplicitlyUnwrappedOptional(producer.replayLazily(upTo: 1))
+					var replayedProducer = ImplicitlyUnwrappedOptional(producer.replay(upTo: 1))
 
 					expect(disposed) == false
 					let disposable1 = replayedProducer?.start()
@@ -2122,7 +2122,7 @@ class SignalProducerSpec: QuickSpec {
 					let producer = SignalProducer<Int, NoError>.never
 						.on(disposed: { disposed = true })
 
-					var replayedProducer = ImplicitlyUnwrappedOptional(producer.replayLazily(upTo: 1))
+					var replayedProducer = ImplicitlyUnwrappedOptional(producer.replay(upTo: 1))
 
 					expect(disposed) == false
 					let disposable = replayedProducer?.start()
@@ -2156,7 +2156,7 @@ class SignalProducerSpec: QuickSpec {
 					expect(deinitValues) == 0
 
 					var replayedProducer: SignalProducer<Value, NoError>! = producer
-						.replayLazily(upTo: 1)
+						.replay(upTo: 1)
 					
 					let disposable = replayedProducer
 						.start()

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -1904,7 +1904,7 @@ class SignalProducerSpec: QuickSpec {
 			}
 		}
 
-		describe("replayLazily") {
+		describe("replay") {
 			var producer: SignalProducer<Int, TestError>!
 			var observer: SignalProducer<Int, TestError>.ProducedSignal.Observer!
 
@@ -1919,6 +1919,31 @@ class SignalProducerSpec: QuickSpec {
 			}
 
 			context("subscribing to underlying producer") {
+				it("should start immediately") {
+					var isStarted = false
+
+					_ = producer
+						.on(started: { isStarted = true })
+						.replay(upTo: 2, startsLazily: false)
+						.assumeNoErrors()
+
+					expect(isStarted) == true
+				}
+
+				it("should not start immediately until the very first signal is to be produced") {
+					var isStarted = false
+
+					let replayedProducer = producer
+						.on(started: { isStarted = true })
+						.replay(upTo: 2)
+						.assumeNoErrors()
+
+					expect(isStarted) == false
+
+					replayedProducer.start()
+					expect(isStarted) == true
+				}
+
 				it("emits new values") {
 					var last: Int?
 


### PR DESCRIPTION
Depend on #3082.

1. Renamed `replayLazily(upTo:)` to `replay(upTo:)`. (`SignalProducer` is generally lazy anyway...)
2. Introduced `replay(upTo:startsLazily:)` to allow starting the underlying producer in place.

Motivation: Needed in a WIP `DynamicProperty` patch to cache the latest value without attaching a dummy observer.