### PR TITLE
Changes for Swift 3 beta 6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "Carthage/Checkouts/Nimble"]
 	path = Carthage/Checkouts/Nimble
-	url = https://github.com/andersio/Nimble.git
+	url = https://github.com/ikesyo/Nimble.git
 [submodule "Carthage/Checkouts/Quick"]
 	path = Carthage/Checkouts/Quick
-	url = https://github.com/norio-nomura/Quick.git
+	url = https://github.com/ikesyo/Quick.git
 [submodule "Carthage/Checkouts/xcconfigs"]
 	path = Carthage/Checkouts/xcconfigs
 	url = https://github.com/jspahrsummers/xcconfigs.git

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" "3.0.0-alpha.2"
+github "antitypical/Result" "3.0.0-alpha.3"

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" "1ef9763"
-github "norio-nomura/Quick" "nn-swift-3-compatibility"
-github "andersio/Nimble" "swift3-beta-4"
+github "ikesyo/Quick" "xcode8-beta6"
+github "ikesyo/Nimble" "swift3-beta-6"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "andersio/Nimble" "7c0762319cd5c902a85b92722a0659cc33cd6338"
 github "norio-nomura/Quick" "eaf60d980d88ffefd8c3a7515f53547453d5938b"
-github "antitypical/Result" "3.0.0-alpha.2"
+github "antitypical/Result" "3.0.0-alpha.3"
 github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "andersio/Nimble" "7c0762319cd5c902a85b92722a0659cc33cd6338"
-github "norio-nomura/Quick" "eaf60d980d88ffefd8c3a7515f53547453d5938b"
+github "ikesyo/Nimble" "4f38620db52b81eef4298492fed057247308b5d6"
+github "ikesyo/Quick" "e14bf151a4c864e6f144559e7b7c09bca0fd38c1"
 github "antitypical/Result" "3.0.0-alpha.3"
 github "jspahrsummers/xcconfigs" "1ef97639ffbe041da0b1392b2114fa19b922a7a1"

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -68,7 +68,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	///                enabled.
 	///   - execute: A closure that returns the signal producer returned by
 	///              calling `apply(Input)` on the action.
