### PR TITLE
Fix possible DynamicProperty crash when incorrect value is passed

### DIFF
--- a/ReactiveCocoa/DynamicProperty.swift
+++ b/ReactiveCocoa/DynamicProperty.swift
@@ -37,7 +37,13 @@ public final class DynamicProperty<Value>: MutablePropertyProtocol {
 	///              Most UI controls are not!
 	public var producer: SignalProducer<Value?, NoError> {
 		return (object.map { $0.reactive.values(forKeyPath: keyPath) } ?? .empty)
-			.map { $0 as! Value }
+			.map {
+				guard let value = $0 as? Value else {
+					assertionFailure("Expected value to be \(Value.self), but \(type(of: $0)) found.")
+					return nil
+				}
+				return value
+		}
 	}
 
 	public private(set) lazy var signal: Signal<Value?, NoError> = {


### PR DESCRIPTION
I've been wondering why `DynamicProperty<Value>` uses producer and signal of type `Value?` and `signal`. I've been digging into its implementation and I assume the force cast to `Value` useless as it should return an optional value.

I thought whether its appropriate to return optional value and IMO it is correct as KVO compliant values will always be of type `Any`. But in case that incorrect value is passed I think that as a developer I want to know about it, but in production code I'd prefer the app not to crash. That's the reason for the assertion.