### PR TITLE
Trigger signal for optional, unbacked protocol requirements.

### DIFF
--- a/ReactiveCocoa/NSObject+Intercepting.swift
+++ b/ReactiveCocoa/NSObject+Intercepting.swift
@@ -6,12 +6,23 @@ extension Reactive where Base: NSObject {
 	/// Create a signal which sends a `next` event at the end of every invocation
 	/// of `selector` on the object.
 	///
+	/// `trigger(for:from:)` can be used to intercept optional protocol
+	/// requirements by supplying the protocol as `protocol`. The instance need
+	/// not have a concrete implementation of the requirement.
+	///
+	/// However, as Cocoa classes usually cache information about delegate
+	/// conformances, trigger signals for optional, unbacked protocol requirements
+	/// should be set up before the instance is assigned as the corresponding
+	/// delegate.
+	///
 	/// - parameters:
 	///   - selector: The selector to observe.
+	///   - protocol: The protocol of the selector, or `nil` if the selector does
+	///               not belong to any protocol.
 	///
 	/// - returns:
 	///   A trigger signal.
-	public func trigger(for selector: Selector) -> Signal<(), NoError> {
+	public func trigger(for selector: Selector, from protocol: Protocol? = nil) -> Signal<(), NoError> {
 		return base.synchronized {
 			let map = associatedValue { _ in NSMutableDictionary() }
 
@@ -22,7 +33,7 @@ extension Reactive where Base: NSObject {
 
 			let (signal, observer) = Signal<(), NoError>.pipe()
 			let isSuccessful = base._rac_setupInvocationObservation(for: selector,
-			                                                        protocol: nil,
+			                                                        protocol: `protocol`,
 			                                                        receiver: observer.send(value:))
 			precondition(isSuccessful)
 

--- a/ReactiveCocoa/RACObjCRuntimeUtilities.m
+++ b/ReactiveCocoa/RACObjCRuntimeUtilities.m
@@ -111,7 +111,7 @@ static void RACSwizzleRespondsToSelector(Class class) {
 		Method method = rac_getImmediateInstanceMethod(class, selector);
 
 		if (method != NULL && method_getImplementation(method) == _objc_msgForward) {
-			SEL aliasSelector = (selector);
+			SEL aliasSelector = RACAliasForSelector(selector);
 			if (objc_getAssociatedObject(self, aliasSelector) != nil) return YES;
 		}
 

--- a/ReactiveCocoaTests/InterceptingSpec.swift
+++ b/ReactiveCocoaTests/InterceptingSpec.swift
@@ -39,6 +39,24 @@ class InterceptingSpec: QuickSpec {
 				expect(object.counter) == 2
 			}
 
+			it("should send a value when the selector is invoked without implementation") {
+				let selector = #selector(TestProtocol.optionalMethod)
+
+				let signal = object.reactive.trigger(for: selector,
+				                                     from: TestProtocol.self)
+
+				var counter = 0
+				signal.observeValues { counter += 1 }
+
+				expect(counter) == 0
+
+				(object as TestProtocol).optionalMethod!()
+				expect(counter) == 1
+
+				(object as TestProtocol).optionalMethod!()
+				expect(counter) == 2
+			}
+
 			it("should complete when the object deinitializes") {
 				let signal = object.reactive.trigger(for: #selector(object.increment))
 
@@ -93,8 +111,13 @@ class InterceptingSpec: QuickSpec {
 	}
 }
 
-class InterceptedObject: NSObject {
+@objc protocol TestProtocol {
+	@objc optional func optionalMethod()
+}
+
+class InterceptedObject: NSObject, TestProtocol {
 	var counter = 0
+	var testProtocolCounter = 0
 
 	dynamic func increment() {
 		counter += 1

--- a/ReactiveCocoaTests/InterceptingSpec.swift
+++ b/ReactiveCocoaTests/InterceptingSpec.swift
@@ -44,6 +44,7 @@ class InterceptingSpec: QuickSpec {
 
 				let signal = object.reactive.trigger(for: selector,
 				                                     from: TestProtocol.self)
+				expect(object.responds(to: selector)) == true
 
 				var counter = 0
 				signal.observeValues { counter += 1 }
@@ -55,6 +56,7 @@ class InterceptingSpec: QuickSpec {
 
 				(object as TestProtocol).optionalMethod!()
 				expect(counter) == 2
+
 			}
 
 			it("should complete when the object deinitializes") {

--- a/ReactiveCocoaTests/InterceptingSpec.swift
+++ b/ReactiveCocoaTests/InterceptingSpec.swift
@@ -119,7 +119,6 @@ class InterceptingSpec: QuickSpec {
 
 class InterceptedObject: NSObject, TestProtocol {
 	var counter = 0
-	var testProtocolCounter = 0
 
 	dynamic func increment() {
 		counter += 1

--- a/ReactiveCocoaTests/InterceptingSpec.swift
+++ b/ReactiveCocoaTests/InterceptingSpec.swift
@@ -41,6 +41,7 @@ class InterceptingSpec: QuickSpec {
 
 			it("should send a value when the selector is invoked without implementation") {
 				let selector = #selector(TestProtocol.optionalMethod)
+				expect(object.responds(to: selector)) == false
 
 				let signal = object.reactive.trigger(for: selector,
 				                                     from: TestProtocol.self)


### PR DESCRIPTION
Extend `trigger(for:)` to provide an equivalent of `rac_signalForSelector:fromProtocol:`.