### PR TITLE
Add attributedText binding target to UITextView and UITextField

### DIFF
--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -7,11 +7,6 @@ extension Reactive where Base: UITextField {
 	public var text: BindingTarget<String?> {
 		return makeBindingTarget { $0.text = $1 }
 	}
-	
-	/// Sets the attributed text of the text field.
-	public var attributedText: BindingTarget<NSAttributedString?> {
-		return makeBindingTarget { $0.attributedText = $1 }
-	}
 
 	/// A signal of text values emitted by the text field upon end of editing.
 	///
@@ -28,5 +23,27 @@ extension Reactive where Base: UITextField {
 	public var continuousTextValues: Signal<String?, NoError> {
 		return trigger(for: .editingChanged)
 			.map { [unowned base = self.base] in base.text }
+	}
+	
+	/// Sets the attributed text of the text field.
+	public var attributedText: BindingTarget<NSAttributedString?> {
+		return makeBindingTarget { $0.attributedText = $1 }
+	}
+	
+	/// A signal of attributed text values emitted by the text field upon end of editing.
+	///
+	/// - note: To observe attributed text values that change on all editing events,
+	///   see `continuousAttributedTextValues`.
+	public var attributedTextValues: Signal<NSAttributedString?, NoError> {
+		return trigger(for: .editingDidEnd)
+			.map { [unowned base = self.base] in base.attributedText }
+	}
+	
+	/// A signal of attributed text values emitted by the text field upon any changes.
+	///
+	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
+	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
+		return trigger(for: .editingDidEnd)
+			.map { [unowned base = self.base] in base.attributedText }
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -7,6 +7,11 @@ extension Reactive where Base: UITextField {
 	public var text: BindingTarget<String?> {
 		return makeBindingTarget { $0.text = $1 }
 	}
+	
+	/// Sets the attributed text of the text field.
+	public var attributedText: BindingTarget<NSAttributedString?> {
+		return makeBindingTarget { $0.attributedText = $1 }
+	}
 
 	/// A signal of text values emitted by the text field upon end of editing.
 	///

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -43,7 +43,7 @@ extension Reactive where Base: UITextField {
 	///
 	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
 	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
-		return trigger(for: .editingDidEnd)
+		return trigger(for: .editingChanged)
 			.map { [unowned base = self.base] in base.attributedText }
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -20,14 +20,14 @@ extension Reactive where Base: UITextView {
 	///
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
-	public var textValues: Signal<String, NoError> {
+	public var textValues: Signal<String?, NoError> {
 		return textValues(forName: .UITextViewTextDidEndEditing)
 	}
 
 	/// A signal of text values emitted by the text view upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
-	public var continuousTextValues: Signal<String, NoError> {
+	public var continuousTextValues: Signal<String?, NoError> {
 		return textValues(forName: .UITextViewTextDidChange)
 	}
 	

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -9,7 +9,7 @@ extension Reactive where Base: UITextView {
 	}
 	
 	/// Sets the attributed text of the text view.
-	public var attributedText: BindingTarget<NSAttributedString> {
+	public var attributedText: BindingTarget<NSAttributedString?> {
 		return makeBindingTarget { $0.attributedText = $1 }
 	}
 

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -8,7 +8,7 @@ extension Reactive where Base: UITextView {
 		return makeBindingTarget { $0.text = $1 }
 	}
 
-	private func textValues(forName name: NSNotification.Name) -> Signal<String, NoError> {
+	private func textValues(forName name: NSNotification.Name) -> Signal<String?, NoError> {
 		return NotificationCenter.default
 			.reactive
 			.notifications(forName: name, object: base)
@@ -55,7 +55,7 @@ extension Reactive where Base: UITextView {
 	/// A signal of attributed text values emitted by the text view upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `attributedTextValues`.
-	public var attributedContinuousTextValues: Signal<NSAttributedString?, NoError> {
+	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
 		return attributedTextValues(forName: .UITextViewTextDidChange)
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -7,6 +7,11 @@ extension Reactive where Base: UITextView {
 	public var text: BindingTarget<String> {
 		return makeBindingTarget { $0.text = $1 }
 	}
+	
+	/// Sets the attributed text of the text view.
+	public var attributedText: BindingTarget<NSAttributedString> {
+		return makeBindingTarget { $0.attributedText = $1 }
+	}
 
 	private func textValues(forName name: NSNotification.Name) -> Signal<String, NoError> {
 		return NotificationCenter.default

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -7,11 +7,6 @@ extension Reactive where Base: UITextView {
 	public var text: BindingTarget<String?> {
 		return makeBindingTarget { $0.text = $1 }
 	}
-	
-	/// Sets the attributed text of the text view.
-	public var attributedText: BindingTarget<NSAttributedString?> {
-		return makeBindingTarget { $0.attributedText = $1 }
-	}
 
 	private func textValues(forName name: NSNotification.Name) -> Signal<String, NoError> {
 		return NotificationCenter.default
@@ -34,5 +29,33 @@ extension Reactive where Base: UITextView {
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String, NoError> {
 		return textValues(forName: .UITextViewTextDidChange)
+	}
+	
+	/// Sets the attributed text of the text view.
+	public var attributedText: BindingTarget<NSAttributedString?> {
+		return makeBindingTarget { $0.attributedText = $1 }
+	}
+	
+	private func attributedTextValues(forName name: NSNotification.Name) -> Signal<String, NoError> {
+		return NotificationCenter.default
+			.reactive
+			.notifications(forName: name, object: base)
+			.take(during: lifetime)
+			.map { ($0.object as! UITextView).attributedText! }
+	}
+	
+	/// A signal of attributed text values emitted by the text view upon end of editing.
+	///
+	/// - note: To observe attributed text values that change on all editing events,
+	///   see `continuousAttributedTextValues`.
+	public var attributedTextValues: Signal<NSAttributedString?, NoError> {
+		return attributedTextValues(forName: .UITextViewTextDidEndEditing)
+	}
+	
+	/// A signal of attributed text values emitted by the text view upon any changes.
+	///
+	/// - note: To observe text values only when editing ends, see `attributedTextValues`.
+	public var attributedContinuousTextValues: Signal<NSAttributedString?, NoError> {
+		return attributedTextValues(forName: .UITextViewTextDidChange)
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -4,7 +4,7 @@ import enum Result.NoError
 
 extension Reactive where Base: UITextView {
 	/// Sets the text of the text view.
-	public var text: BindingTarget<String> {
+	public var text: BindingTarget<String?> {
 		return makeBindingTarget { $0.text = $1 }
 	}
 	

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -36,7 +36,7 @@ extension Reactive where Base: UITextView {
 		return makeBindingTarget { $0.attributedText = $1 }
 	}
 	
-	private func attributedTextValues(forName name: NSNotification.Name) -> Signal<String, NoError> {
+	private func attributedTextValues(forName name: NSNotification.Name) -> Signal<NSAttributedString?, NoError> {
 		return NotificationCenter.default
 			.reactive
 			.notifications(forName: name, object: base)

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -3,6 +3,7 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
+import enum Result.NoError
 
 class UITextFieldSpec: QuickSpec {
 	override func spec() {

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -58,10 +58,10 @@ class UITextFieldSpec: QuickSpec {
 			textField.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
 			
 			observer.send(value: firstChange)
-			expect(textField.attributedText) == firstChange
+			expect(textField.attributedText?.string) == firstChange.string
 			
 			observer.send(value: secondChange)
-			expect(textField.attributedText) == secondChange
+			expect(textField.attributedText?.string) == secondChange.string
 		}
 		
 		it("should emit user initiated changes to its attributed text value when the editing ends") {
@@ -85,7 +85,7 @@ class UITextFieldSpec: QuickSpec {
 			}
 			
 			textField.sendActions(for: .editingChanged)
-			expect(latestValue) == textField.attributedText
+			expect(latestValue?.string) == textField.attributedText?.string
 		}
 	}
 }

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -22,6 +22,22 @@ class UITextFieldSpec: QuickSpec {
 			}
 			expect(_textField).to(beNil())
 		}
+		
+		it("should accept changes from bindings to its attributed text value") {
+			let firstChange = NSAttributedString(string: "first")
+			let secondChange = NSAttributedString(string: "second")
+			
+			textField.attributedText = NSAttributedString(string: "")
+			
+			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			textField.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+			
+			observer.send(value: firstChange)
+			expect(textField.attributedText) == firstChange
+			
+			observer.send(value: secondChange)
+			expect(textField.attributedText) == secondChange
+		}
 
 		it("should emit user initiated changes to its text value when the editing ends") {
 			textField.text = "Test"

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -23,22 +23,6 @@ class UITextFieldSpec: QuickSpec {
 			}
 			expect(_textField).to(beNil())
 		}
-		
-		it("should accept changes from bindings to its attributed text value") {
-			let firstChange = NSAttributedString(string: "first")
-			let secondChange = NSAttributedString(string: "second")
-			
-			textField.attributedText = NSAttributedString(string: "")
-			
-			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
-			textField.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
-			
-			observer.send(value: firstChange)
-			expect(textField.attributedText) == firstChange
-			
-			observer.send(value: secondChange)
-			expect(textField.attributedText) == secondChange
-		}
 
 		it("should emit user initiated changes to its text value when the editing ends") {
 			textField.text = "Test"
@@ -62,6 +46,46 @@ class UITextFieldSpec: QuickSpec {
 
 			textField.sendActions(for: .editingChanged)
 			expect(latestValue) == textField.text
+		}
+		
+		it("should accept changes from bindings to its attributed text value") {
+			let firstChange = NSAttributedString(string: "first")
+			let secondChange = NSAttributedString(string: "second")
+			
+			textField.attributedText = NSAttributedString(string: "")
+			
+			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			textField.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+			
+			observer.send(value: firstChange)
+			expect(textField.attributedText) == firstChange
+			
+			observer.send(value: secondChange)
+			expect(textField.attributedText) == secondChange
+		}
+		
+		it("should emit user initiated changes to its attributed text value when the editing ends") {
+			textField.attributedText = NSAttributedString(string: "Test")
+			
+			var latestValue: NSAttributedString?
+			textField.reactive.attributedTextValues.observeValues { attributedText in
+				latestValue = attributedText
+			}
+			
+			textField.sendActions(for: .editingDidEnd)
+			expect(latestValue) == textField.attributedText
+		}
+		
+		it("should emit user initiated changes to its attributed text value continuously") {
+			textField.attributedText = NSAttributedString(string: "Test")
+			
+			var latestValue: NSAttributedString?
+			textField.reactive.continuousAttributedTextValues.observeValues { attributedText in
+				latestValue = attributedText
+			}
+			
+			textField.sendActions(for: .editingChanged)
+			expect(latestValue) == textField.attributedText
 		}
 	}
 }

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -23,6 +23,22 @@ class UITextViewSpec: QuickSpec {
 				expect(_textView).toEventually(beNil())
 			}
 
+			it("should accept changes from bindings to its attributed text value") {
+				let firstChange = NSAttributedString(string: "first")
+				let secondChange = NSAttributedString(string: "second")
+				
+				textView.attributedText = NSAttributedString(string: "")
+				
+				let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+				textView.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+				
+				observer.send(value: firstChange)
+				expect(textView.attributedText) == firstChange
+				
+				observer.send(value: secondChange)
+				expect(textView.attributedText) == secondChange
+			}
+
 			it("should emit user initiated changes to its text value when the editing ends") {
 				textView.text = "Test"
 

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -10,10 +10,10 @@ class UITextViewSpec: QuickSpec {
 		var textView: UITextView!
 		weak var _textView: UITextView?
 		let attributes = [
-			NSFontAttributeName: UIFont(name: "Georgia", size: 18.0)!,
+			NSFontAttributeName: UIFont.systemFont(ofSize: 18),
 			NSForegroundColorAttributeName: UIColor.red
 		]
-
+		
 		beforeEach {
 			autoreleasepool {
 				textView = UITextView(frame: .zero)

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -24,22 +24,6 @@ class UITextViewSpec: QuickSpec {
 			expect(_textView).toEventually(beNil())
 		}
 
-		it("should accept changes from bindings to its attributed text value") {
-			let firstChange = NSAttributedString(string: "first")
-			let secondChange = NSAttributedString(string: "second")
-			
-			textView.attributedText = NSAttributedString(string: "")
-			
-			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
-			textView.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
-			
-			observer.send(value: firstChange)
-			expect(textView.attributedText) == firstChange
-			
-			observer.send(value: secondChange)
-			expect(textView.attributedText) == secondChange
-		}
-
 		it("should emit user initiated changes to its text value when the editing ends") {
 			textView.text = "Test"
 
@@ -64,6 +48,46 @@ class UITextViewSpec: QuickSpec {
 			NotificationCenter.default.post(name: .UITextViewTextDidChange,
 			object: textView)
 			expect(latestValue) == textView.text
+		}
+		
+		it("should accept changes from bindings to its attributed text value") {
+			let firstChange = NSAttributedString(string: "first")
+			let secondChange = NSAttributedString(string: "second")
+			
+			textView.attributedText = NSAttributedString(string: "")
+			
+			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			textView.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+			
+			observer.send(value: firstChange)
+			expect(textView.attributedText) == firstChange
+			
+			observer.send(value: secondChange)
+			expect(textView.attributedText) == secondChange
+		}
+		
+		it("should emit user initiated changes to its attributed text value when the editing ends") {
+			textView.attributedText = NSAttributedString(string: "Test")
+			
+			var latestValue: NSAttributedString?
+			textView.reactive.attributedTextValues.observeValues { attributedText in
+				latestValue = attributedText
+			}
+			
+			textView.sendActions(for: .editingDidEnd)
+			expect(latestValue) == textView.attributedText
+		}
+		
+		it("should emit user initiated changes to its attributed text value continuously") {
+			textView.attributedText = NSAttributedString(string: "Test")
+			
+			var latestValue: NSAttributedString?
+			textView.reactive.continuousAttributedTextValues.observeValues { attributedText in
+				latestValue = attributedText
+			}
+			
+			textView.sendActions(for: .editingChanged)
+			expect(latestValue) == textView.attributedText
 		}
 	}
 }

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -3,66 +3,67 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
+import enum Result.NoError
 
 class UITextViewSpec: QuickSpec {
 	override func spec() {
-			var textView: UITextView!
-			weak var _textView: UITextView?
+		var textView: UITextView!
+		weak var _textView: UITextView?
 
-			beforeEach {
-				autoreleasepool {
-					textView = UITextView(frame: .zero)
-					_textView = textView
-				}
+		beforeEach {
+			autoreleasepool {
+				textView = UITextView(frame: .zero)
+				_textView = textView
+			}
+		}
+
+		afterEach {
+			autoreleasepool {
+				textView = nil
+			}
+			expect(_textView).toEventually(beNil())
+		}
+
+		it("should accept changes from bindings to its attributed text value") {
+			let firstChange = NSAttributedString(string: "first")
+			let secondChange = NSAttributedString(string: "second")
+			
+			textView.attributedText = NSAttributedString(string: "")
+			
+			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			textView.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+			
+			observer.send(value: firstChange)
+			expect(textView.attributedText) == firstChange
+			
+			observer.send(value: secondChange)
+			expect(textView.attributedText) == secondChange
+		}
+
+		it("should emit user initiated changes to its text value when the editing ends") {
+			textView.text = "Test"
+
+			var latestValue: String?
+			textView.reactive.textValues.observeValues { text in
+			latestValue = text
 			}
 
-			afterEach {
-				autoreleasepool {
-					textView = nil
-				}
-				expect(_textView).toEventually(beNil())
+			NotificationCenter.default.post(name: .UITextViewTextDidEndEditing,
+			object: textView)
+			expect(latestValue) == textView.text
+		}
+
+		it("should emit user initiated changes to its text value continuously") {
+			textView.text = "Test"
+
+			var latestValue: String?
+				textView.reactive.continuousTextValues.observeValues { text in
+					latestValue = text
 			}
 
-			it("should accept changes from bindings to its attributed text value") {
-				let firstChange = NSAttributedString(string: "first")
-				let secondChange = NSAttributedString(string: "second")
-				
-				textView.attributedText = NSAttributedString(string: "")
-				
-				let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
-				textView.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
-				
-				observer.send(value: firstChange)
-				expect(textView.attributedText) == firstChange
-				
-				observer.send(value: secondChange)
-				expect(textView.attributedText) == secondChange
-			}
-
-			it("should emit user initiated changes to its text value when the editing ends") {
-				textView.text = "Test"
-
-				var latestValue: String?
-				textView.reactive.textValues.observeValues { text in
-				latestValue = text
-				}
-
-				NotificationCenter.default.post(name: .UITextViewTextDidEndEditing,
-				object: textView)
-				expect(latestValue) == textView.text
-			}
-
-			it("should emit user initiated changes to its text value continuously") {
-				textView.text = "Test"
-
-				var latestValue: String?
-					textView.reactive.continuousTextValues.observeValues { text in
-						latestValue = text
-				}
-
-				NotificationCenter.default.post(name: .UITextViewTextDidChange,
-				object: textView)
-				expect(latestValue) == textView.text
+			NotificationCenter.default.post(name: .UITextViewTextDidChange,
+			object: textView)
+			expect(latestValue) == textView.text
 		}
 	}
 }

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -29,11 +29,10 @@ class UITextViewSpec: QuickSpec {
 
 			var latestValue: String?
 			textView.reactive.textValues.observeValues { text in
-			latestValue = text
+				latestValue = text
 			}
 
-			NotificationCenter.default.post(name: .UITextViewTextDidEndEditing,
-			object: textView)
+			NotificationCenter.default.post(name: .UITextViewTextDidEndEditing, object: textView)
 			expect(latestValue) == textView.text
 		}
 
@@ -41,8 +40,8 @@ class UITextViewSpec: QuickSpec {
 			textView.text = "Test"
 
 			var latestValue: String?
-				textView.reactive.continuousTextValues.observeValues { text in
-					latestValue = text
+			textView.reactive.continuousTextValues.observeValues { text in
+				latestValue = text
 			}
 
 			NotificationCenter.default.post(name: .UITextViewTextDidChange,

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -9,6 +9,10 @@ class UITextViewSpec: QuickSpec {
 	override func spec() {
 		var textView: UITextView!
 		weak var _textView: UITextView?
+		let attributes = [
+			NSFontAttributeName: UIFont(name: "Georgia", size: 18.0)!,
+			NSForegroundColorAttributeName: UIColor.red
+		]
 
 		beforeEach {
 			autoreleasepool {
@@ -44,14 +48,13 @@ class UITextViewSpec: QuickSpec {
 				latestValue = text
 			}
 
-			NotificationCenter.default.post(name: .UITextViewTextDidChange,
-			object: textView)
+			NotificationCenter.default.post(name: .UITextViewTextDidChange, object: textView)
 			expect(latestValue) == textView.text
 		}
 		
 		it("should accept changes from bindings to its attributed text value") {
-			let firstChange = NSAttributedString(string: "first")
-			let secondChange = NSAttributedString(string: "second")
+			let firstChange = NSAttributedString(string: "first", attributes: attributes)
+			let secondChange = NSAttributedString(string: "second", attributes: attributes)
 			
 			textView.attributedText = NSAttributedString(string: "")
 			
@@ -66,26 +69,26 @@ class UITextViewSpec: QuickSpec {
 		}
 		
 		it("should emit user initiated changes to its attributed text value when the editing ends") {
-			textView.attributedText = NSAttributedString(string: "Test")
+			textView.attributedText = NSAttributedString(string: "Test", attributes: attributes)
 			
 			var latestValue: NSAttributedString?
 			textView.reactive.attributedTextValues.observeValues { attributedText in
 				latestValue = attributedText
 			}
 			
-			textView.sendActions(for: .editingDidEnd)
+			NotificationCenter.default.post(name: .UITextViewTextDidEndEditing, object: textView)
 			expect(latestValue) == textView.attributedText
 		}
 		
 		it("should emit user initiated changes to its attributed text value continuously") {
-			textView.attributedText = NSAttributedString(string: "Test")
+			textView.attributedText = NSAttributedString(string: "Test", attributes: attributes)
 			
 			var latestValue: NSAttributedString?
 			textView.reactive.continuousAttributedTextValues.observeValues { attributedText in
 				latestValue = attributedText
 			}
 			
-			textView.sendActions(for: .editingChanged)
+			NotificationCenter.default.post(name: .UITextViewTextDidChange, object: textView)
 			expect(latestValue) == textView.attributedText
 		}
 	}


### PR DESCRIPTION
very simple attributedText binding target for `UITextView` and `UITextField`.