### PR TITLE
Default binding source and target providers.

### DIFF
--- a/ReactiveCocoa/AppKit/NSControl.swift
+++ b/ReactiveCocoa/AppKit/NSControl.swift
@@ -109,3 +109,77 @@ extension Reactive where Base: NSControl {
 		}
 	}
 }
+
+extension NSControl {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+	) -> Disposable? where Source.Value == String, Source.Error == NoError {
+		return target.reactive.stringValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+	) -> Disposable? where Source.Value == NSAttributedString, Source.Error == NoError {
+		return target.reactive.attributedStringValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+	) -> Disposable? where Source.Value == Bool, Source.Error == NoError {
+		return target.reactive.boolValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+	) -> Disposable? where Source.Value == Int32, Source.Error == NoError {
+		return target.reactive.intValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+	) -> Disposable? where Source.Value == Int, Source.Error == NoError {
+		return target.reactive.integerValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+	) -> Disposable? where Source.Value == Double, Source.Error == NoError {
+		return target.reactive.doubleValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+	) -> Disposable? where Source.Value == Float, Source.Error == NoError {
+		return target.reactive.floatValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+		) -> Disposable? where Source.Value == Any, Source.Error == NoError {
+		return target.reactive.objectValue <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: NSControl,
+		source: Source
+		) -> Disposable? where Source.Value == Any?, Source.Error == NoError {
+		return target.reactive.objectValue <~ source
+	}
+}

--- a/ReactiveCocoa/AppKit/NSTextField.swift
+++ b/ReactiveCocoa/AppKit/NSTextField.swift
@@ -23,3 +23,9 @@ extension Reactive where Base: NSTextField {
 			.map { ($0.object as! NSTextField).attributedStringValue }
 	}
 }
+
+extension NSTextField: BindingSourceProtocol {
+	public func observe(_ observer: Observer<String, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.stringValues.take(during: lifetime).observe(observer)
+	}
+}

--- a/ReactiveCocoa/UIKit/UIActivityIndicatorView.swift
+++ b/ReactiveCocoa/UIKit/UIActivityIndicatorView.swift
@@ -1,9 +1,20 @@
 import ReactiveSwift
+import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UIActivityIndicatorView {
 	/// Sets whether the activity indicator should be animating.
 	public var isAnimating: BindingTarget<Bool> {
 		return makeBindingTarget { $1 ? $0.startAnimating() : $0.stopAnimating() }
+	}
+}
+
+extension UIActivityIndicatorView {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UIActivityIndicatorView,
+		source: Source
+	) -> Disposable? where Source.Value == Bool, Source.Error == NoError {
+		return target.reactive.isAnimating <~ source
 	}
 }

--- a/ReactiveCocoa/UIKit/UIImageView.swift
+++ b/ReactiveCocoa/UIKit/UIImageView.swift
@@ -1,4 +1,5 @@
 import ReactiveSwift
+import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UIImageView {
@@ -10,5 +11,23 @@ extension Reactive where Base: UIImageView {
 	/// Sets the image of the image view for its highlighted state.
 	public var highlightedImage: BindingTarget<UIImage?> {
 		return makeBindingTarget { $0.highlightedImage = $1 }
+	}
+}
+
+extension UIImageView {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UIImageView,
+		source: Source
+	) -> Disposable? where Source.Value == UIImage, Source.Error == NoError {
+		return target.reactive.image <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UIImageView,
+		source: Source
+	) -> Disposable? where Source.Value == UIImage?, Source.Error == NoError {
+		return target.reactive.image <~ source
 	}
 }

--- a/ReactiveCocoa/UIKit/UILabel.swift
+++ b/ReactiveCocoa/UIKit/UILabel.swift
@@ -1,4 +1,5 @@
 import ReactiveSwift
+import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UILabel {
@@ -15,5 +16,39 @@ extension Reactive where Base: UILabel {
 	/// Sets the color of the text of the label.
 	public var textColor: BindingTarget<UIColor> {
 		return makeBindingTarget { $0.textColor = $1 }
+	}
+}
+
+extension UILabel {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UILabel,
+		source: Source
+	) -> Disposable? where Source.Value == String?, Source.Error == NoError {
+		return target.reactive.text <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UILabel,
+		source: Source
+	) -> Disposable? where Source.Value == String, Source.Error == NoError {
+		return target.reactive.text <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UILabel,
+		source: Source
+	) -> Disposable? where Source.Value == NSAttributedString?, Source.Error == NoError {
+		return target.reactive.attributedText <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UILabel,
+		source: Source
+	) -> Disposable? where Source.Value == NSAttributedString, Source.Error == NoError {
+		return target.reactive.attributedText <~ source
 	}
 }

