### PR TITLE
Decoupled the deinitialization detection from `Lifetime`.

### DIFF
--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -1684,10 +1684,15 @@ extension SignalProducerProtocol {
 		// out of scope. This lets us know when we're supposed to dispose the
 		// underlying producer. This is necessary because `struct`s don't have
 		// `deinit`.
-		let lifetime = Lifetime()
+		let token = Lifetime.Token()
+		let lifetime = Lifetime(token)
 
 		return SignalProducer { observer, disposable in
-			var lifetime: Lifetime? = lifetime
+			var token: Lifetime.Token? = token
+
+			// Suppress the "never read" warning.
+			_ = token
+
 			let initializedProducer: SignalProducer<Value, Error>
 			let initializedObserver: SignalProducer<Value, Error>.ProducedSignal.Observer
 			let shouldStartUnderlyingProducer: Bool
@@ -1710,11 +1715,11 @@ extension SignalProducerProtocol {
 			disposable += {
 				// Don't dispose of the original producer until all observers
 				// have terminated.
-				lifetime = nil
+				token = nil
 			}
 
 			if shouldStartUnderlyingProducer {
-				self.take(during: lifetime!)
+				self.take(during: lifetime)
 					.start(initializedObserver)
 			}
 		}


### PR DESCRIPTION
Solution 1 in issue #3111 (Reliability of `Lifetime`).

Recap: The split prevents the completion of `Lifetime`'s signal from being deferred from the actual deinitialization due to external retainments.