### PR TITLE
Changed the method prefix and class suffix used for swizzling.

### DIFF
--- a/ReactiveCocoa/RACObjCRuntimeUtilities.m
+++ b/ReactiveCocoa/RACObjCRuntimeUtilities.m
@@ -7,8 +7,8 @@ NSString * const RACSelectorSignalErrorDomain = @"RACSelectorSignalErrorDomain";
 const NSInteger RACSelectorSignalErrorMethodSwizzlingRace = 1;
 const NSExceptionName RACSwizzleException = @"RACSwizzleException";
 
-static NSString * const RACSignalForSelectorAliasPrefix = @"rac_alias_";
-static NSString * const RACSubclassSuffix = @"_RACSelectorSignal";
+static NSString * const RACSignalForSelectorAliasPrefix = @"rac_swift_";
+static NSString * const RACSubclassSuffix = @"_RACIntercepting";
 static void *RACSubclassAssociationKey = &RACSubclassAssociationKey;
 
 static NSMutableSet *swizzledClasses() {


### PR DESCRIPTION
Fixes https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3269.