--- a/ReactiveCocoa/UIKit/UIProgressView.swift
+++ b/ReactiveCocoa/UIKit/UIProgressView.swift
@@ -1,9 +1,20 @@
 import ReactiveSwift
+import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UIProgressView {
 	/// Sets the relative progress to be reflected by the progress view.
 	public var progress: BindingTarget<Float> {
 		return makeBindingTarget { $0.progress = $1 }
+	}
+}
+
+extension UIProgressView {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UIProgressView,
+		source: Source
+	) -> Disposable? where Source.Value == Float, Source.Error == NoError {
+		return target.reactive.progress <~ source
 	}
 }

--- a/ReactiveCocoa/UIKit/UISegmentedControl.swift
+++ b/ReactiveCocoa/UIKit/UISegmentedControl.swift
@@ -13,3 +13,19 @@ extension Reactive where Base: UISegmentedControl {
 		return controlEvents(.valueChanged).map { $0.selectedSegmentIndex }
 	}
 }
+
+extension UISegmentedControl {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UISegmentedControl,
+		source: Source
+	) -> Disposable? where Source.Value == Int, Source.Error == NoError {
+		return target.reactive.selectedSegmentIndex <~ source
+	}
+}
+
+extension UISegmentedControl: BindingSourceProtocol {
+	public func observe(_ observer: Observer<Int, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.selectedSegmentIndexes.take(during: lifetime).observe(observer)
+	}
+}

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -43,3 +43,43 @@ extension Reactive where Base: UITextField {
 		return controlEvents(.editingChanged).map { $0.attributedText }
 	}
 }
+
+extension UITextField {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextField,
+		source: Source
+	) -> Disposable? where Source.Value == String?, Source.Error == NoError {
+		return target.reactive.text <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextField,
+		source: Source
+	) -> Disposable? where Source.Value == String, Source.Error == NoError {
+		return target.reactive.text <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextField,
+		source: Source
+	) -> Disposable? where Source.Value == NSAttributedString?, Source.Error == NoError {
+		return target.reactive.attributedText <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextField,
+		source: Source
+	) -> Disposable? where Source.Value == NSAttributedString, Source.Error == NoError {
+		return target.reactive.attributedText <~ source
+	}
+}
+
+extension UITextField: BindingSourceProtocol {
+	public func observe(_ observer: Observer<String?, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.textValues.take(during: lifetime).observe(observer)
+	}
+}

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -59,3 +59,44 @@ extension Reactive where Base: UITextView {
 		return attributedTextValues(forName: .UITextViewTextDidChange)
 	}
 }
+
+extension UITextView {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextView,
+		source: Source
+	) -> Disposable? where Source.Value == String, Source.Error == NoError {
+		return target.reactive.text <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextView,
+		source: Source
+	) -> Disposable? where Source.Value == String?, Source.Error == NoError {
+		return target.reactive.text <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextView,
+		source: Source
+	) -> Disposable? where Source.Value == NSAttributedString, Source.Error == NoError {
+		return target.reactive.attributedText <~ source
+	}
+
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UITextView,
+		source: Source
+	) -> Disposable? where Source.Value == NSAttributedString?, Source.Error == NoError {
+		return target.reactive.attributedText <~ source
+	}
+}
+
+extension UITextView: BindingSourceProtocol {
+	public func observe(_ observer: Observer<String?, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.textValues.take(during: lifetime).observe(observer)
+	}
+}
+

--- a/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
@@ -13,3 +13,20 @@ extension Reactive where Base: UIDatePicker {
 		return controlEvents(.valueChanged).map { $0.date }
 	}
 }
+
+extension UIDatePicker {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UIDatePicker,
+		source: Source
+	) -> Disposable? where Source.Value == Date, Source.Error == NoError {
+		return target.reactive.date <~ source
+	}
+}
+
+extension UIDatePicker: BindingSourceProtocol {
+	public func observe(_ observer: Observer<Date, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.dates.take(during: lifetime).observe(observer)
+	}
+}
+

--- a/ReactiveCocoa/UIKit/iOS/UISlider.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISlider.swift
@@ -28,3 +28,19 @@ extension Reactive where Base: UISlider {
 		return controlEvents(.valueChanged).map { $0.value }
 	}
 }
