### PR TITLE
Add convenience `CocoaAction` initialiser for `Void` actions

### DIFF
--- a/ReactiveCocoa/CocoaAction.swift
+++ b/ReactiveCocoa/CocoaAction.swift
@@ -70,7 +70,14 @@ public final class CocoaAction: NSObject {
 	public convenience init<Action: ActionProtocol>(_ action: Action, input: Action.Input) {
 		self.init(action, { _ in input })
 	}
-	
+
+	/// Initializes a Cocoa action that will ignore its input.
+	///
+	/// - parameter action: An action with input type `Void`.
+	public convenience init<Action: ActionProtocol>(_ action: Action) where Action.Input == Void {
+		self.init(action, { _ in })
+	}
+
 	deinit {
 		disposable.dispose()
 	}

--- a/ReactiveCocoaTests/CocoaActionSpec.swift
+++ b/ReactiveCocoaTests/CocoaActionSpec.swift
@@ -65,7 +65,18 @@ class CocoaActionSpec: QuickSpec {
 			
 			_ = cocoaAction
 		}
-		
+
+		it("ignores the input when initialized with a void action") {
+			let action = Action<Void, Int, NoError> { SignalProducer(value: 1) }
+
+			var result: Int?
+			action.values.observeResult { result = $0.value }
+
+			CocoaAction(action).execute(NSObject())
+
+			expect(result) == 1
+		}
+
 		context("lifetime") {
 			it("unsafeCocoaAction should not create a retain cycle") {
 				weak var weakAction: Action<Int, Int, NoError>?


### PR DESCRIPTION
`unsafeCocoaAction` is just that: unsafe. It's not initially obvious how to bind `Void` actions to buttons, and this is a step towards a convenient and safe way of achieving that.
