### PR TITLE
Fix casing for enum values in markup

### DIFF
--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -100,7 +100,7 @@ public final class Action<Input, Output, Error: Swift.Error> {
 	/// with the given input, then forward the results upon the produced Signal.
 	///
 	/// - note: If the action is disabled when the returned SignalProducer is
-	///         started, the produced signal will send `ActionError.NotEnabled`,
+	///         started, the produced signal will send `ActionError.disabled`,
 	///         and nothing will be sent upon `values` or `errors` for that
 	///         particular signal.
 	///
@@ -158,7 +158,7 @@ public protocol ActionProtocol {
 	/// with the given input, then forward the results upon the produced Signal.
 	///
 	/// - note: If the action is disabled when the returned SignalProducer is
-	///         started, the produced signal will send `ActionError.NotEnabled`,
+	///         started, the produced signal will send `ActionError.disabled`,
 	///         and nothing will be sent upon `values` or `errors` for that
 	///         particular signal.
 	///

--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -9,7 +9,7 @@
 /// Represents a signal event.
 ///
 /// Signals must conform to the grammar:
-/// `Next* (Failed | Completed | Interrupted)?`
+/// `next* (failed | completed | interrupted)?`
 public enum Event<Value, Error: Swift.Error> {
 	/// A value provided by the signal.
 	case next(Value)

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -224,8 +224,8 @@ extension SignalProtocol {
 	///
 	/// - parameters:
 	///   - result: A closure that accepts instance of `Result<Value, Error>`
-	///             enum that contains either a `Success(Value)` or
-	///             `Failure<Error>` case.
+	///             enum that contains either a `.success(Value)` or
+	///             `.failure<Error>` case.
 	///
 	/// - returns: An optional `Disposable` which can be used to stop the
 	///            invocation of the callback. Disposing of the Disposable will
@@ -1367,14 +1367,14 @@ extension SignalProtocol {
 		}
 	}
 
-	/// Apply `operation` to values from `self` with `Success`ful results
-	/// forwarded on the returned signal and `Failure`s sent as failed events.
+	/// Apply `operation` to values from `self` with `success`ful results
+	/// forwarded on the returned signal and `failure`s sent as failed events.
 	///
 	/// - parameters:
 	///   - operation: A closure that accepts a value and returns a `Result`.
 	///
-	/// - returns: A signal that receives `Success`ful `Result` as `next` event
-	///            and `Failure` as failed event.
+	/// - returns: A signal that receives `success`ful `Result` as `next` event
+	///            and `failure` as failed event.
 	public func attempt(_ operation: @escaping (Value) -> Result<(), Error>) -> Signal<Value, Error> {
 		return attemptMap { value in
 			return operation(value).map {
@@ -1383,15 +1383,15 @@ extension SignalProtocol {
 		}
 	}
 
-	/// Apply `operation` to values from `self` with `Success`ful results mapped
-	/// on the returned signal and `Failure`s sent as failed events.
+	/// Apply `operation` to values from `self` with `success`ful results mapped
+	/// on the returned signal and `failure`s sent as failed events.
 	///
 	/// - parameters:
 	///   - operation: A closure that accepts a value and returns a result of
-	///                a mapped value as `Success`.
+	///                a mapped value as `success`.
 	///
 	/// - returns: A signal that sends mapped values from `self` if returned
-	///            `Result` is `Success`ful, failed events otherwise.
+	///            `Result` is `success`ful, `failed` events otherwise.
 	public func attemptMap<U>(_ operation: @escaping (Value) -> Result<U, Error>) -> Signal<U, Error> {
 		return Signal { observer in
 			self.observe { event in

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -81,8 +81,8 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	///
 	/// - parameters:
 	///   - result: A `Result` instance that will send either `next` event if
-	///             `result` is `Success`ful or `failed` event if `result` is a
-	///             `Failure`.
+	///             `result` is `success`ful or `failed` event if `result` is a
+	///             `failure`.
 	public init(result: Result<Value, Error>) {
 		switch result {
 		case let .success(value):
@@ -147,9 +147,9 @@ public struct SignalProducer<Value, Error: Swift.Error> {
 	/// - parameters:
 	///   - operation: A closure that returns instance of `Result`.
 	///
-	/// - returns: A `SignalProducer` that will forward `Success`ful `result` as
+	/// - returns: A `SignalProducer` that will forward `success`ful `result` as
 	///            `next` event and then complete or `failed` event if `result`
-	///            is a `Failure`.
+	///            is a `failure`.
 	public static func attempt(_ operation: @escaping () -> Result<Value, Error>) -> SignalProducer {
 		return self.init { observer, disposable in
 			operation().analysis(ifSuccess: { value in
@@ -270,8 +270,8 @@ extension SignalProducerProtocol {
 	/// received.
 	///
 	/// - parameters:
-	///   - result: A closure that accepts a `result` that contains a `Success`
-	///             case for `next` events or `Failure` case for `failed` event.
+	///   - result: A closure that accepts a `result` that contains a `.success`
+	///             case for `next` events or `.failure` case for `failed` event.
 	///
 	/// - returns:  A Disposable which can be used to interrupt the work
 	///             associated with the Signal, and prevent any future callbacks
@@ -1029,28 +1029,28 @@ extension SignalProducerProtocol {
 		return lift(Signal.zip(with:))(other)
 	}
 
-	/// Apply `operation` to values from `self` with `Success`ful results
-	/// forwarded on the returned producer and `Failure`s sent as `failed`
+	/// Apply `operation` to values from `self` with `success`ful results
+	/// forwarded on the returned producer and `failure`s sent as `failed`
 	/// events.
 	///
 	/// - parameters:
 	///   - operation: A closure that accepts a value and returns a `Result`.
 	///
-	/// - returns: A producer that receives `Success`ful `Result` as `next`
-	///            event and `Failure` as `failed` event.
+	/// - returns: A producer that receives `success`ful `Result` as `next`
+	///            event and `failure` as `failed` event.
 	public func attempt(operation: @escaping (Value) -> Result<(), Error>) -> SignalProducer<Value, Error> {
 		return lift { $0.attempt(operation) }
 	}
 
-	/// Apply `operation` to values from `self` with `Success`ful results
-	/// mapped on the returned producer and `Failure`s sent as `failed` events.
+	/// Apply `operation` to values from `self` with `success`ful results
+	/// mapped on the returned producer and `failure`s sent as `failed` events.
 	///
 	/// - parameters:
 	///   - operation: A closure that accepts a value and returns a result of
-	///                a mapped value as `Success`.
+	///                a mapped value as `success`.
 	///
 	/// - returns: A producer that sends mapped values from `self` if returned
-	///            `Result` is `Success`ful, `failed` events otherwise.
+	///            `Result` is `success`ful, `failed` events otherwise.
 	public func attemptMap<U>(_ operation: @escaping (Value) -> Result<U, Error>) -> SignalProducer<U, Error> {
 		return lift { $0.attemptMap(operation) }
 	}
@@ -1671,7 +1671,7 @@ extension SignalProducerProtocol {
 	/// When a completion or error is sent, the returned `Result` will represent
 	/// those cases.
 	///
-	/// - returns: Result when single `Completion` or `failed` event is 
+	/// - returns: Result when single `completion` or `failed` event is
 	///            received.
 	public func wait() -> Result<(), Error> {
 		return then(SignalProducer<(), Error>(value: ())).last() ?? .success(())


### PR DESCRIPTION
The documentation still contained old naming convention for enum cases (first letter was uppercase). Fixed this.

Also renamed `NotEnabled` case of `ActionError` to `disabled`.