### PR TITLE
New `flatMap` overload for flattening property of optional properties.

### DIFF
--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -175,6 +175,24 @@ extension PropertyProtocol {
 	}
 }
 
+extension PropertyProtocol where Value: OptionalProtocol, Value.Wrapped: PropertyProtocol {
+	/// Maps each value from `self` to an optional property, then flattens the
+	/// resulting properties (into a single property), according to the
+	/// semantics of the given strategy.
+	///
+	/// If the mapping results in `nil`, it would be treated as a constant
+	/// property of `nil`.
+	///
+	/// - parameters:
+	///   - strategy: The preferred flatten strategy.
+	///   - transform: The transform to be applied on `self` before flattening.
+	///
+	/// - returns: A property that sends the values of its inner properties.
+	public func flatMap<P: PropertyProtocol>(_ strategy: FlattenStrategy, transform: @escaping (Value) -> P?) -> Property<P.Value?> {
+		return lift { $0.flatMap(strategy) { transform($0)?.producer.optionalize() ?? SignalProducer(value: nil) } }
+	}
+}
+
 extension PropertyProtocol where Value: Hashable {
 	/// Forwards only those values from `self` that are unique across the set of
 	/// all values that have been seen.


### PR DESCRIPTION
It allows a `Property<Value>` in `U` of a `Property<U?>` to be flattened as `Property<Value?>`.

e.g.
```
class TweetViewModel {
    let message: Property<String>
}

let viewModel = MutableProperty<TweetViewModel?>(nil)
// ...

// Currently: SignalProducer<String, NoError>
messageLabel.rac_text <~ viewModel.producer.flatMap { $0?.message.producer ?? .empty }

// With the new overload: Property<String?>
messageLabel.rac_text <~ viewModel.flatMap { $0?.message }
```

This specific use case is due to the design of property contract, which rallies behind `PropertyProtocol` and expects multiple concrete types, unlike `Signal` or `SignalProducer`. So `Property(value: "defaultValue")` might not be available, unless the inner type is coincidentally, or intentionally wrapped as, `Property`.

-

I'd be glad to know if there is any better approach to this though... Perhaps should I create a default "dummy" view model instead?