### PR TITLE
fix broken link to legacy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ introductory examples of using it.
 [Code]: ReactiveCocoa
 [Documentation]: Documentation
 [Framework Overview]: Documentation/FrameworkOverview.md
-[Legacy Documentation]: Documentation/Legacy
+[Legacy Documentation]: https://github.com/ReactiveCocoa/ReactiveObjC/blob/master/Documentation/
 [Objective-C API]: ReactiveCocoa/Objective-C
 [Objective-C Bridging]: Documentation/ObjectiveCBridging.md
 [Signal producers]: Documentation/FrameworkOverview.md#signal-producers


### PR DESCRIPTION
The legacy documentation now lives in the ReactiveCocoaObjC project. 
Fixes #3225