+
+extension UISlider {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UISlider,
+		source: Source
+	) -> Disposable? where Source.Value == Float, Source.Error == NoError {
+		return target.reactive.value <~ source
+	}
+}
+
+extension UISlider: BindingSourceProtocol {
+	public func observe(_ observer: Observer<Float, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.values.take(during: lifetime).observe(observer)
+	}
+}

--- a/ReactiveCocoa/UIKit/iOS/UIStepper.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIStepper.swift
@@ -25,3 +25,19 @@ extension Reactive where Base: UIStepper {
 		return controlEvents(.valueChanged).map { $0.value }
 	}
 }
+
+extension UIStepper {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UIStepper,
+		source: Source
+	) -> Disposable? where Source.Value == Double, Source.Error == NoError {
+		return target.reactive.value <~ source
+	}
+}
+
+extension UIStepper: BindingSourceProtocol {
+	public func observe(_ observer: Observer<Double, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.values.take(during: lifetime).observe(observer)
+	}
+}

--- a/ReactiveCocoa/UIKit/iOS/UISwitch.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISwitch.swift
@@ -28,3 +28,19 @@ extension Reactive where Base: UISwitch {
 		return controlEvents(.valueChanged).map { $0.isOn }
 	}
 }
+
+extension UISwitch {
+	@discardableResult
+	public static func <~ <Source: BindingSourceProtocol>(
+		target: UISwitch,
+		source: Source
+	) -> Disposable? where Source.Value == Bool, Source.Error == NoError {
+		return target.reactive.isOn <~ source
+	}
+}
+
+extension UISwitch: BindingSourceProtocol {
+	public func observe(_ observer: Observer<Bool, NoError>, during lifetime: Lifetime) -> Disposable? {
+		return reactive.isOnValues.take(during: lifetime).observe(observer)
+	}
+}

--- a/ReactiveCocoaTests/AppKit/NSControlSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSControlSpec.swift
@@ -33,6 +33,18 @@ class NSControlSpec: QuickSpec {
 				expect(_control).to(beNil())
 			}
 
