### PR TITLE
Remove warning on XCode8 for #3183

### DIFF
--- a/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
@@ -46,14 +46,22 @@
 /// Returns a signal which sends the current value of the key path on
 /// subscription, then sends the new value every time it changes, and sends
 /// completed if self or observer is deallocated.
+#if __clang__ && (__clang_major__ >= 8)
 #define RACObserve(TARGET, KEYPATH) \
-	({ \
-		_Pragma("clang diagnostic push") \
-		_Pragma("clang diagnostic ignored \"-Wreceiver-is-weak\"") \
-		__weak id target_ = (TARGET); \
-		[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
-		_Pragma("clang diagnostic pop") \
-	})
+({ \
+	__weak id target_ = (TARGET); \
+	[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
+})
+#else
+#define RACObserve(TARGET, KEYPATH) \
+({ \
+	_Pragma("clang diagnostic push") \
+	_Pragma("clang diagnostic ignored \"-Wreceiver-is-weak\"") \
+	__weak id target_ = (TARGET); \
+	[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
+	_Pragma("clang diagnostic pop") \
+})
+#endif
 
 @class RACDisposable;
 @class RACSignal;

--- a/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
+++ b/ReactiveCocoa/Objective-C/NSObject+RACPropertySubscribing.h
@@ -46,19 +46,20 @@
 /// Returns a signal which sends the current value of the key path on
 /// subscription, then sends the new value every time it changes, and sends
 /// completed if self or observer is deallocated.
-#if __clang__ && (__clang_major__ >= 8)
-#define RACObserve(TARGET, KEYPATH) \
+#define _RACObserve(TARGET, KEYPATH) \
 ({ \
 	__weak id target_ = (TARGET); \
 	[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
 })
+
+#if __clang__ && (__clang_major__ >= 8)
+#define RACObserve(TARGET, KEYPATH) _RACObserve(TARGET, KEYPATH)
 #else
 #define RACObserve(TARGET, KEYPATH) \
 ({ \
 	_Pragma("clang diagnostic push") \
 	_Pragma("clang diagnostic ignored \"-Wreceiver-is-weak\"") \
-	__weak id target_ = (TARGET); \
-	[target_ rac_valuesForKeyPath:@keypath(TARGET, KEYPATH) observer:self]; \
+	_RACObserve(TARGET, KEYPATH) \
 	_Pragma("clang diagnostic pop") \
 })
 #endif


### PR DESCRIPTION
The option `receiver-is-weak` seems to be ignored according to the llvm
mailing list:
http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20160418/156202.html.