### PR TITLE
Add cross reference notes to UIKit text observation methods

### DIFF
--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -9,12 +9,17 @@ extension Reactive where Base: UITextField {
 	}
 
 	/// A signal of text values emitted by the text field upon end of editing.
+	///
+	/// - note: To observe text values that change on all editing events,
+	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
 		return trigger(for: .editingDidEnd)
 			.map { [unowned base = self.base] in base.text }
 	}
 
 	/// A signal of text values emitted by the text field upon any changes.
+	///
+	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {
 		return trigger(for: .editingChanged)
 			.map { [unowned base = self.base] in base.text }

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -9,6 +9,9 @@ extension Reactive where Base: UITextView {
 	}
 
 	/// A signal of text values emitted by the text view upon end of editing.
+	///
+	/// - note: To observe text values that change on all editing events,
+	///   see `continuousTextValues`.
 	public var textValues: Signal<String, NoError> {
 		return NotificationCenter.default
 			.reactive
@@ -18,6 +21,8 @@ extension Reactive where Base: UITextView {
 	}
 
 	/// A signal of text values emitted by the text view upon any changes.
+	///
+	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String, NoError> {
 		return NotificationCenter.default
 			.reactive


### PR DESCRIPTION
Hopefully helps users to be more aware of the difference between the different ways of observing text changes.