### PR TITLE
Alter `Atomic.modify` to return the result of the supplied action.

### DIFF
--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -224,8 +224,10 @@ public final class SerialDisposable: Disposable {
 		}
 
 		set(d) {
-			let oldState = state.modify { state in
+			let oldState: State = state.modify { state in
+				let old = state
 				state.innerDisposable = d
+				return old
 			}
 
 			oldState.innerDisposable?.dispose()

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -597,7 +597,7 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// - returns: The previous property value.
 	@discardableResult
 	public func swap(_ newValue: Value) -> Value {
-		return modify { $0 = newValue }
+		return atomic.swap(newValue)
 	}
 
 	/// Atomically modifies the variable.
@@ -605,9 +605,10 @@ public final class MutableProperty<Value>: MutablePropertyProtocol {
 	/// - parameters:
 	///   - action: A closure that accepts old property value and returns a new
 	///             property value.
-	/// - returns: The previous property value.
+	///
+	/// - returns: The result of the action.
 	@discardableResult
-	public func modify(_ action: @noescape (inout Value) throws -> Void) rethrows -> Value {
+	public func modify<Result>(_ action: @noescape (inout Value) throws -> Result) rethrows -> Result {
 		return try atomic.modify(action)
 	}
 

--- a/ReactiveCocoaTests/Swift/AtomicSpec.swift
+++ b/ReactiveCocoaTests/Swift/AtomicSpec.swift
@@ -31,7 +31,7 @@ class AtomicSpec: QuickSpec {
 		}
 
 		it("should modify the value atomically") {
-			expect(atomic.modify({ $0 += 1 })) == 1
+			atomic.modify { $0 += 1 }
 			expect(atomic.value) == 2
 		}
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -138,7 +138,7 @@ class PropertySpec: QuickSpec {
 			it("should modify the value atomically") {
 				let property = MutableProperty(initialPropertyValue)
 
-				expect(property.modify({ $0 = subsequentPropertyValue })) == initialPropertyValue
+				property.modify { $0 = subsequentPropertyValue }
 				expect(property.value) == subsequentPropertyValue
 			}
 
@@ -151,8 +151,8 @@ class PropertySpec: QuickSpec {
 				}
 
 				expect(value) == initialPropertyValue
-				expect(property.modify({ $0 = subsequentPropertyValue })) == initialPropertyValue
 
+				property.modify { $0 = subsequentPropertyValue }
 				expect(property.value) == subsequentPropertyValue
 				expect(value) == subsequentPropertyValue
 			}


### PR DESCRIPTION
After revisiting all the use of `Atomic.modify`, it is observed that for those who need the old state, most of them needs only one or two specific bits. However, the current `Atomic.modify` would relentlessly copy everything (or make CoW types non-uniquely referenced).

Therefore, this PR altered `modify` to be more primitive and efficiently covering all the cases. The only downside is the lost of sugar for those who need a full copy of the old value. 🌴 

Having said that, a caveat is that [the Swift compiler can infer the return type of a closure, if the closure has a single expression only](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20151214/002583.html) at this moment. In other words, the return type of multi-line closures have to be stated explicitly, if it cannot be inferred from the LHS of an assignment statement (or `Void`).

```
// OK, since return type is obviously `Void`.
value.modify { $0 += 1 }
value.modify {
    $0 += 1
    $0 += 2
}
```

```
// This needs explicit type annotation, or the compiler
// will complain about not being able to infer the return
// type.
let previousValue = value.modify {
    let old = $0
    $0 += 1
    return old
}

// This works.
let previousValue = value.modify { value -> Int in
    let old = value
    value += 1
    return old
}

// Or this
let previousValue: Int = value.modify {
    let old = $0
    $0 += 1
    return old
}
```