### PR TITLE
Send the UIControl sender for each control event

### DIFF
--- a/ReactiveCocoa/UIKit/UIControl.swift
+++ b/ReactiveCocoa/UIKit/UIControl.swift
@@ -35,20 +35,20 @@ extension Reactive where Base: UIControl {
 		}
 	}
 
-	/// Create a signal which sends a `next` event for each of the specified
+	/// Create a signal which sends a `value` event for each of the specified
 	/// control events.
 	///
 	/// - parameters:
 	///   - controlEvents: The control event mask.
 	///
 	/// - returns:
-	///   A trigger signal.
-	public func trigger(for controlEvents: UIControlEvents) -> Signal<(), NoError> {
+	///   A signal that sends the control each time the control event occurs.
+	public func controlEvents(_ controlEvents: UIControlEvents) -> Signal<Base, NoError> {
 		return Signal { observer in
-			let receiver = CocoaTarget(observer)
+			let receiver = CocoaTarget(observer) { $0 as! Base }
 			base.addTarget(receiver,
-			                   action: #selector(receiver.sendNext),
-			                   for: controlEvents)
+			               action: #selector(receiver.sendNext),
+			               for: controlEvents)
 
 			let disposable = lifetime.ended.observeCompleted(observer.sendCompleted)
 
@@ -60,6 +60,11 @@ extension Reactive where Base: UIControl {
 				                   for: controlEvents)
 			}
 		}
+	}
+
+	@available(*, unavailable, renamed: "controlEvents(_:)")
+	public func trigger(for controlEvents: UIControlEvents) -> Signal<(), NoError> {
+		fatalError()
 	}
 
 	/// Sets whether the control is enabled.

--- a/ReactiveCocoa/UIKit/UISegmentedControl.swift
+++ b/ReactiveCocoa/UIKit/UISegmentedControl.swift
@@ -10,7 +10,6 @@ extension Reactive where Base: UISegmentedControl {
 
 	/// A signal of indexes of selections emitted by the segmented control.
 	public var selectedSegmentIndexes: Signal<Int, NoError> {
-		return trigger(for: .valueChanged)
-			.map { [unowned base = self.base] in base.selectedSegmentIndex }
+		return controlEvents(.valueChanged).map { $0.selectedSegmentIndex }
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -13,16 +13,14 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
-		return trigger(for: .editingDidEnd)
-			.map { [unowned base = self.base] in base.text }
+		return controlEvents(.editingDidEnd).map { $0.text }
 	}
 
 	/// A signal of text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {
-		return trigger(for: .editingChanged)
-			.map { [unowned base = self.base] in base.text }
+		return controlEvents(.editingChanged).map { $0.text }
 	}
 	
 	/// Sets the attributed text of the text field.
@@ -35,15 +33,13 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe attributed text values that change on all editing events,
 	///   see `continuousAttributedTextValues`.
 	public var attributedTextValues: Signal<NSAttributedString?, NoError> {
-		return trigger(for: .editingDidEnd)
-			.map { [unowned base = self.base] in base.attributedText }
+		return controlEvents(.editingDidEnd).map { $0.attributedText }
 	}
 	
 	/// A signal of attributed text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
 	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
-		return trigger(for: .editingChanged)
-			.map { [unowned base = self.base] in base.attributedText }
+		return controlEvents(.editingChanged).map { $0.attributedText }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
@@ -10,7 +10,6 @@ extension Reactive where Base: UIDatePicker {
 
 	/// A signal of dates emitted by the date picker.
 	public var dates: Signal<Date, NoError> {
-		return trigger(for: .valueChanged)
-			.map { [unowned base = self.base] in base.date }
+		return controlEvents(.valueChanged).map { $0.date }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISlider.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISlider.swift
@@ -25,7 +25,6 @@ extension Reactive where Base: UISlider {
 	/// - note: If slider's `isContinuous` property is `false` then values are
 	///         sent only when user releases the slider.
 	public var values: Signal<Float, NoError> {
-		return trigger(for: .valueChanged)
-			.map { [unowned base = self.base] in base.value }
+		return controlEvents(.valueChanged).map { $0.value }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIStepper.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIStepper.swift
@@ -22,7 +22,6 @@ extension Reactive where Base: UIStepper {
 	/// A signal of double values emitted by the stepper upon each user's
 	/// interaction.
 	public var values: Signal<Double, NoError> {
-		return trigger(for: .valueChanged)
-			.map { [unowned base = self.base] in base.value }
+		return controlEvents(.valueChanged).map { $0.value }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISwitch.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISwitch.swift
@@ -10,7 +10,6 @@ extension Reactive where Base: UISwitch {
 
 	/// A signal of on-off states in `Bool` emitted by the switch.
 	public var isOnValues: Signal<Bool, NoError> {
-		return trigger(for: .valueChanged)
-			.map { [unowned base = self.base] in base.isOn }
+		return controlEvents(.valueChanged).map { $0.isOn }
 	}
 }


### PR DESCRIPTION
Changes `Reactive<UIControl>.trigger(for:)` to emit the control itself for each value, and as it is no longer just a trigger signal, renames it `controlEvents(_:)`.

Streamlines the definition of the various value-changed convenience signals, and removes the need to capture an extra unowned reference.