+			it("should not result in ambiguous reference") {
+				control <~ MutableProperty<String>("")
+				control <~ MutableProperty<NSAttributedString>(NSAttributedString())
+				control <~ MutableProperty<Bool>(false)
+				control <~ MutableProperty<Int32>(0)
+				control <~ MutableProperty<Int>(0)
+				control <~ MutableProperty<Double>(0.0)
+				control <~ MutableProperty<Float>(0.0)
+				control <~ MutableProperty<Any>(0)
+				control <~ MutableProperty<Any?>(nil)
+			}
+
 			it("should emit changes in Int") {
 				var values = [Int]()
 				control.reactive.integerValues.observeValues { values.append($0) }

--- a/ReactiveCocoaTests/UIKit/UIActivityIndicatorViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIActivityIndicatorViewSpec.swift
@@ -19,6 +19,10 @@ class UIActivityIndicatorSpec: QuickSpec {
 			expect(_activityIndicatorView).to(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			activityIndicatorView <~ MutableProperty(false)
+		}
+
 		it("should accept changes from bindings to its animating state") {
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
 			activityIndicatorView.reactive.isAnimating <~ SignalProducer(pipeSignal)

--- a/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
@@ -19,7 +19,7 @@ class UIBarButtonItemSpec: QuickSpec {
 			barButtonItem = nil
 			expect(_barButtonItem).to(beNil())
 		}
-
+		
 		it("should not be retained with the presence of a `pressed` action") {
 			let action = Action<(),(),NoError> { SignalProducer(value: ()) }
 			barButtonItem.reactive.pressed = CocoaAction(action)

--- a/ReactiveCocoaTests/UIKit/UIDatePickerSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIDatePickerSpec.swift
@@ -24,6 +24,13 @@ class UIDatePickerSpec: QuickSpec {
 			expect(_picker).to(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			MutableProperty(Date()) <~ picker
+			MutableProperty<Date?>(nil) <~ picker
+
+			picker <~ MutableProperty(Date())
+		}
+
 		it("should accept changes from bindings to its date value") {
 			picker.reactive.date.consume(date)
 			expect(picker.date) == date

--- a/ReactiveCocoaTests/UIKit/UIImageViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIImageViewSpec.swift
@@ -20,6 +20,11 @@ class UIImageViewSpec: QuickSpec {
 			expect(_imageView).to(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			imageView <~ MutableProperty(UIImage())
+			imageView <~ MutableProperty<UIImage?>(nil)
+		}
+
 		it("should accept changes from bindings to its displaying image") {
 			let firstChange = UIImage()
 			let secondChange = UIImage()

--- a/ReactiveCocoaTests/UIKit/UIProgressViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIProgressViewSpec.swift
@@ -20,6 +20,10 @@ class UIProgressViewSpec: QuickSpec {
 			expect(_progressView).to(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			progressView <~ MutableProperty<Float>(0.0)
+		}
+
 		it("should accept changes from bindings to its progress value") {
 			let firstChange: Float = 0.5
 			let secondChange: Float = 0.0

--- a/ReactiveCocoaTests/UIKit/UISegmentedControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISegmentedControlSpec.swift
@@ -6,6 +6,13 @@ import Result
 
 class UISegmentedControlSpec: QuickSpec {
 	override func spec() {
+		it("should not result in ambiguous reference") {
+			let s = UISegmentedControl(items: ["0", "1", "2"])
+
+			MutableProperty<Int>(0) <~ s
+			s <~ MutableProperty<Int>(1)
+		}
+
 		it("should accept changes from bindings to its selected segment index") {
 			let s = UISegmentedControl(items: ["0", "1", "2"])
 			s.selectedSegmentIndex = UISegmentedControlNoSegment

--- a/ReactiveCocoaTests/UIKit/UISliderSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISliderSpec.swift
@@ -20,6 +20,13 @@ class UISliderSpec: QuickSpec {
 			expect(_slider).to(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			MutableProperty(0.0) <~ slider
+			MutableProperty<Float?>(nil) <~ slider
+			
+			slider <~ MutableProperty<Float>(0.0)
+		}
+
 		it("should accept changes from bindings to its value") {
 			expect(slider.value) == 0.0
 

--- a/ReactiveCocoaTests/UIKit/UIStepperSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIStepperSpec.swift
@@ -20,6 +20,12 @@ class UIStepperSpec: QuickSpec {
 			expect(_stepper).to(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			MutableProperty(0.0) <~ stepper
+			MutableProperty<Double?>(nil) <~ stepper
+			stepper <~ MutableProperty<Double>(0.0)
+		}
+
 		it("should accept changes from bindings to its value") {
 			expect(stepper.value) == 0.0
 

--- a/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
@@ -19,6 +19,13 @@ class UISwitchSpec: QuickSpec {
 			expect(_toggle).to(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			MutableProperty(false) <~ toggle
+			MutableProperty<Bool?>(nil) <~ toggle
+
+			toggle <~ MutableProperty<Bool>(true)
+		}
+
 		it("should accept changes from bindings to its `isOn` state") {
 			toggle.isOn = false
 

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -1,5 +1,6 @@
 import ReactiveSwift
 import ReactiveCocoa
+import Foundation
 import UIKit
 import Quick
 import Nimble
@@ -22,6 +23,15 @@ class UITextFieldSpec: QuickSpec {
 				textField = nil
 			}
 			expect(_textField).to(beNil())
+		}
+
+		it("should not result in ambiguous reference") {
+			MutableProperty<String?>(nil) <~ textField
+
+			textField <~ MutableProperty<String>("")
+			textField <~ MutableProperty<String?>("")
+			textField <~ MutableProperty(NSAttributedString())
+			textField <~ MutableProperty<NSAttributedString?>(nil)
 		}
 
 		it("should emit user initiated changes to its text value when the editing ends") {

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -28,6 +28,15 @@ class UITextViewSpec: QuickSpec {
 			expect(_textView).toEventually(beNil())
 		}
 
+		it("should not result in ambiguous reference") {
+			MutableProperty<String?>(nil) <~ textView
+
+			textView <~ MutableProperty<String>("")
+			textView <~ MutableProperty<String?>("")
+			textView <~ MutableProperty(NSAttributedString())
+			textView <~ MutableProperty<NSAttributedString?>(nil)
+		}
+
 		it("should emit user initiated changes to its text value when the editing ends") {
 			textView.text = "Test"
 


### PR DESCRIPTION
#3263 

Allow types to be used directly in a unidirectional binding, by declaring a default binding target and a default signal.

```
myLabel <~ viewModel.title
viewModel.searchString <~ myTextField
```

--

It seems bad in terms of discoverability & local reasoning though. Makes me wonder if an operator would be a better alternative, e.g. `myLabel%.text`