-	public init<P: PropertyProtocol where P.Value == Bool>(enabledIf property: P, _ execute: (Input) -> SignalProducer<Output, Error>) {
+	public init<P: PropertyProtocol>(enabledIf property: P, _ execute: @escaping (Input) -> SignalProducer<Output, Error>) where P.Value == Bool {
 		executeClosure = execute
 		isUserEnabled = Property(property)
 
@@ -88,7 +88,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	/// - parameters:
 	///   - execute: A closure that returns the signal producer returned by
 	///              calling `apply(Input)` on the action.
-	public convenience init(_ execute: (Input) -> SignalProducer<Output, Error>) {
+	public convenience init(_ execute: @escaping (Input) -> SignalProducer<Output, Error>) {
 		self.init(enabledIf: Property(value: true), execute)
 	}
 

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -93,7 +93,7 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	internal init(_ value: Value, name: StaticString? = nil, didSet action: ((Value) -> Void)? = nil) {
 		_value = value
 		lock = NSRecursiveLock()
-		lock.name = name.map(String.init(_:))
+		lock.name = name.map(String.init(describing:))
 		didSetObserver = action
 	}
 

--- a/ReactiveCocoa/Swift/Atomic.swift
+++ b/ReactiveCocoa/Swift/Atomic.swift
@@ -53,7 +53,7 @@ public final class Atomic<Value>: AtomicProtocol {
 	///
 	/// - returns: The result of the action.
 	@discardableResult
-	public func modify<Result>(_ action: @noescape (inout Value) throws -> Result) rethrows -> Result {
+	public func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
 		lock.lock()
 		defer { lock.unlock() }
 
@@ -68,7 +68,7 @@ public final class Atomic<Value>: AtomicProtocol {
 	///
 	/// - returns: The result of the action.
 	@discardableResult
-	public func withValue<Result>(_ action: @noescape (Value) throws -> Result) rethrows -> Result {
+	public func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
 		lock.lock()
 		defer { lock.unlock() }
 
@@ -104,7 +104,7 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	///
 	/// - returns: The result of the action.
 	@discardableResult
-	func modify<Result>(_ action: @noescape (inout Value) throws -> Result) rethrows -> Result {
+	func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result {
 		lock.lock()
 		defer {
 			didSetObserver?(_value)
@@ -122,7 +122,7 @@ internal final class RecursiveAtomic<Value>: AtomicProtocol {
 	///
 	/// - returns: The result of the action.
 	@discardableResult
-	func withValue<Result>(_ action: @noescape (Value) throws -> Result) rethrows -> Result {
+	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result {
 		lock.lock()
 		defer { lock.unlock() }
 
@@ -134,10 +134,10 @@ public protocol AtomicProtocol: class {
 	associatedtype Value
 
 	@discardableResult
-	func withValue<Result>(_ action: @noescape (Value) throws -> Result) rethrows -> Result
+	func withValue<Result>(_ action: (Value) throws -> Result) rethrows -> Result
 
 	@discardableResult
-	func modify<Result>(_ action: @noescape (inout Value) throws -> Result) rethrows -> Result
+	func modify<Result>(_ action: (inout Value) throws -> Result) rethrows -> Result
 }
 
 extension AtomicProtocol {	

--- a/ReactiveCocoa/Swift/Bag.swift
+++ b/ReactiveCocoa/Swift/Bag.swift
@@ -9,16 +9,16 @@
 /// A uniquely identifying token for removing a value that was inserted into a
 /// Bag.
 public final class RemovalToken {
-	private var identifier: UInt?
+	fileprivate var identifier: UInt?
 
-	private init(identifier: UInt) {
+	fileprivate init(identifier: UInt) {
 		self.identifier = identifier
 	}
 }
 
 /// An unordered, non-unique collection of values of type `Element`.
 public struct Bag<Element> {
-	private var elements: [BagElement<Element>] = []
+	fileprivate var elements: [BagElement<Element>] = []
 	private var currentIdentifier: UInt = 0
 
 	public init() {

--- a/ReactiveCocoa/Swift/CocoaAction.swift
+++ b/ReactiveCocoa/Swift/CocoaAction.swift
@@ -35,7 +35,7 @@ public final class CocoaAction: NSObject {
 	///                     action and returns a value (e.g. 
 	///                     `(UISwitch) -> (Bool)` to reflect whether a provided
 	///                     switch is currently on.
-	public init<Input, Output, Error>(_ action: Action<Input, Output, Error>, _ inputTransform: (AnyObject?) -> Input) {
+	public init<Input, Output, Error>(_ action: Action<Input, Output, Error>, _ inputTransform: @escaping (AnyObject?) -> Input) {
 		_execute = { input in
 			let producer = action.apply(inputTransform(input))
 			producer.start()

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -115,7 +115,9 @@ public final class CompositeDisposable: Disposable {
 	/// - parameters:
 	///   - disposables: A collection of objects conforming to the `Disposable`
 	///                  protocol
-	public init<S: Sequence where S.Iterator.Element == Disposable>(_ disposables: S) {
+	public init<S: Sequence>(_ disposables: S)
+		where S.Iterator.Element == Disposable
+	{
 		var bag: Bag<Disposable> = Bag()
 
 		for disposable in disposables {
@@ -131,7 +133,9 @@ public final class CompositeDisposable: Disposable {
 	/// - parameters:
 	///   - disposables: A collection of objects conforming to the `Disposable`
 	///                  protocol
-	public convenience init<S: Sequence where S.Iterator.Element == Disposable?>(_ disposables: S) {
+	public convenience init<S: Sequence>(_ disposables: S)
+		where S.Iterator.Element == Disposable?
+	{
 		self.init(disposables.flatMap { $0 })
 	}
 

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -81,7 +81,7 @@ public final class CompositeDisposable: Disposable {
 		private let bagToken: Atomic<RemovalToken?>
 		private weak var disposable: CompositeDisposable?
 
-		private static let empty = DisposableHandle()
+		fileprivate static let empty = DisposableHandle()
 
 		private init() {
 			self.bagToken = Atomic(nil)

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -61,7 +61,7 @@ public final class ActionDisposable: Disposable {
 	///
 	/// - parameters:
 	///   - action: A closure to run when calling `dispose()`.
-	public init(action: () -> Void) {
+	public init(action: @escaping () -> Void) {
 		self.action = Atomic(action)
 	}
 
@@ -181,7 +181,7 @@ public final class CompositeDisposable: Disposable {
 	///
 	/// - returns: An instance of `DisposableHandle` that can be used to
 	///            opaquely remove the disposable later (if desired).
-	public func add(_ action: () -> Void) -> DisposableHandle {
+	public func add(_ action: @escaping () -> Void) -> DisposableHandle {
 		return add(ActionDisposable(action: action))
 	}
 }
@@ -312,7 +312,7 @@ public func +=(lhs: CompositeDisposable, rhs: Disposable?) -> CompositeDisposabl
 /// - returns: An instance of `DisposableHandle` that can be used to opaquely
 ///            remove the disposable later (if desired).
 @discardableResult
-public func +=(lhs: CompositeDisposable, rhs: () -> ()) -> CompositeDisposable.DisposableHandle {
+public func +=(lhs: CompositeDisposable, rhs: @escaping () -> ()) -> CompositeDisposable.DisposableHandle {
 	return lhs.add(rhs)
 }
 
@@ -348,6 +348,6 @@ public func +=(lhs: ScopedDisposable<CompositeDisposable>, rhs: Disposable?) -> 
 /// - returns: An instance of `DisposableHandle` that can be used to opaquely
 ///            remove the disposable later (if desired).
 @discardableResult
-public func +=(lhs: ScopedDisposable<CompositeDisposable>, rhs: () -> ()) -> CompositeDisposable.DisposableHandle {
+public func +=(lhs: ScopedDisposable<CompositeDisposable>, rhs: @escaping () -> ()) -> CompositeDisposable.DisposableHandle {
 	return lhs.innerDisposable.add(rhs)
 }

--- a/ReactiveCocoa/Swift/Disposable.swift
+++ b/ReactiveCocoa/Swift/Disposable.swift
@@ -83,11 +83,11 @@ public final class CompositeDisposable: Disposable {
 
 		fileprivate static let empty = DisposableHandle()
 
-		private init() {
+		fileprivate init() {
 			self.bagToken = Atomic(nil)
 		}
 
-		private init(bagToken: RemovalToken, disposable: CompositeDisposable) {
+		fileprivate init(bagToken: RemovalToken, disposable: CompositeDisposable) {
 			self.bagToken = Atomic(bagToken)
 			self.disposable = disposable
 		}

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -5,8 +5,8 @@ import enum Result.NoError
 /// types, including generic types when boxed via `AnyObject`).
 private protocol ObjectiveCRepresentable {
 	associatedtype Value
-	static func extract(from representation: AnyObject) -> Value
-	static func represent(_ value: Value) -> AnyObject
+	static func extract(from representation: Any) -> Value
+	static func represent(_ value: Value) -> Any
 }
 
 /// Wraps a `dynamic` property, or one defined in Objective-C, using Key-Value
@@ -19,8 +19,8 @@ public final class DynamicProperty<Value>: MutablePropertyProtocol {
 	private weak var object: NSObject?
 	private let keyPath: String
 
-	private let extractValue: (from: AnyObject) -> Value
-	private let represent: (Value) -> AnyObject
+	private let extractValue: (_ from: Any) -> Value
+	private let represent: (Value) -> Any
 
 	private var property: MutableProperty<Value?>?
 

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -63,7 +63,7 @@ public final class DynamicProperty<Value>: MutablePropertyProtocol {
 	///   - keyPath: Key path to observe on the object.
 	///   - representable: A representation that bridges the values across the
 	///                    language boundary.
-	private init<Representatable: ObjectiveCRepresentable>(
+	fileprivate init<Representatable: ObjectiveCRepresentable>(
 		object: NSObject?,
 		keyPath: String,
 		representable: Representatable.Type
@@ -132,7 +132,7 @@ private struct BridgeableRepresentation<Value: _ObjectiveCBridgeable>: Objective
 		return result!
 	}
 
-	static func represent(_ value: Value) -> AnyObject {
+	static func represent(_ value: Value) -> Any {
 		return value._bridgeToObjectiveC()
 	}
 }

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -63,7 +63,13 @@ public final class DynamicProperty<Value>: MutablePropertyProtocol {
 	///   - keyPath: Key path to observe on the object.
 	///   - representable: A representation that bridges the values across the
 	///                    language boundary.
-	private init<Representatable: ObjectiveCRepresentable where Representatable.Value == Value>(object: NSObject?, keyPath: String, representable: Representatable.Type) {
+	private init<Representatable: ObjectiveCRepresentable>(
+		object: NSObject?,
+		keyPath: String,
+		representable: Representatable.Type
+	)
+		where Representatable.Value == Value
+	{
 		self.object = object
 		self.keyPath = keyPath
 

--- a/ReactiveCocoa/Swift/DynamicProperty.swift
+++ b/ReactiveCocoa/Swift/DynamicProperty.swift
@@ -114,18 +114,18 @@ extension DynamicProperty where Value: AnyObject {
 
 /// Represents values in Objective-C directly, via `AnyObject`.
 private struct DirectRepresentation<Value: AnyObject>: ObjectiveCRepresentable {
-	static func extract(from representation: AnyObject) -> Value {
+	static func extract(from representation: Any) -> Value {
 		return representation as! Value
 	}
 
-	static func represent(_ value: Value) -> AnyObject {
+	static func represent(_ value: Value) -> Any {
 		return value
 	}
 }
 
 /// Represents values in Objective-C indirectly, via bridging.
 private struct BridgeableRepresentation<Value: _ObjectiveCBridgeable>: ObjectiveCRepresentable {
-	static func extract(from representation: AnyObject) -> Value {
+	static func extract(from representation: Any) -> Value {
 		let object = representation as! Value._ObjectiveCType
 		var result: Value?
 		Value._forceBridgeFromObjectiveC(object, result: &result)

--- a/ReactiveCocoa/Swift/EventLogger.swift
+++ b/ReactiveCocoa/Swift/EventLogger.swift
@@ -57,7 +57,7 @@ extension SignalProtocol {
 	public func logEvents(identifier: String = "", events: Set<LoggingEvent.Signal> = LoggingEvent.Signal.allEvents, fileName: String = #file, functionName: String = #function, lineNumber: Int = #line, logger: EventLogger = defaultEventLog) -> Signal<Value, Error> {
 		func log<T>(_ event: LoggingEvent.Signal) -> ((T) -> Void)? {
 			return event.logIfNeeded(events: events) { event in
-				logger(identifier: identifier, event: event, fileName: fileName, functionName: functionName, lineNumber: lineNumber)
+				logger(identifier, event, fileName, functionName, lineNumber)
 			}
 		}
 
@@ -95,13 +95,7 @@ extension SignalProducerProtocol {
 	) -> SignalProducer<Value, Error> {
 		func log<T>(_ event: LoggingEvent.SignalProducer) -> ((T) -> Void)? {
 			return event.logIfNeeded(events: events) { event in
-				logger(
-					identifier: identifier,
-					event: event,
-					fileName: fileName,
-					functionName: functionName,
-					lineNumber: lineNumber
-				)
+				logger(identifier, event, fileName, functionName, lineNumber)
 			}
 		}
 
@@ -122,7 +116,7 @@ extension LoggingEvent.Signal: LoggingEventProtocol {}
 extension LoggingEvent.SignalProducer: LoggingEventProtocol {}
 
 private extension LoggingEventProtocol {
-	func logIfNeeded<T>(events: Set<Self>, logger: (String) -> Void) -> ((T) -> Void)? {
+	func logIfNeeded<T>(events: Set<Self>, logger: @escaping (String) -> Void) -> ((T) -> Void)? {
 		guard events.contains(self) else {
 			return nil
 		}

--- a/ReactiveCocoa/Swift/EventLogger.swift
+++ b/ReactiveCocoa/Swift/EventLogger.swift
@@ -32,7 +32,13 @@ private func defaultEventLog(identifier: String, event: String, fileName: String
 }
 
 /// A type that represents an event logging function.
-public typealias EventLogger = (identifier: String, event: String, fileName: String, functionName: String, lineNumber: Int) -> Void
+public typealias EventLogger = (
+	_ identifier: String,
+	_ event: String,
+	_ fileName: String,
+	_ functionName: String,
+	_ lineNumber: Int
+) -> Void
 
 extension SignalProtocol {
 	/// Logs all events that the receiver sends. By default, it will print to 

--- a/ReactiveCocoa/Swift/Flatten.swift
+++ b/ReactiveCocoa/Swift/Flatten.swift
@@ -330,7 +330,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 	///
 	/// - note: The returned signal completes only when `signal` and all
 	///         producers emitted from `signal` complete.
-	private func concat() -> Signal<Value.Value, Error> {
+	fileprivate func concat() -> Signal<Value.Value, Error> {
 		return Signal<Value.Value, Error> { relayObserver in
 			let disposable = CompositeDisposable()
 			let relayDisposable = CompositeDisposable()
@@ -342,7 +342,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 		}
 	}
 
-	private func observeConcat(_ observer: Observer<Value.Value, Error>, _ disposable: CompositeDisposable? = nil) -> Disposable? {
+	fileprivate func observeConcat(_ observer: Observer<Value.Value, Error>, _ disposable: CompositeDisposable? = nil) -> Disposable? {
 		let state = ConcatState(observer: observer, disposable: disposable)
 
 		return self.observe { event in
@@ -377,7 +377,7 @@ extension SignalProducerProtocol where Value: SignalProducerProtocol, Error == V
 	///
 	/// - note: The returned producer completes only when `producer` and all
 	///         producers emitted from `producer` complete.
-	private func concat() -> SignalProducer<Value.Value, Error> {
+	fileprivate func concat() -> SignalProducer<Value.Value, Error> {
 		return SignalProducer<Value.Value, Error> { observer, disposable in
 			self.startWithSignal { signal, signalDisposable in
 				disposable += signalDisposable
@@ -399,7 +399,9 @@ extension SignalProducerProtocol {
 	}
 	
 	/// `concat`s `self` onto initial `previous`.
-	public func prefix<P: SignalProducerProtocol where P.Value == Value, P.Error == Error>(_ previous: P) -> SignalProducer<Value, Error> {
+	public func prefix<P: SignalProducerProtocol>(_ previous: P) -> SignalProducer<Value, Error>
+		where P.Value == Value, P.Error == Error
+	{
 		return previous.concat(self.producer)
 	}
 	
@@ -481,7 +483,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 	/// Merges a `signal` of SignalProducers down into a single signal, biased
 	/// toward the producer added earlier. Returns a Signal that will forward
 	/// events from the inner producers as they arrive.
-	private func merge() -> Signal<Value.Value, Error> {
+	fileprivate func merge() -> Signal<Value.Value, Error> {
 		return Signal<Value.Value, Error> { relayObserver in
 			let disposable = CompositeDisposable()
 			let relayDisposable = CompositeDisposable()
@@ -493,7 +495,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 		}
 	}
 
-	private func observeMerge(_ observer: Observer<Value.Value, Error>, _ disposable: CompositeDisposable) -> Disposable? {
+	fileprivate func observeMerge(_ observer: Observer<Value.Value, Error>, _ disposable: CompositeDisposable) -> Disposable? {
 		let inFlight = Atomic(1)
 		let decrementInFlight = {
 			let shouldComplete: Bool = inFlight.modify {
@@ -542,7 +544,7 @@ extension SignalProducerProtocol where Value: SignalProducerProtocol, Error == V
 	/// Merges a `signal` of SignalProducers down into a single signal, biased
 	/// toward the producer added earlier. Returns a Signal that will forward
 	/// events from the inner producers as they arrive.
-	private func merge() -> SignalProducer<Value.Value, Error> {
+	fileprivate func merge() -> SignalProducer<Value.Value, Error> {
 		return SignalProducer<Value.Value, Error> { relayObserver, disposable in
 			self.startWithSignal { signal, signalDisposable in
 				disposable += signalDisposable
@@ -557,7 +559,9 @@ extension SignalProducerProtocol where Value: SignalProducerProtocol, Error == V
 extension SignalProtocol {
 	/// Merges the given signals into a single `Signal` that will emit all
 	/// values from each of them, and complete when all of them have completed.
-	public static func merge<Seq: Sequence, S: SignalProtocol where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S>(_ signals: Seq) -> Signal<Value, Error> {
+	public static func merge<Seq: Sequence, S: SignalProtocol>(_ signals: Seq) -> Signal<Value, Error>
+		where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S
+	{
 		let producer = SignalProducer<S, Error>(values: signals)
 		var result: Signal<Value, Error>!
 
@@ -570,7 +574,9 @@ extension SignalProtocol {
 	
 	/// Merges the given signals into a single `Signal` that will emit all
 	/// values from each of them, and complete when all of them have completed.
-	public static func merge<S: SignalProtocol where S.Value == Value, S.Error == Error>(_ signals: S...) -> Signal<Value, Error> {
+	public static func merge<S: SignalProtocol>(_ signals: S...) -> Signal<Value, Error>
+		where S.Value == Value, S.Error == Error
+	{
 		return Signal.merge(signals)
 	}
 }
@@ -579,14 +585,18 @@ extension SignalProducerProtocol {
 	/// Merges the given producers into a single `SignalProducer` that will emit
 	/// all values from each of them, and complete when all of them have
 	/// completed.
-	public static func merge<Seq: Sequence, S: SignalProducerProtocol where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S>(_ producers: Seq) -> SignalProducer<Value, Error> {
+	public static func merge<Seq: Sequence, S: SignalProducerProtocol>(_ producers: Seq) -> SignalProducer<Value, Error>
+		where S.Value == Value, S.Error == Error, Seq.Iterator.Element == S
+	{
 		return SignalProducer(values: producers).flatten(.merge)
 	}
 	
 	/// Merges the given producers into a single `SignalProducer` that will emit
 	/// all values from each of them, and complete when all of them have
 	/// completed.
-	public static func merge<S: SignalProducerProtocol where S.Value == Value, S.Error == Error>(_ producers: S...) -> SignalProducer<Value, Error> {
+	public static func merge<S: SignalProducerProtocol>(_ producers: S...) -> SignalProducer<Value, Error>
+		where S.Value == Value, S.Error == Error
+	{
 		return SignalProducer.merge(producers)
 	}
 }
@@ -600,7 +610,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 	///
 	/// The returned signal completes when `signal` and the latest inner
 	/// signal have both completed.
-	private func switchToLatest() -> Signal<Value.Value, Error> {
+	fileprivate func switchToLatest() -> Signal<Value.Value, Error> {
 		return Signal<Value.Value, Error> { observer in
 			let composite = CompositeDisposable()
 			let serial = SerialDisposable()
@@ -612,7 +622,7 @@ extension SignalProtocol where Value: SignalProducerProtocol, Error == Value.Err
 		}
 	}
 
-	private func observeSwitchToLatest(_ observer: Observer<Value.Value, Error>, _ latestInnerDisposable: SerialDisposable) -> Disposable? {
+	fileprivate func observeSwitchToLatest(_ observer: Observer<Value.Value, Error>, _ latestInnerDisposable: SerialDisposable) -> Disposable? {
 		let state = Atomic(LatestState<Value, Error>())
 
 		return self.observe { event in
@@ -694,7 +704,7 @@ extension SignalProducerProtocol where Value: SignalProducerProtocol, Error == V
 	///
 	/// The returned signal completes when `signal` and the latest inner
 	/// signal have both completed.
-	private func switchToLatest() -> SignalProducer<Value.Value, Error> {
+	fileprivate func switchToLatest() -> SignalProducer<Value.Value, Error> {
 		return SignalProducer<Value.Value, Error> { observer, disposable in
 			let latestInnerDisposable = SerialDisposable()
 			disposable += latestInnerDisposable
@@ -722,7 +732,7 @@ extension SignalProtocol {
 	///
 	/// If `signal` or any of the created producers fail, the returned signal
 	/// will forward that failure immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, Error>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 	
@@ -732,7 +742,7 @@ extension SignalProtocol {
 	///
 	/// If `signal` fails, the returned signal will forward that failure
 	/// immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, NoError>) -> Signal<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -742,7 +752,7 @@ extension SignalProtocol {
 	///
 	/// If `signal` or any of the created signals emit an error, the returned
 	/// signal will forward that error immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, Error>) -> Signal<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, Error>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -752,7 +762,7 @@ extension SignalProtocol {
 	///
 	/// If `signal` emits an error, the returned signal will forward that
 	/// error immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, NoError>) -> Signal<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> Signal<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 }
@@ -764,14 +774,14 @@ extension SignalProtocol where Error == NoError {
 	///
 	/// If any of the created signals emit an error, the returned signal
 	/// will forward that error immediately.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, E>) -> Signal<U, E> {
+	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, E>) -> Signal<U, E> {
 		return map(transform).flatten(strategy)
 	}
 	
 	/// Maps each event from `signal` to a new signal, then flattens the
 	/// resulting signals (into a signal of values), according to the
 	/// semantics of the given strategy.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, NoError>) -> Signal<U, NoError> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> Signal<U, NoError> {
 		return map(transform).flatten(strategy)
 	}
 	
@@ -781,14 +791,14 @@ extension SignalProtocol where Error == NoError {
 	///
 	/// If any of the created signals emit an error, the returned signal
 	/// will forward that error immediately.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, E>) -> Signal<U, E> {
+	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, E>) -> Signal<U, E> {
 		return map(transform).flatten(strategy)
 	}
 	
 	/// Maps each event from `signal` to a new signal, then flattens the
 	/// resulting signals (into a signal of values), according to the
 	/// semantics of the given strategy.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, NoError>) -> Signal<U, NoError> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> Signal<U, NoError> {
 		return map(transform).flatten(strategy)
 	}
 }
@@ -800,7 +810,7 @@ extension SignalProducerProtocol {
 	///
 	/// If `self` or any of the created producers fail, the returned producer
 	/// will forward that failure immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, Error>) -> SignalProducer<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 	
@@ -810,7 +820,7 @@ extension SignalProducerProtocol {
 	///
 	/// If `self` fails, the returned producer will forward that failure
 	/// immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -820,7 +830,7 @@ extension SignalProducerProtocol {
 	///
 	/// If `self` or any of the created signals emit an error, the returned
 	/// producer will forward that error immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, Error>) -> SignalProducer<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -830,7 +840,7 @@ extension SignalProducerProtocol {
 	///
 	/// If `self` emits an error, the returned producer will forward that
 	/// error immediately.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, NoError>) -> SignalProducer<U, Error> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, Error> {
 		return map(transform).flatten(strategy)
 	}
 }
@@ -842,14 +852,14 @@ extension SignalProducerProtocol where Error == NoError {
 	///
 	/// If any of the created producers fail, the returned producer will
 	/// forward that failure immediately.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, E>) -> SignalProducer<U, E> {
+	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, E>) -> SignalProducer<U, E> {
 		return map(transform).flatten(strategy)
 	}
 	
 	/// Maps each event from `self` to a new producer, then flattens the
 	/// resulting producers (into a producer of values), according to the
 	/// semantics of the given strategy.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, NoError> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> SignalProducer<U, NoError>) -> SignalProducer<U, NoError> {
 		return map(transform).flatten(strategy)
 	}
 
@@ -859,14 +869,14 @@ extension SignalProducerProtocol where Error == NoError {
 	///
 	/// If any of the created signals emit an error, the returned
 	/// producer will forward that error immediately.
-	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, E>) -> SignalProducer<U, E> {
+	public func flatMap<U, E>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, E>) -> SignalProducer<U, E> {
 		return map(transform).flatten(strategy)
 	}
 
 	/// Maps each event from `self` to a new producer, then flattens the
 	/// resulting signals (into a producer of values), according to the
 	/// semantics of the given strategy.
-	public func flatMap<U>(_ strategy: FlattenStrategy, transform: (Value) -> Signal<U, NoError>) -> SignalProducer<U, NoError> {
+	public func flatMap<U>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> Signal<U, NoError>) -> SignalProducer<U, NoError> {
 		return map(transform).flatten(strategy)
 	}
 }
@@ -875,13 +885,13 @@ extension SignalProducerProtocol where Error == NoError {
 extension SignalProtocol {
 	/// Catches any failure that may occur on the input signal, mapping to a new
 	/// producer that starts in its place.
-	public func flatMapError<F>(_ handler: (Error) -> SignalProducer<Value, F>) -> Signal<Value, F> {
+	public func flatMapError<F>(_ handler: @escaping (Error) -> SignalProducer<Value, F>) -> Signal<Value, F> {
 		return Signal { observer in
 			self.observeFlatMapError(handler, observer, SerialDisposable())
 		}
 	}
 
-	private func observeFlatMapError<F>(_ handler: (Error) -> SignalProducer<Value, F>, _ observer: Observer<Value, F>, _ serialDisposable: SerialDisposable) -> Disposable? {
+	fileprivate func observeFlatMapError<F>(_ handler: @escaping (Error) -> SignalProducer<Value, F>, _ observer: Observer<Value, F>, _ serialDisposable: SerialDisposable) -> Disposable? {
 		return self.observe { event in
 			switch event {
 			case let .next(value):
@@ -903,7 +913,7 @@ extension SignalProtocol {
 extension SignalProducerProtocol {
 	/// Catches any failure that may occur on the input producer, mapping to a
 	/// new producer that starts in its place.
-	public func flatMapError<F>(_ handler: (Error) -> SignalProducer<Value, F>) -> SignalProducer<Value, F> {
+	public func flatMapError<F>(_ handler: @escaping (Error) -> SignalProducer<Value, F>) -> SignalProducer<Value, F> {
 		return SignalProducer { observer, disposable in
 			let serialDisposable = SerialDisposable()
 			disposable += serialDisposable

--- a/ReactiveCocoa/Swift/FoundationExtensions.swift
+++ b/ReactiveCocoa/Swift/FoundationExtensions.swift
@@ -67,7 +67,7 @@ extension URLSession {
 					observer.sendNext((data, response))
 					observer.sendCompleted()
 				} else {
-					observer.sendFailed(error ?? defaultSessionError)
+					observer.sendFailed(error as NSError? ?? defaultSessionError)
 				}
 			}
 

--- a/ReactiveCocoa/Swift/Lifetime.swift
+++ b/ReactiveCocoa/Swift/Lifetime.swift
@@ -35,7 +35,7 @@ public final class Lifetime {
 	/// ```
 	public final class Token {
 		/// A signal that sends a Completed event when the lifetime ends.
-		private let ended: Signal<(), NoError>
+		fileprivate let ended: Signal<(), NoError>
 
 		private let endedObserver: Signal<(), NoError>.Observer
 

--- a/ReactiveCocoa/Swift/NSObject+KeyValueObserving.swift
+++ b/ReactiveCocoa/Swift/NSObject+KeyValueObserving.swift
@@ -27,7 +27,7 @@ extension NSObject {
 
 internal final class KeyValueObserver: NSObject {
 	typealias Action = (_ object: AnyObject?) -> Void
-	private static let context = UnsafeMutablePointer<Void>.allocate(capacity: 1)
+	private static let context = UnsafeMutableRawPointer.allocate(bytes: 1, alignedTo: 0)
 
 	unowned(unsafe) let unsafeObject: NSObject
 	let key: String
@@ -54,12 +54,12 @@ internal final class KeyValueObserver: NSObject {
 
 	override func observeValue(
 		forKeyPath keyPath: String?,
-		of object: AnyObject?,
-		change: [NSKeyValueChangeKey : AnyObject]?,
+		of object: Any?,
+		change: [NSKeyValueChangeKey : Any]?,
 		context: UnsafeMutableRawPointer?
 	) {
 		if context == KeyValueObserver.context {
-			action(object)
+			action(object as! NSObject)
 		}
 	}
 }
@@ -234,7 +234,7 @@ internal struct PropertyAttributes {
 			let string = String(validatingUTF8: attrString)
 			preconditionFailure("Could not read past type in attribute string: \(string).")
 		}
-		var next = UnsafeMutablePointer<Int8>(_next)
+		var next = UnsafeMutablePointer<Int8>(mutating: _next)
 
 		let typeLength = typeString.distance(to: next)
 		precondition(typeLength > 0, "Invalid type in attribute string.")
@@ -255,7 +255,7 @@ internal struct PropertyAttributes {
 			if className != UnsafePointer(next) {
 				let length = className.distance(to: next)
 				let name = UnsafeMutablePointer<Int8>.allocate(capacity: length + 1)
-				name.initialize(from: UnsafeMutablePointer<Int8>(className), count: length)
+				name.initialize(from: UnsafeMutablePointer<Int8>(mutating: className), count: length)
 				(name + length).initialize(to: Code.nul)
 
 				// attempt to look up the class in the runtime

--- a/ReactiveCocoa/Swift/NSObject+KeyValueObserving.swift
+++ b/ReactiveCocoa/Swift/NSObject+KeyValueObserving.swift
@@ -110,7 +110,7 @@ extension KeyValueObserver {
 		// Attempting to observe non-weak properties using dynamic getters will
 		// result in broken behavior, so don't even try.
 		let shouldObserveDeinit = keyPathHead.withCString { cString -> Bool in
-			if let propertyPointer = class_getProperty(object.dynamicType, cString) {
+			if let propertyPointer = class_getProperty(type(of: object), cString) {
 				let attributes = PropertyAttributes(property: propertyPointer)
 				return attributes.isObject && attributes.isWeak && attributes.objectClass != NSClassFromString("Protocol") && !attributes.isBlock
 			}

--- a/ReactiveCocoa/Swift/NSObject+KeyValueObserving.swift
+++ b/ReactiveCocoa/Swift/NSObject+KeyValueObserving.swift
@@ -33,7 +33,7 @@ internal final class KeyValueObserver: NSObject {
 	let key: String
 	let action: Action
 
-	private init(observing object: NSObject, key: String, options: NSKeyValueObservingOptions, action: Action) {
+	fileprivate init(observing object: NSObject, key: String, options: NSKeyValueObservingOptions, action: Action) {
 		self.unsafeObject = object
 		self.key = key
 		self.action = action

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -26,7 +26,7 @@ extension RACScheduler: DateSchedulerProtocol {
 	/// - returns: Disposable that can be used to cancel the work before it
 	///            begins.
 	@discardableResult
-	public func schedule(_ action: () -> Void) -> Disposable? {
+	public func schedule(_ action: @escaping () -> Void) -> Disposable? {
 		let disposable: RACDisposable = self.schedule(action) // Call the Objective-C implementation
 		return disposable as Disposable?
 	}
@@ -40,7 +40,7 @@ extension RACScheduler: DateSchedulerProtocol {
 	/// - returns: Optional disposable that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(after date: Date, action: () -> Void) -> Disposable? {
+	public func schedule(after date: Date, action: @escaping () -> Void) -> Disposable? {
 		return self.after(date, schedule: action)
 	}
 
@@ -56,7 +56,7 @@ extension RACScheduler: DateSchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval, action: () -> Void) -> Disposable? {
+	public func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval, action: @escaping () -> Void) -> Disposable? {
 		return self.after(date, repeatingEvery: interval, withLeeway: leeway, schedule: action)
 	}
 }
@@ -109,7 +109,7 @@ extension RACSignal {
 			}
 
 			let failed: (_ nsError: Swift.Error?) -> () = {
-				observer.sendFailed($0 ?? defaultNSError("Nil RACSignal error", file: file, line: line))
+				observer.sendFailed(($0 as? NSError) ?? defaultNSError("Nil RACSignal error", file: file, line: line))
 			}
 
 			let completed = {
@@ -299,7 +299,7 @@ extension RACCommand {
 **/
 
 extension ActionProtocol {
-	private var isCommandEnabled: RACSignal {
+	fileprivate var isCommandEnabled: RACSignal {
 		return self.isEnabled.producer
 			.map { $0 as NSNumber }
 			.toRACSignal()

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -108,7 +108,7 @@ extension RACSignal {
 				observer.sendNext(obj)
 			}
 
-			let failed: (nsError: Swift.Error?) -> () = {
+			let failed: (_ nsError: Swift.Error?) -> () = {
 				observer.sendFailed($0 ?? defaultNSError("Nil RACSignal error", file: file, line: line))
 			}
 

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -102,7 +102,7 @@ extension RACSignal {
 	///   - line: Current line in file.
 	///
 	/// - returns: Signal producer created from `self`.
-	public func toSignalProducer(file: String = #file, line: Int = #line) -> SignalProducer<AnyObject?, NSError> {
+	public func toSignalProducer(file: String = #file, line: Int = #line) -> SignalProducer<Any?, NSError> {
 		return SignalProducer { observer, disposable in
 			let next = { obj in
 				observer.sendNext(obj)
@@ -121,7 +121,7 @@ extension RACSignal {
 	}
 }
 
-extension SignalProducerProtocol where Value: AnyObject {
+extension SignalProducerProtocol {
 	/// Create a `RACSignal` that will `start()` the producer once for each
 	/// subscription.
 	///
@@ -129,57 +129,11 @@ extension SignalProducerProtocol where Value: AnyObject {
 	///
 	/// - returns: `RACSignal` instantiated from `self`.
 	public func toRACSignal() -> RACSignal {
-		return self
-			.lift { $0.optionalize() }
-			.toRACSignal()
-	}
-}
-
-extension SignalProducerProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject {
-	/// Create a `RACSignal` that will `start()` the producer once for each
-	/// subscription.
-	///
-	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		return self
-			.mapError { $0 as NSError }
-			.toRACSignal()
-	}
-}
-
-extension SignalProducerProtocol where Value: AnyObject, Error: NSError {
-	/// Create a `RACSignal` that will `start()` the producer once for each
-	/// subscription.
-	///
-	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		return self
-			.lift { $0.optionalize() }
-			.toRACSignal()
-	}
-}
-
-extension SignalProducerProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject, Error: NSError {
-	/// Create a `RACSignal` that will `start()` the producer once for each
-	/// subscription.
-	///
-	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		// This special casing of `Error: NSError` is a workaround for
-		// rdar://22708537 which causes an NSError's UserInfo dictionary to get
-		// discarded during a cast from ErrorType to NSError in a generic
-		// function
 		return RACSignal.createSignal { subscriber in
 			let selfDisposable = self.start { event in
 				switch event {
 				case let .next(value):
-					subscriber.sendNext(value.optional)
+					subscriber.sendNext(value)
 				case let .failed(error):
 					subscriber.sendError(error)
 				case .completed:
@@ -196,61 +150,18 @@ extension SignalProducerProtocol where Value: OptionalProtocol, Value.Wrapped: A
 	}
 }
 
-extension SignalProtocol where Value: AnyObject {
+extension SignalProtocol {
 	/// Create a `RACSignal` that will observe the given signal.
 	///
 	/// - note: Any `interrupted` events will be silently discarded.
 	///
 	/// - returns: `RACSignal` instantiated from `self`.
 	public func toRACSignal() -> RACSignal {
-		return self
-			.optionalize()
-			.toRACSignal()
-	}
-}
-
-extension SignalProtocol where Value: AnyObject, Error: NSError {
-	/// Create a `RACSignal` that will observe the given signal.
-	///
-	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		return self
-			.optionalize()
-			.toRACSignal()
-	}
-}
-
-extension SignalProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject {
-	/// Create a `RACSignal` that will observe the given signal.
-	///
-	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		return self
-			.mapError { $0 as NSError }
-			.toRACSignal()
-	}
-}
-
-extension SignalProtocol where Value: OptionalProtocol, Value.Wrapped: AnyObject, Error: NSError {
-	/// Create a `RACSignal` that will observe the given signal.
-	///
-	/// - note: Any `interrupted` events will be silently discarded.
-	///
-	/// - returns: `RACSignal` instantiated from `self`.
-	public func toRACSignal() -> RACSignal {
-		// This special casing of `Error: NSError` is a workaround for
-		// rdar://22708537 which causes an NSError's UserInfo dictionary to get
-		// discarded during a cast from ErrorType to NSError in a generic
-		// function
 		return RACSignal.createSignal { subscriber in
 			let selfDisposable = self.observe { event in
 				switch event {
 				case let .next(value):
-					subscriber.sendNext(value.optional)
+					subscriber.sendNext(value)
 				case let .failed(error):
 					subscriber.sendError(error)
 				case .completed:
@@ -285,14 +196,14 @@ extension RACCommand {
 	///   - line: Current line in file.
 	///
 	/// - returns: Action created from `self`.
-	public func toAction(file: String = #file, line: Int = #line) -> Action<AnyObject?, AnyObject?, NSError> {
+	public func toAction(file: String = #file, line: Int = #line) -> Action<Any?, Any?, NSError> {
 		let enabledProperty = MutableProperty(true)
 
 		enabledProperty <~ self.enabled.toSignalProducer()
 			.map { $0 as! Bool }
 			.flatMapError { _ in SignalProducer<Bool, NoError>(value: false) }
 
-		return Action(enabledIf: enabledProperty) { input -> SignalProducer<AnyObject?, NSError> in
+		return Action(enabledIf: enabledProperty) { input -> SignalProducer<Any?, NSError> in
 			let executionSignal = RACSignal.`defer` {
 				return self.execute(input)
 			}
@@ -318,7 +229,7 @@ extension ActionProtocol {
 ///   - line: Current line in file.
 ///
 /// - returns: Action created from `self`.
-public func bridgedAction<Input>(from command: RACCommand<Input>, file: String = #file, line: Int = #line) -> Action<AnyObject?, AnyObject?, NSError> {
+public func bridgedAction<Input>(from command: RACCommand<Input>, file: String = #file, line: Int = #line) -> Action<Any?, Any?, NSError> {
 	let command = command as! RACCommand<AnyObject>
 	let enabledProperty = MutableProperty(true)
 
@@ -326,16 +237,16 @@ public func bridgedAction<Input>(from command: RACCommand<Input>, file: String =
 		.map { $0 as! Bool }
 		.flatMapError { _ in SignalProducer<Bool, NoError>(value: false) }
 
-	return Action(enabledIf: enabledProperty) { input -> SignalProducer<AnyObject?, NSError> in
+	return Action(enabledIf: enabledProperty) { input -> SignalProducer<Any?, NSError> in
 		let executionSignal = RACSignal.`defer` {
-			return command.execute(input)
+			return command.execute(input as AnyObject?)
 		}
 
 		return executionSignal.toSignalProducer(file: file, line: line)
 	}
 }
 
-extension ActionProtocol where Input: AnyObject, Output: AnyObject {
+extension ActionProtocol where Input: AnyObject {
 	/// Creates a RACCommand that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing
@@ -352,41 +263,7 @@ extension ActionProtocol where Input: AnyObject, Output: AnyObject {
 	}
 }
 
-extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output: AnyObject {
-	/// Creates a RACCommand that will execute the action.
-	///
-	/// - note: The returned command will not necessarily be marked as executing
-	///         when the action is. However, the reverse is always true: the Action
-	///         will always be marked as executing when the RACCommand is.
-	///
-	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input.Wrapped> {
-		return RACCommand<Input.Wrapped>(enabled: action.isCommandEnabled) { input -> RACSignal in
-			return self
-				.apply(Input(reconstructing: input))
-				.toRACSignal()
-		}
-	}
-}
-
-extension ActionProtocol where Input: AnyObject, Output: OptionalProtocol, Output.Wrapped: AnyObject {
-	/// Creates a RACCommand that will execute the action.
-	///
-	/// - note: The returned command will not necessarily be marked as executing
-	///         when the action is. However, the reverse is always true: the Action
-	///         will always be marked as executing when the RACCommand is.
-	///
-	/// - returns: `RACCommand` with bound action.
-	public func toRACCommand() -> RACCommand<Input> {
-		return RACCommand<Input>(enabled: action.isCommandEnabled) { input -> RACSignal in
-			return self
-				.apply(input!)
-				.toRACSignal()
-		}
-	}
-}
-
-extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject, Output: OptionalProtocol, Output.Wrapped: AnyObject {
+extension ActionProtocol where Input: OptionalProtocol, Input.Wrapped: AnyObject {
 	/// Creates a RACCommand that will execute the action.
 	///
 	/// - note: The returned command will not necessarily be marked as executing

--- a/ReactiveCocoa/Swift/Observer.swift
+++ b/ReactiveCocoa/Swift/Observer.swift
@@ -27,7 +27,7 @@ public protocol ObserverProtocol {
 /// An Observer is a simple wrapper around a function which can receive Events
 /// (typically from a Signal).
 public final class Observer<Value, Error: Swift.Error> {
-	public typealias Action = (Event<Value, Error>) -> Void
+	public typealias Action = @escaping (Event<Value, Error>) -> Void
 
 	/// An action that will be performed upon arrival of the event.
 	public let action: Action

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -39,12 +39,12 @@ public protocol MutablePropertyProtocol: PropertyProtocol {
 /// any intermediate property during the composition.
 extension PropertyProtocol {
 	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol instead.
-	private func lift<U>(_ transform: (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> Property<U> {
+	fileprivate func lift<U>(_ transform: (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> Property<U> {
 		return Property(self, transform: transform)
 	}
 
 	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol instead.
-	private func lift<P: PropertyProtocol, U>(_ transform: (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> (P) -> Property<U> {
+	fileprivate func lift<P: PropertyProtocol, U>(_ transform: (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> (P) -> Property<U> {
 		return { otherProperty in
 			return Property(self, otherProperty, transform: transform)
 		}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -39,12 +39,12 @@ public protocol MutablePropertyProtocol: PropertyProtocol {
 /// any intermediate property during the composition.
 extension PropertyProtocol {
 	/// Lifts a unary SignalProducer operator to operate upon PropertyProtocol instead.
-	fileprivate func lift<U>(_ transform: (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> Property<U> {
+	fileprivate func lift<U>(_ transform: @escaping (SignalProducer<Value, NoError>) -> SignalProducer<U, NoError>) -> Property<U> {
 		return Property(self, transform: transform)
 	}
 
 	/// Lifts a binary SignalProducer operator to operate upon PropertyProtocol instead.
-	fileprivate func lift<P: PropertyProtocol, U>(_ transform: (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> (P) -> Property<U> {
+	fileprivate func lift<P: PropertyProtocol, U>(_ transform: @escaping (SignalProducer<Value, NoError>) -> (SignalProducer<P.Value, NoError>) -> SignalProducer<U, NoError>) -> (P) -> Property<U> {
 		return { otherProperty in
 			return Property(self, otherProperty, transform: transform)
 		}
@@ -449,9 +449,9 @@ public final class Property<Value>: PropertyProtocol {
 	///   - property: The source property.
 	///   - transform: A unary `SignalProducer` transform to be applied on
 	///     `property`.
-	private convenience init<P: PropertyProtocol>(
+	fileprivate convenience init<P: PropertyProtocol>(
 		_ property: P,
-		transform: (SignalProducer<P.Value, NoError>) -> SignalProducer<Value, NoError>
+		transform: @escaping (SignalProducer<P.Value, NoError>) -> SignalProducer<Value, NoError>
 	) {
 		self.init(
 			unsafeProducer: transform(property.producer),
@@ -467,7 +467,7 @@ public final class Property<Value>: PropertyProtocol {
 	///   - secondProperty: The first source property.
 	///   - transform: A binary `SignalProducer` transform to be applied on
 	///             `firstProperty` and `secondProperty`.
-	private convenience init<P1: PropertyProtocol, P2: PropertyProtocol>(_ firstProperty: P1, _ secondProperty: P2, transform: (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
+	fileprivate convenience init<P1: PropertyProtocol, P2: PropertyProtocol>(_ firstProperty: P1, _ secondProperty: P2, transform: @escaping (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
 		self.init(unsafeProducer: transform(firstProperty.producer)(secondProperty.producer),
 		          capturing: Property.capture(firstProperty) + Property.capture(secondProperty))
 	}

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -185,13 +185,13 @@ extension PropertyProtocol where Value: Hashable {
 extension PropertyProtocol {
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B) -> Property<(A.Value, B.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol>(_ a: A, _ b: B) -> Property<(A.Value, B.Value)> where Value == A.Value {
 		return a.combineLatest(with: b)
 	}
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C) -> Property<(A.Value, B.Value, C.Value)> {
+	public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol>(_ a: A, _ b: B, _ c: C) -> Property<(A.Value, B.Value, C.Value)> where Value == A.Value {
 		return combineLatest(a, b)
 			.combineLatest(with: c)
 			.map(repack)
@@ -199,7 +199,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D) -> Property<(A.Value, B.Value, C.Value, D.Value)> {
+		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D) -> Property<(A.Value, B.Value, C.Value, D.Value)> where Value == A.Value {
 		return combineLatest(a, b, c)
 			.combineLatest(with: d)
 			.map(repack)
@@ -207,7 +207,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value)> {
+		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value)> where Value == A.Value {
 		return combineLatest(a, b, c, d)
 			.combineLatest(with: e)
 			.map(repack)
@@ -215,7 +215,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> {
+		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> where Value == A.Value {
 		return combineLatest(a, b, c, d, e)
 			.combineLatest(with: f)
 			.map(repack)
@@ -223,7 +223,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> {
+		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> where Value == A.Value {
 		return combineLatest(a, b, c, d, e, f)
 			.combineLatest(with: g)
 			.map(repack)
@@ -231,7 +231,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> {
+		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> where Value == A.Value {
 		return combineLatest(a, b, c, d, e, f, g)
 			.combineLatest(with: h)
 			.map(repack)
@@ -239,7 +239,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> {
+		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> where Value == A.Value {
 		return combineLatest(a, b, c, d, e, f, g, h)
 			.combineLatest(with: i)
 			.map(repack)
@@ -247,7 +247,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given properties, in the manner described
 	/// by `combineLatest(with:)`.
-		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> {
+		public static func combineLatest<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> where Value == A.Value {
 		return combineLatest(a, b, c, d, e, f, g, h, i)
 			.combineLatest(with: j)
 			.map(repack)
@@ -255,7 +255,7 @@ extension PropertyProtocol {
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatest(with:)`. Returns nil if the sequence is empty.
-	public static func combineLatest<S: Sequence where S.Iterator.Element: PropertyProtocol>(_ properties: S) -> Property<[S.Iterator.Element.Value]>? {
+	public static func combineLatest<S: Sequence>(_ properties: S) -> Property<[S.Iterator.Element.Value]>? where S.Iterator.Element: PropertyProtocol {
 		var generator = properties.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }
@@ -269,13 +269,13 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B) -> Property<(A.Value, B.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol>(_ a: A, _ b: B) -> Property<(A.Value, B.Value)> where Value == A.Value {
 		return a.zip(with: b)
 	}
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C) -> Property<(A.Value, B.Value, C.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol>(_ a: A, _ b: B, _ c: C) -> Property<(A.Value, B.Value, C.Value)> where Value == A.Value {
 		return zip(a, b)
 			.zip(with: c)
 			.map(repack)
@@ -283,7 +283,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D) -> Property<(A.Value, B.Value, C.Value, D.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D) -> Property<(A.Value, B.Value, C.Value, D.Value)> where Value == A.Value {
 		return zip(a, b, c)
 			.zip(with: d)
 			.map(repack)
@@ -291,7 +291,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value)> where Value == A.Value {
 		return zip(a, b, c, d)
 			.zip(with: e)
 			.map(repack)
@@ -299,7 +299,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value)> where Value == A.Value {
 		return zip(a, b, c, d, e)
 			.zip(with: f)
 			.map(repack)
@@ -307,7 +307,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value)> where Value == A.Value {
 		return zip(a, b, c, d, e, f)
 			.zip(with: g)
 			.map(repack)
@@ -315,7 +315,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value)> where Value == A.Value {
 		return zip(a, b, c, d, e, f, g)
 			.zip(with: h)
 			.map(repack)
@@ -323,7 +323,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value)> where Value == A.Value {
 		return zip(a, b, c, d, e, f, g, h)
 			.zip(with: i)
 			.map(repack)
@@ -331,7 +331,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`.
-	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol where Value == A.Value>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> {
+	public static func zip<A: PropertyProtocol, B: PropertyProtocol, C: PropertyProtocol, D: PropertyProtocol, E: PropertyProtocol, F: PropertyProtocol, G: PropertyProtocol, H: PropertyProtocol, I: PropertyProtocol, J: PropertyProtocol>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E, _ f: F, _ g: G, _ h: H, _ i: I, _ j: J) -> Property<(A.Value, B.Value, C.Value, D.Value, E.Value, F.Value, G.Value, H.Value, I.Value, J.Value)> where Value == A.Value {
 		return zip(a, b, c, d, e, f, g, h, i)
 			.zip(with: j)
 			.map(repack)
@@ -339,7 +339,7 @@ extension PropertyProtocol {
 
 	/// Zips the values of all the given properties, in the manner described by
 	/// `zip(with:)`. Returns nil if the sequence is empty.
-	public static func zip<S: Sequence where S.Iterator.Element: PropertyProtocol>(_ properties: S) -> Property<[S.Iterator.Element.Value]>? {
+	public static func zip<S: Sequence>(_ properties: S) -> Property<[S.Iterator.Element.Value]>? where S.Iterator.Element: PropertyProtocol {
 		var generator = properties.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }
@@ -412,7 +412,7 @@ public final class Property<Value>: PropertyProtocol {
 	///
 	/// - parameters:
 	///   - property: A property to be wrapped.
-	public init<P: PropertyProtocol where P.Value == Value>(_ property: P) {
+	public init<P: PropertyProtocol>(_ property: P) where P.Value == Value {
 		sources = Property.capture(property)
 		_value = { property.value }
 		_producer = { property.producer }
@@ -467,7 +467,7 @@ public final class Property<Value>: PropertyProtocol {
 	///   - secondProperty: The first source property.
 	///   - transform: A binary `SignalProducer` transform to be applied on
 	///             `firstProperty` and `secondProperty`.
-	private convenience init<P1: PropertyProtocol, P2: PropertyProtocol>(_ firstProperty: P1, _ secondProperty: P2, transform: @noescape (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
+	private convenience init<P1: PropertyProtocol, P2: PropertyProtocol>(_ firstProperty: P1, _ secondProperty: P2, transform: (SignalProducer<P1.Value, NoError>) -> (SignalProducer<P2.Value, NoError>) -> SignalProducer<Value, NoError>) {
 		self.init(unsafeProducer: transform(firstProperty.producer)(secondProperty.producer),
 		          capturing: Property.capture(firstProperty) + Property.capture(secondProperty))
 	}
@@ -776,7 +776,7 @@ public func <~ <P: MutablePropertyProtocol>(property: P, producer: SignalProduce
 /// - returns: A disposable that can be used to terminate binding before the
 ///            deinitialization of property or signal's `completed` event.
 @discardableResult
-public func <~ <P: MutablePropertyProtocol, S: SignalProtocol where P.Value == S.Value?, S.Error == NoError>(property: P, signal: S) -> Disposable {
+public func <~ <P: MutablePropertyProtocol, S: SignalProtocol>(property: P, signal: S) -> Disposable where P.Value == S.Value?, S.Error == NoError {
 	return property <~ signal.optionalize()
 }
 
@@ -812,7 +812,7 @@ public func <~ <P: MutablePropertyProtocol, S: SignalProtocol where P.Value == S
 /// - returns: A disposable that can be used to terminate binding before the
 ///            deinitialization of property or producer's `completed` event.
 @discardableResult
-public func <~ <P: MutablePropertyProtocol, S: SignalProducerProtocol where P.Value == S.Value?, S.Error == NoError>(property: P, producer: S) -> Disposable {
+public func <~ <P: MutablePropertyProtocol, S: SignalProducerProtocol>(property: P, producer: S) -> Disposable where P.Value == S.Value?, S.Error == NoError {
 	return property <~ producer.optionalize()
 }
 
@@ -845,7 +845,7 @@ public func <~ <P: MutablePropertyProtocol, S: SignalProducerProtocol where P.Va
 ///            deinitialization of destination property or source property
 ///            producer's `completed` event.
 @discardableResult
-public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol where Destination.Value == Source.Value?>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
+public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol>(destinationProperty: Destination, sourceProperty: Source) -> Disposable where Destination.Value == Source.Value? {
 	return destinationProperty <~ sourceProperty.producer
 }
 
@@ -878,6 +878,6 @@ public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol w
 ///            deinitialization of destination property or source property
 ///            producer's `completed` event.
 @discardableResult
-public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol where Source.Value == Destination.Value>(destinationProperty: Destination, sourceProperty: Source) -> Disposable {
+public func <~ <Destination: MutablePropertyProtocol, Source: PropertyProtocol>(destinationProperty: Destination, sourceProperty: Source) -> Disposable where Source.Value == Destination.Value {
 	return destinationProperty <~ sourceProperty.producer
 }

--- a/ReactiveCocoa/Swift/Scheduler.swift
+++ b/ReactiveCocoa/Swift/Scheduler.swift
@@ -17,7 +17,7 @@ public protocol SchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	func schedule(_ action: () -> Void) -> Disposable?
+	func schedule(_ action: @escaping () -> Void) -> Disposable?
 }
 
 /// A particular kind of scheduler that supports enqueuing actions at future
@@ -38,7 +38,7 @@ public protocol DateSchedulerProtocol: SchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	func schedule(after date: Date, action: () -> Void) -> Disposable?
+	func schedule(after date: Date, action: @escaping () -> Void) -> Disposable?
 
 	/// Schedules a recurring action at the given interval, beginning at the
 	/// given date.
@@ -52,7 +52,7 @@ public protocol DateSchedulerProtocol: SchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval, action: () -> Void) -> Disposable?
+	func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval, action: @escaping () -> Void) -> Disposable?
 }
 
 /// A scheduler that performs all work synchronously.
@@ -66,7 +66,7 @@ public final class ImmediateScheduler: SchedulerProtocol {
 	///
 	/// - returns: `nil`.
 	@discardableResult
-	public func schedule(_ action: () -> Void) -> Disposable? {
+	public func schedule(_ action: @escaping () -> Void) -> Disposable? {
 		action()
 		return nil
 	}
@@ -106,7 +106,7 @@ public final class UIScheduler: SchedulerProtocol {
 	/// - returns: `Disposable` that can be used to cancel the work before it
 	///            begins.
 	@discardableResult
-	public func schedule(_ action: () -> Void) -> Disposable? {
+	public func schedule(_ action: @escaping () -> Void) -> Disposable? {
 		let disposable = SimpleDisposable()
 		let actionAndDecrement = {
 			if !disposable.isDisposed {
@@ -188,7 +188,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// - returns: `Disposable` that can be used to cancel the work before it
 	///            begins.
 	@discardableResult
-	public func schedule(_ action: () -> Void) -> Disposable? {
+	public func schedule(_ action: @escaping () -> Void) -> Disposable? {
 		let d = SimpleDisposable()
 
 		queue.async {
@@ -218,7 +218,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(after date: Date, action: () -> Void) -> Disposable? {
+	public func schedule(after date: Date, action: @escaping () -> Void) -> Disposable? {
 		let d = SimpleDisposable()
 
 		queue.asyncAfter(wallDeadline: wallTime(with: date)) {
@@ -242,7 +242,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// - returns: Optional disposable that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(after date: Date, interval: TimeInterval, action: () -> Void) -> Disposable? {
+	public func schedule(after date: Date, interval: TimeInterval, action: @escaping () -> Void) -> Disposable? {
 		// Apple's "Power Efficiency Guide for Mac Apps" recommends a leeway of
 		// at least 10% of the timer interval.
 		return schedule(after: date, interval: interval, leeway: interval * 0.1, action: action)
@@ -260,7 +260,7 @@ public final class QueueScheduler: DateSchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval, action: () -> Void) -> Disposable? {
+	public func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval, action: @escaping () -> Void) -> Disposable? {
 		precondition(interval >= 0)
 		precondition(leeway >= 0)
 
@@ -289,7 +289,7 @@ public final class TestScheduler: DateSchedulerProtocol {
 		let date: Date
 		let action: () -> Void
 
-		init(date: Date, action: () -> Void) {
+		init(date: Date, action: @escaping () -> Void) {
 			self.date = date
 			self.action = action
 		}
@@ -349,7 +349,7 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(_ action: () -> Void) -> Disposable? {
+	public func schedule(_ action: @escaping () -> Void) -> Disposable? {
 		return schedule(ScheduledAction(date: currentDate, action: action))
 	}
 
@@ -362,12 +362,12 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// - returns: Optional disposable that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(after delay: TimeInterval, action: () -> Void) -> Disposable? {
+	public func schedule(after delay: TimeInterval, action: @escaping () -> Void) -> Disposable? {
 		return schedule(after: currentDate.addingTimeInterval(delay), action: action)
 	}
 
 	@discardableResult
-	public func schedule(after date: Date, action: () -> Void) -> Disposable? {
+	public func schedule(after date: Date, action: @escaping () -> Void) -> Disposable? {
 		return schedule(ScheduledAction(date: date, action: action))
 	}
 
@@ -381,7 +381,7 @@ public final class TestScheduler: DateSchedulerProtocol {
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
-	private func schedule(after date: Date, interval: TimeInterval, disposable: SerialDisposable, action: () -> Void) {
+	private func schedule(after date: Date, interval: TimeInterval, disposable: SerialDisposable, action: @escaping () -> Void) {
 		precondition(interval >= 0)
 
 		disposable.innerDisposable = schedule(after: date) { [unowned self] in
@@ -402,7 +402,7 @@ public final class TestScheduler: DateSchedulerProtocol {
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///            before it begins.
 	@discardableResult
-	public func schedule(after delay: TimeInterval, interval: TimeInterval, leeway: TimeInterval = 0, action: () -> Void) -> Disposable? {
+	public func schedule(after delay: TimeInterval, interval: TimeInterval, leeway: TimeInterval = 0, action: @escaping () -> Void) -> Disposable? {
 		return schedule(after: currentDate.addingTimeInterval(delay), interval: interval, leeway: leeway, action: action)
 	}
 
@@ -417,7 +417,7 @@ public final class TestScheduler: DateSchedulerProtocol {
 	///
 	/// - returns: Optional `Disposable` that can be used to cancel the work
 	///	           before it begins.
-	public func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval = 0, action: () -> Void) -> Disposable? {
+	public func schedule(after date: Date, interval: TimeInterval, leeway: TimeInterval = 0, action: @escaping () -> Void) -> Disposable? {
 		let disposable = SerialDisposable()
 		schedule(after: date, interval: interval, disposable: disposable, action: action)
 		return disposable

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -1651,7 +1651,9 @@ extension SignalProtocol {
 
 	/// Combines the values of all the given signals, in the manner described by
 	/// `combineLatestWith`. No events will be sent if the sequence is empty.
-	public static func combineLatest<S: Sequence where S.Iterator.Element == Signal<Value, Error>>(_ signals: S) -> Signal<[Value], Error> {
+	public static func combineLatest<S: Sequence>(_ signals: S) -> Signal<[Value], Error>
+		where S.Iterator.Element == Signal<Value, Error>
+	{
 		var generator = signals.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }
@@ -1735,7 +1737,9 @@ extension SignalProtocol {
 
 	/// Zips the values of all the given signals, in the manner described by
 	/// `zipWith`. No events will be sent if the sequence is empty.
-	public static func zip<S: Sequence where S.Iterator.Element == Signal<Value, Error>>(_ signals: S) -> Signal<[Value], Error> {
+	public static func zip<S: Sequence>(_ signals: S) -> Signal<[Value], Error>
+		where S.Iterator.Element == Signal<Value, Error>
+	{
 		var generator = signals.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -517,7 +517,7 @@ extension SignalProtocol {
 				switch event {
 				case let .next(value):
 					state.append(value)
-					if predicate(values: state.values) {
+					if predicate(state.values) {
 						observer.sendNext(state.values)
 						state.flush()
 					}
@@ -581,7 +581,7 @@ extension SignalProtocol {
 			return self.observe { event in
 				switch event {
 				case let .next(value):
-					if predicate(values: state.values, next: value) {
+					if predicate(state.values, value) {
 						observer.sendNext(state.values)
 						state.flush()
 					}

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -184,7 +184,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 			producerDisposable.dispose()
 		}
 
-		setup(signal: signal, interrupter: cancelDisposable)
+		setup(signal, cancelDisposable)
 
 		if cancelDisposable.isDisposed {
 			return

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -47,7 +47,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///
 	/// - parameters:
 	///   - startHandler: A closure that accepts observer and a disposable.
-	public init(_ startHandler: (Signal<Value, Error>.Observer, CompositeDisposable) -> Void) {
+	public init(_ startHandler: @escaping (Signal<Value, Error>.Observer, CompositeDisposable) -> Void) {
 		self.startHandler = startHandler
 	}
 
@@ -99,7 +99,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - values: A sequence of values that a `Signal` will send as separate
 	///             `next` events and then complete.
-	public init<S: Sequence where S.Iterator.Element == Value>(values: S) {
+	public init<S: Sequence>(values: S) where S.Iterator.Element == Value {
 		self.init { observer, disposable in
 			for value in values {
 				observer.sendNext(value)
@@ -150,7 +150,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	/// - returns: A `SignalProducer` that will forward `Success`ful `result` as
 	///            `next` event and then complete or `failed` event if `result`
 	///            is a `Failure`.
-	public static func attempt(_ operation: () -> Result<Value, Error>) -> SignalProducer {
+	public static func attempt(_ operation: @escaping () -> Result<Value, Error>) -> SignalProducer {
 		return self.init { observer, disposable in
 			operation().analysis(ifSuccess: { value in
 				observer.sendNext(value)
@@ -170,7 +170,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///
 	/// - parameters:
 	///   - setUp: A closure that accepts a `signal` and `interrupter`.
-	public func startWithSignal(_ setup: @noescape (signal: Signal<Value, Error>, interrupter: Disposable) -> Void) {
+	public func startWithSignal(_ setup: (_ signal: Signal<Value, Error>, _ interrupter: Disposable) -> Void) {
 		let (signal, observer) = Signal<Value, Error>.pipe()
 
 		// Disposes of the work associated with the SignalProducer and any
@@ -215,11 +215,11 @@ public protocol SignalProducerProtocol {
 	var producer: SignalProducer<Value, Error> { get }
 
 	/// Initialize a signal
-	init(_ startHandler: (Signal<Value, Error>.Observer, CompositeDisposable) -> Void)
+	init(_ startHandler: @escaping (Signal<Value, Error>.Observer, CompositeDisposable) -> Void)
 
 	/// Creates a Signal from the producer, passes it into the given closure,
 	/// then starts sending events on the Signal when the closure has returned.
-	func startWithSignal(_ setup: @noescape (signal: Signal<Value, Error>, interrupter: Disposable) -> Void)
+	func startWithSignal(_ setup: (_ signal: Signal<Value, Error>, _ interrupter: Disposable) -> Void)
 }
 
 extension SignalProducer: SignalProducerProtocol {
@@ -239,7 +239,7 @@ extension SignalProducerProtocol {
 	///            associated with the signal and immediately send an
 	///            `interrupted` event.
 	@discardableResult
-	public func start(_ observer: Signal<Value, Error>.Observer = Signal<Value, Error>.Observer()) -> Disposable {
+	public func start(_ observer: Signal<Value, Error>.Observer = .init()) -> Disposable {
 		var disposable: Disposable!
 
 		startWithSignal { signal, innerDisposable in
@@ -277,7 +277,7 @@ extension SignalProducerProtocol {
 	///             associated with the Signal, and prevent any future callbacks
 	///             from being invoked.
 	@discardableResult
-	public func startWithResult(_ result: (Result<Value, Error>) -> Void) -> Disposable {
+	public func startWithResult(_ result: @escaping (Result<Value, Error>) -> Void) -> Disposable {
 		return start(
 			Observer(
 				next: { result(.success($0)) },
@@ -297,7 +297,7 @@ extension SignalProducerProtocol {
 	/// - returns: A `Disposable` which can be used to interrupt the work
 	///            associated with the signal.
 	@discardableResult
-	public func startWithCompleted(_ completed: () -> Void) -> Disposable {
+	public func startWithCompleted(_ completed: @escaping () -> Void) -> Disposable {
 		return start(Observer(completed: completed))
 	}
 	
@@ -311,7 +311,7 @@ extension SignalProducerProtocol {
 	/// - returns: A `Disposable` which can be used to interrupt the work
 	///            associated with the signal.
 	@discardableResult
-	public func startWithFailed(_ failed: (Error) -> Void) -> Disposable {
+	public func startWithFailed(_ failed: @escaping (Error) -> Void) -> Disposable {
 		return start(Observer(failed: failed))
 	}
 	
@@ -326,7 +326,7 @@ extension SignalProducerProtocol {
 	/// - returns: A `Disposable` which can be used to interrupt the work
 	///            associated with the signal.
 	@discardableResult
-	public func startWithInterrupted(_ interrupted: () -> Void) -> Disposable {
+	public func startWithInterrupted(_ interrupted: @escaping () -> Void) -> Disposable {
 		return start(Observer(interrupted: interrupted))
 	}
 }
@@ -343,7 +343,7 @@ extension SignalProducerProtocol where Error == NoError {
 	///            associated with the Signal, and prevent any future callbacks
 	///            from being invoked.
 	@discardableResult
-	public func startWithNext(_ next: (Value) -> Void) -> Disposable {
+	public func startWithNext(_ next: @escaping (Value) -> Void) -> Disposable {
 		return start(Observer(next: next))
 	}
 }
@@ -360,7 +360,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A signal producer that applies signal's operator to every
 	///            created signal.
-	public func lift<U, F>(_ transform: (Signal<Value, Error>) -> Signal<U, F>) -> SignalProducer<U, F> {
+	public func lift<U, F>(_ transform: @escaping (Signal<Value, Error>) -> Signal<U, F>) -> SignalProducer<U, F> {
 		return SignalProducer { observer, outerDisposable in
 			self.startWithSignal { signal, innerDisposable in
 				outerDisposable += innerDisposable
@@ -385,7 +385,7 @@ extension SignalProducerProtocol {
 	///   - transform: A binary operator to lift.
 	///
 	/// - returns: A binary operator that operates on two signal producers.
-	public func lift<U, F, V, G>(_ transform: (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
+	public func lift<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
 		return liftRight(transform)
 	}
 
@@ -393,7 +393,7 @@ extension SignalProducerProtocol {
 	/// That is, the argument producer will be started before the receiver. When
 	/// both producers are synchronous this order can be important depending on
 	/// the operator to generate correct results.
-	private func liftRight<U, F, V, G>(_ transform: (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
+	private func liftRight<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
 		return { otherProducer in
 			return SignalProducer { observer, outerDisposable in
 				self.startWithSignal { signal, disposable in
@@ -413,7 +413,7 @@ extension SignalProducerProtocol {
 	/// That is, the receiver will be started before the argument producer. When
 	/// both producers are synchronous this order can be important depending on
 	/// the operator to generate correct results.
-	private func liftLeft<U, F, V, G>(_ transform: (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
+	private func liftLeft<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (SignalProducer<U, F>) -> SignalProducer<V, G> {
 		return { otherProducer in
 			return SignalProducer { observer, outerDisposable in
 				otherProducer.startWithSignal { otherSignal, otherDisposable in
@@ -443,7 +443,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A binary operator that works on `Signal` and returns
 	///            `SignalProducer`.
-	public func lift<U, F, V, G>(_ transform: (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (Signal<U, F>) -> SignalProducer<V, G> {
+	public func lift<U, F, V, G>(_ transform: @escaping (Signal<Value, Error>) -> (Signal<U, F>) -> Signal<V, G>) -> (Signal<U, F>) -> SignalProducer<V, G> {
 		return { otherSignal in
 			return SignalProducer { observer, outerDisposable in
 				let (wrapperSignal, otherSignalObserver) = Signal<U, F>.pipe()
@@ -475,7 +475,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A signal producer that, when started, will send a mapped
 	///            value of `self.`
-	public func map<U>(_ transform: (Value) -> U) -> SignalProducer<U, Error> {
+	public func map<U>(_ transform: @escaping (Value) -> U) -> SignalProducer<U, Error> {
 		return lift { $0.map(transform) }
 	}
 
@@ -486,7 +486,7 @@ extension SignalProducerProtocol {
 	///                different error.
 	///
 	/// - returns: A producer that emits errors of new type.
-	public func mapError<F>(_ transform: (Error) -> F) -> SignalProducer<Value, F> {
+	public func mapError<F>(_ transform: @escaping (Error) -> F) -> SignalProducer<Value, F> {
 		return lift { $0.mapError(transform) }
 	}
 
@@ -498,7 +498,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that, when started, will send only the values
 	///            passing the given predicate.
-	public func filter(_ predicate: (Value) -> Bool) -> SignalProducer<Value, Error> {
+	public func filter(_ predicate: @escaping (Value) -> Bool) -> SignalProducer<Value, Error> {
 		return lift { $0.filter(predicate) }
 	}
 
@@ -585,7 +585,7 @@ extension SignalProducerProtocol {
 	/// - returns: A producer that, when started, collects values passing the
 	///            predicate and, when `self` completes, forwards them as a
 	///            single array and complets.
-	public func collect(_ predicate: (values: [Value]) -> Bool) -> SignalProducer<[Value], Error> {
+	public func collect(_ predicate: @escaping (_ values: [Value]) -> Bool) -> SignalProducer<[Value], Error> {
 		return lift { $0.collect(predicate) }
 	}
 
@@ -628,7 +628,7 @@ extension SignalProducerProtocol {
 	/// - returns: A signal that will yield an array of values based on a
 	///            predicate which matches the values collected and the next
 	///            value.
-	public func collect(_ predicate: (values: [Value], next: Value) -> Bool) -> SignalProducer<[Value], Error> {
+	public func collect(_ predicate: @escaping (_ values: [Value], _ next: Value) -> Bool) -> SignalProducer<[Value], Error> {
 		return lift { $0.collect(predicate) }
 	}
 
@@ -905,7 +905,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that sends accumulated value after `self`
 	///             completes.
-	public func reduce<U>(_ initial: U, _ combine: (U, Value) -> U) -> SignalProducer<U, Error> {
+	public func reduce<U>(_ initial: U, _ combine: @escaping (U, Value) -> U) -> SignalProducer<U, Error> {
 		return lift { $0.reduce(initial, combine) }
 	}
 
@@ -923,7 +923,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that sends accumulated value each time `self`
 	///            emits own value.
-	public func scan<U>(_ initial: U, _ combine: (U, Value) -> U) -> SignalProducer<U, Error> {
+	public func scan<U>(_ initial: U, _ combine: @escaping (U, Value) -> U) -> SignalProducer<U, Error> {
 		return lift { $0.scan(initial, combine) }
 	}
 
@@ -933,7 +933,7 @@ extension SignalProducerProtocol {
 	/// - note: The first value is always forwarded.
 	///
 	/// - returns: A producer that does not send two equal values sequentially.
-	public func skipRepeats(_ isRepeat: (Value, Value) -> Bool) -> SignalProducer<Value, Error> {
+	public func skipRepeats(_ isRepeat: @escaping (Value, Value) -> Bool) -> SignalProducer<Value, Error> {
 		return lift { $0.skipRepeats(isRepeat) }
 	}
 
@@ -945,7 +945,7 @@ extension SignalProducerProtocol {
 	///                should still not forward that value to a `producer`.
 	///
 	/// - returns: A producer that sends only forwarded values from `self`.
-	public func skip(while predicate: (Value) -> Bool) -> SignalProducer<Value, Error> {
+	public func skip(while predicate: @escaping (Value) -> Bool) -> SignalProducer<Value, Error> {
 		return lift { $0.skip(while: predicate) }
 	}
 
@@ -1003,7 +1003,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that sends events until the values sent by `self`
 	///            pass the given `predicate`.
-	public func take(while predicate: (Value) -> Bool) -> SignalProducer<Value, Error> {
+	public func take(while predicate: @escaping (Value) -> Bool) -> SignalProducer<Value, Error> {
 		return lift { $0.take(while: predicate) }
 	}
 
@@ -1038,7 +1038,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that receives `Success`ful `Result` as `next`
 	///            event and `Failure` as `failed` event.
-	public func attempt(operation: (Value) -> Result<(), Error>) -> SignalProducer<Value, Error> {
+	public func attempt(operation: @escaping (Value) -> Result<(), Error>) -> SignalProducer<Value, Error> {
 		return lift { $0.attempt(operation) }
 	}
 
@@ -1051,7 +1051,7 @@ extension SignalProducerProtocol {
 	///
 	/// - returns: A producer that sends mapped values from `self` if returned
 	///            `Result` is `Success`ful, `failed` events otherwise.
-	public func attemptMap<U>(_ operation: (Value) -> Result<U, Error>) -> SignalProducer<U, Error> {
+	public func attemptMap<U>(_ operation: @escaping (Value) -> Result<U, Error>) -> SignalProducer<U, Error> {
 		return lift { $0.attemptMap(operation) }
 	}
 
@@ -1202,7 +1202,7 @@ extension SignalProducerProtocol {
 	///                value.
 	///
 	/// - returns: A producer that sends unique values during its lifetime.
-	public func uniqueValues<Identity: Hashable>(_ transform: (Value) -> Identity) -> SignalProducer<Value, Error> {
+	public func uniqueValues<Identity: Hashable>(_ transform: @escaping (Value) -> Identity) -> SignalProducer<Value, Error> {
 		return lift { $0.uniqueValues(transform) }
 	}
 }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -28,7 +28,7 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///
 	/// - parameters:
 	///   - signal: A signal to observe after starting the producer.
-	public init<S: SignalProtocol where S.Value == Value, S.Error == Error>(signal: S) {
+	public init<S: SignalProtocol>(signal: S) where S.Value == Value, S.Error == Error {
 		self.init { observer, disposable in
 			disposable += signal.observe(observer)
 		}
@@ -1371,7 +1371,9 @@ extension SignalProducerProtocol {
 
 	/// Combines the values of all the given producers, in the manner described by
 	/// `combineLatestWith`. Will return an empty `SignalProducer` if the sequence is empty.
-	public static func combineLatest<S: Sequence where S.Iterator.Element == SignalProducer<Value, Error>>(_ producers: S) -> SignalProducer<[Value], Error> {
+	public static func combineLatest<S: Sequence>(_ producers: S) -> SignalProducer<[Value], Error>
+		where S.Iterator.Element == SignalProducer<Value, Error>
+	{
 		var generator = producers.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }
@@ -1455,7 +1457,9 @@ extension SignalProducerProtocol {
 
 	/// Zips the values of all the given producers, in the manner described by
 	/// `zipWith`. Will return an empty `SignalProducer` if the sequence is empty.
-	public static func zip<S: Sequence where S.Iterator.Element == SignalProducer<Value, Error>>(_ producers: S) -> SignalProducer<[Value], Error> {
+	public static func zip<S: Sequence>(_ producers: S) -> SignalProducer<[Value], Error>
+		where S.Iterator.Element == SignalProducer<Value, Error>
+	{
 		var generator = producers.makeIterator()
 		if let first = generator.next() {
 			let initial = first.map { [$0] }

--- a/ReactiveCocoaTests/Swift/KeyValueObservingSpec.swift
+++ b/ReactiveCocoaTests/Swift/KeyValueObservingSpec.swift
@@ -169,7 +169,7 @@ class KeyValueObservingSpec: QuickSpec {
 					}
 
 					concurrentQueue.sync(flags: .barrier) {}
-					expect(observedValue).toEventually(be(2))
+					expect(observedValue).toEventually(equal(2))
 				}
 
 				it("should handle changes being made on another queue using deliverOn") {
@@ -190,7 +190,7 @@ class KeyValueObservingSpec: QuickSpec {
 					}
 
 					concurrentQueue.sync(flags: .barrier) {}
-					expect(observedValue).toEventually(be(2))
+					expect(observedValue).toEventually(equal(2))
 				}
 
 				it("async disposal of target") {
@@ -210,7 +210,7 @@ class KeyValueObservingSpec: QuickSpec {
 					}
 
 					concurrentQueue.sync(flags: .barrier) {}
-					expect(observedValue).toEventually(be(2))
+					expect(observedValue).toEventually(equal(2))
 				}
 			}
 
@@ -315,7 +315,7 @@ class KeyValueObservingSpec: QuickSpec {
 
 			it("should be able to classify weak references") {
 				"weakProperty".withCString { cString in
-					let propertyPointer = class_getProperty(object.dynamicType, cString)
+					let propertyPointer = class_getProperty(type(of: object), cString)
 					expect(propertyPointer) != nil
 
 					if let pointer = propertyPointer {
@@ -330,7 +330,7 @@ class KeyValueObservingSpec: QuickSpec {
 
 			it("should be able to classify blocks") {
 				"block".withCString { cString in
-					let propertyPointer = class_getProperty(object.dynamicType, cString)
+					let propertyPointer = class_getProperty(type(of: object), cString)
 					expect(propertyPointer) != nil
 
 					if let pointer = propertyPointer {
@@ -345,7 +345,7 @@ class KeyValueObservingSpec: QuickSpec {
 
 			it("should be able to classify non object properties") {
 				"integer".withCString { cString in
-					let propertyPointer = class_getProperty(object.dynamicType, cString)
+					let propertyPointer = class_getProperty(type(of: object), cString)
 					expect(propertyPointer) != nil
 
 					if let pointer = propertyPointer {

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -105,8 +105,8 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					expect(lastValue).to(beNil())
 
 					for number in [1, 2, 3] {
-						observer.sendNext(number)
-						expect(lastValue) == number
+						observer.sendNext(number as NSNumber)
+						expect(lastValue) == number as NSNumber
 					}
 
 					expect(didComplete) == false
@@ -119,15 +119,15 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					let racSignal = signal.toRACSignal()
 
 					let expectedError = TestError.error2
-					var error: Error?
+					var error: TestError?
 
 					racSignal.subscribeError {
-						error = $0
+						error = $0 as? TestError
 						return
 					}
 
 					observer.sendFailed(expectedError)
-					expect(error) == expectedError as NSError
+					expect(error) == expectedError
 				}
 				
 				it("should maintain userInfo on NSError") {
@@ -156,7 +156,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 							subscriptions += 1
 						}
 
-						return .success(subscriptions)
+						return .success(subscriptions as NSNumber)
 					}
 					let racSignal = producer.toRACSignal()
 
@@ -170,7 +170,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					let racSignal = producer.toRACSignal().materialize()
 
 					let event = racSignal.first() as? RACEvent
-					expect(event?.error) == TestError.error1 as NSError
+					expect(event?.error as? NSError) == TestError.error1 as NSError
 				}
 				
 				it("should maintain userInfo on NSError") {
@@ -191,7 +191,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			var enabledSubject: RACSubject!
 			var enabled = false
 
-			var action: Action<AnyObject?, AnyObject?, NSError>!
+			var action: Action<Any?, Any?, NSError>!
 
 			beforeEach {
 				enabledSubject = RACSubject()
@@ -222,7 +222,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			}
 
 			it("should execute the command once per start()") {
-				let producer = action.apply(0)
+				let producer = action.apply(0 as NSNumber)
 				expect(results) == []
 
 				producer.start()
@@ -231,7 +231,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				producer.start()
 				expect(results).toEventually(equal([ 1, 1 ]))
 
-				let otherProducer = action.apply(2)
+				let otherProducer = action.apply(2 as NSNumber)
 				expect(results) == [ 1, 1 ]
 
 				otherProducer.start()
@@ -257,7 +257,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 
 				action = Action(enabledIf: enabledProperty) { input in
 					let inputNumber = input as! Int
-					return SignalProducer(value: "\(inputNumber + 1)")
+					return SignalProducer(value: "\(inputNumber + 1)" as NSString)
 				}
 
 				expect(action.isEnabled.value) == true
@@ -280,7 +280,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 			}
 
 			it("should apply and start a signal once per execution") {
-				let signal = command.execute(0)
+				let signal = command.execute(0 as NSNumber)
 
 				do {
 					try signal.asynchronouslyWaitUntilCompleted()
@@ -289,7 +289,7 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					try signal.asynchronouslyWaitUntilCompleted()
 					expect(results) == [ "1" ]
 
-					try command.execute(2).asynchronouslyWaitUntilCompleted()
+					try command.execute(2 as NSNumber).asynchronouslyWaitUntilCompleted()
 					expect(results) == [ "1", "3" ]
 				} catch {
 					XCTFail("Failed to wait for completion")

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -1394,7 +1394,7 @@ class PropertySpec: QuickSpec {
 			var property: DynamicProperty<Int>!
 
 			let propertyValue: () -> Int? = {
-				if let value: AnyObject = property?.value {
+				if let value: Any = property?.value {
 					return value as? Int
 				} else {
 					return nil

--- a/ReactiveCocoaTests/Swift/SchedulerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SchedulerSpec.swift
@@ -26,7 +26,7 @@ class SchedulerSpec: QuickSpec {
 		}
 
 		describe("UIScheduler") {
-			func dispatchSyncInBackground(_ action: () -> Void) {
+			func dispatchSyncInBackground(_ action: @escaping () -> Void) {
 				let group = DispatchGroup()
 
 				let globalQueue: DispatchQueue

--- a/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerLiftingSpec.swift
@@ -516,16 +516,16 @@ class SignalProducerLiftingSpec: QuickSpec {
 
 					if i % 3 == 0 {
 						expectation.append([Int]((i - 2)...i))
-						expect(observedValues) == expectation
+						expect(observedValues as NSArray) == expectation as NSArray
 					} else {
-						expect(observedValues) == expectation
+						expect(observedValues as NSArray) == expectation as NSArray
 					}
 				}
 
 				observer.sendCompleted()
 
 				expectation.append([7])
-				expect(observedValues) == expectation
+				expect(observedValues as NSArray) == expectation as NSArray
 			}
 
 			it("should collect values until it matches a certain value") {
@@ -543,7 +543,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				producer.startWithCompleted {
-					expect(expectedValues) == []
+					expect(expectedValues as NSArray) == [] as NSArray
 				}
 
 				expectedValues
@@ -568,7 +568,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				}
 
 				producer.startWithCompleted {
-					expect(expectedValues) == []
+					expect(expectedValues as NSArray) == [] as NSArray
 				}
 
 				expectedValues
@@ -1077,7 +1077,7 @@ class SignalProducerLiftingSpec: QuickSpec {
 				class Payload {
 					let action: () -> Void
 
-					init(onDeinit action: () -> Void) {
+					init(onDeinit action: @escaping () -> Void) {
 						self.action = action
 					}
 

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -698,7 +698,7 @@ class SignalProducerSpec: QuickSpec {
 				observerA.sendCompleted()
 				observerB.sendCompleted()
 
-				expect(values) == [[1, 2], [3, 2]]
+				expect(values as NSArray) == [[1, 2], [3, 2]]
 			}
 
 			it("should start signal producers in order as defined") {
@@ -723,7 +723,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				expect(ids) == [1, 2]
-				expect(values) == [[1, 2]]
+				expect(values as NSArray) == [[1, 2]] as NSArray
 			}
 		}
 
@@ -735,7 +735,7 @@ class SignalProducerSpec: QuickSpec {
 				let producer = SignalProducer.zip([producerA, producerB])
 				let result = producer.collect().single()
 				
-				expect(result?.value) == [[1, 3], [2, 4]]
+				expect(result?.value.map { $0 as NSArray }) == [[1, 3], [2, 4]] as NSArray
 			}
 
 			it("should start signal producers in order as defined") {
@@ -760,7 +760,7 @@ class SignalProducerSpec: QuickSpec {
 				}
 
 				expect(ids) == [1, 2]
-				expect(values) == [[1, 2]]
+				expect(values as NSArray) == [[1, 2]] as NSArray
 			}
 		}
 
@@ -774,7 +774,7 @@ class SignalProducerSpec: QuickSpec {
 				let tick2 = startDate.addingTimeInterval(2)
 				let tick3 = startDate.addingTimeInterval(3)
 
-				var dates: [NSDate] = []
+				var dates: [Date] = []
 				producer.startWithNext { dates.append($0) }
 
 				scheduler.advance(by: 0.9)
@@ -926,7 +926,7 @@ class SignalProducerSpec: QuickSpec {
 
 				let producer = timer(interval: 2, on: testScheduler, leeway: 0)
 
-				var next: NSDate?
+				var next: Date?
 				producer.start(on: startScheduler).startWithNext { next = $0 }
 
 				startScheduler.advance(by: 2)
@@ -1700,7 +1700,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(result).to(beNil())
 
 				observer.sendNext(1)
-				expect(result).toEventually(be(1), timeout: 5.0)
+				expect(result).toEventually(equal(1), timeout: 5.0)
 			}
 
 			it("should return a nil result if no values are sent before completion") {
@@ -1753,7 +1753,7 @@ class SignalProducerSpec: QuickSpec {
 				expect(result).to(beNil())
 
 				observer.sendCompleted()
-				expect(result).toEventually(be(1))
+				expect(result).toEventually(equal(1))
 			}
 
 			it("should return a nil result if no values are sent before completion") {
@@ -2151,7 +2151,7 @@ class SignalProducerSpec: QuickSpec {
 					final class Value {
 						private let deinitBlock: () -> Void
 
-						init(deinitBlock: () -> Void) {
+						init(deinitBlock: @escaping () -> Void) {
 							self.deinitBlock = deinitBlock
 						}
 
@@ -2232,7 +2232,7 @@ extension SignalProducer {
 
 	/// Creates a producer that can be started as many times as elements in `results`.
 	/// Each signal will immediately send either a value or an error.
-	private static func attemptWithResults<C: Collection where C.Iterator.Element == Result<Value, Error>, C.IndexDistance == C.Index, C.Index == Int>(_ results: C) -> SignalProducer<Value, Error> {
+	fileprivate static func attemptWithResults<C: Collection>(_ results: C) -> SignalProducer<Value, Error> where C.Iterator.Element == Result<Value, Error>, C.IndexDistance == C.Index, C.Index == Int {
 		let resultCount = results.count
 		var operationIndex = 0
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -893,21 +893,20 @@ class SignalSpec: QuickSpec {
 				var expectation: [[Int]] = []
 
 				for i in 1...7 {
-
 					observer.sendNext(i)
 
 					if i % 3 == 0 {
 						expectation.append([Int]((i - 2)...i))
-						expect(observedValues) == expectation
+						expect(observedValues as NSArray) == expectation as NSArray
 					} else {
-						expect(observedValues) == expectation
+						expect(observedValues as NSArray) == expectation as NSArray
 					}
 				}
 
 				observer.sendCompleted()
 
 				expectation.append([7])
-				expect(observedValues) == expectation
+				expect(observedValues as NSArray) == expectation as NSArray
 			}
 
 			it("should collect values until it matches a certain value") {
@@ -925,7 +924,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				signal.observeCompleted {
-					expect(expectedValues) == []
+					expect(expectedValues as NSArray) == []
 				}
 
 				expectedValues
@@ -950,7 +949,7 @@ class SignalSpec: QuickSpec {
 				}
 
 				signal.observeCompleted {
-					expect(expectedValues) == []
+					expect(expectedValues as NSArray) == []
 				}
 
 				expectedValues

--- a/ReactiveCocoaTests/Swift/TestLogger.swift
+++ b/ReactiveCocoaTests/Swift/TestLogger.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import ReactiveCocoa
 
 final class TestLogger {
-	private var expectations: [(String) -> Void]
+	fileprivate var expectations: [(String) -> Void]
 	
 	init(expectations: [(String) -> Void]) {
 		self.expectations = expectations
@@ -18,7 +18,6 @@ final class TestLogger {
 }
 
 extension TestLogger {
-	
 	func logEvent(_ identifier: String, event: String, fileName: String, functionName: String, lineNumber: Int) {
 		expectations.removeFirst()("[\(identifier)] \(event)")
 	}


### PR DESCRIPTION
# Changes

- `dynamictype` -> `type(of:)` (SE-0096)
- Added explicit casting
- Argument labels have been removed from function types (SE-0111)
- Moved location of where statements in generic declarations
- `private` -> `fileprivate` (SE-0025) 
- `@noescape` is now default, `@escaping` is not (SE-0103)
- `id` is now imported as `Any` (SE-0116)
- Updated usage of `String` constructor.

# TODO:

- [x] Update `Result`: https://github.com/antitypical/Result/pull/181.
- [x] Fix `UnsafeMutablePointer` changes.
- [x] Other compile errors.