### PR TITLE
EventLogger now logs the `starting` SignalProducer event.

### DIFF
--- a/ReactiveCocoa/Swift/EventLogger.swift
+++ b/ReactiveCocoa/Swift/EventLogger.swift
@@ -19,10 +19,10 @@ public enum LoggingEvent {
 	}
 
 	public enum SignalProducer: String {
-		case started, next, completed, failed, terminated, disposed, interrupted
+		case starting, started, next, completed, failed, terminated, disposed, interrupted
 
 		public static let allEvents: Set<SignalProducer> = [
-			.started, .next, .completed, .failed, .terminated, .disposed, .interrupted,
+			.starting, .started, .next, .completed, .failed, .terminated, .disposed, .interrupted,
 		]
 	}
 }
@@ -100,6 +100,7 @@ extension SignalProducerProtocol {
 		}
 
 		return self.on(
+			starting: log(.starting),
 			started: log(.started),
 			next: log(.next),
 			failed: log(.failed),

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -2208,6 +2208,7 @@ class SignalProducerSpec: QuickSpec {
 			describe("log events") {
 				it("should output the correct event") {
 					let expectations: [(String) -> Void] = [
+						{ event in expect(event) == "[] starting" },
 						{ event in expect(event) == "[] started" },
 						{ event in expect(event) == "[] next 1" },
 						{ event in expect(event) == "[] completed" },


### PR DESCRIPTION
Fixes #3174.