### PR TITLE
Fixed a `Lifetime` related KVO crash.

### DIFF
--- a/ReactiveCocoa/NSObject+Lifetime.swift
+++ b/ReactiveCocoa/NSObject+Lifetime.swift
@@ -15,10 +15,53 @@ extension Reactive where Base: NSObject {
 			let token = Lifetime.Token()
 			let lifetime = Lifetime(token)
 
+			let objcClass: AnyClass = (base as AnyObject).objcClass
+			let deallocSelector = sel_registerName("dealloc")!
+
+			// Swizzle `-dealloc` so that the lifetime token is released at the
+			// beginning of the deallocation chain, and only after the KVO `-dealloc`.
+			objc_sync_enter(objcClass)
+			if objc_getAssociatedObject(objcClass, &lifetimeKey) == nil {
+				objc_setAssociatedObject(objcClass, &lifetimeKey, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+				var existingImpl: IMP? = nil
+
+				let newImplBlock: @convention(block) (UnsafeRawPointer) -> Void = { objectRef in
+					_rac_objc_setAssociatedObject(objectRef, &lifetimeTokenKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+					let impl: IMP
+
+					if let existingImpl = existingImpl {
+						impl = existingImpl
+					} else {
+						let superclass: AnyClass = class_getSuperclass(objcClass)
+						impl = class_getMethodImplementation(superclass, deallocSelector)
+					}
+
+					typealias Impl = @convention(c) (UnsafeRawPointer, Selector) -> Void
+					unsafeBitCast(impl, to: Impl.self)(objectRef, deallocSelector)
+				}
+
+				let newImpl =  imp_implementationWithBlock(newImplBlock as Any)
+
+				if !class_addMethod(objcClass, deallocSelector, newImpl, "v@:") {
+					// The class has an existing `dealloc`. Preserve that as `existingImpl`.
+					let deallocMethod = class_getInstanceMethod(objcClass, deallocSelector)
+					existingImpl = method_getImplementation(deallocMethod)
+					existingImpl = method_setImplementation(deallocMethod, newImpl)
+				}
+			}
+			objc_sync_exit(objcClass)
+
 			objc_setAssociatedObject(base, &lifetimeTokenKey, token, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 			objc_setAssociatedObject(base, &lifetimeKey, lifetime, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
 			return lifetime
 		}
 	}
+}
+
+@objc private protocol ObjCClassReporting {
+	@objc(class)
+	var objcClass: AnyClass { get }
 }

--- a/ReactiveCocoa/RACObjCRuntimeUtilities.h
+++ b/ReactiveCocoa/RACObjCRuntimeUtilities.h
@@ -2,6 +2,8 @@
 #import <objc/runtime.h>
 
 NS_ASSUME_NONNULL_BEGIN
+/// A trampoline of `objc_setAssociatedObject` that is made to circumvent the
+/// reference counting calls in the imported version in Swift.
 void _rac_objc_setAssociatedObject(const void* object, const void* key, id _Nullable value, objc_AssociationPolicy policy);
 
 @interface NSObject (RACObjCRuntimeUtilities)

--- a/ReactiveCocoa/RACObjCRuntimeUtilities.h
+++ b/ReactiveCocoa/RACObjCRuntimeUtilities.h
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
+#import <objc/runtime.h>
 
 NS_ASSUME_NONNULL_BEGIN
+void _rac_objc_setAssociatedObject(const void* object, const void* key, id _Nullable value, objc_AssociationPolicy policy);
+
 @interface NSObject (RACObjCRuntimeUtilities)
 
 /// Register a block which would be triggered when `selector` is called.

--- a/ReactiveCocoa/RACObjCRuntimeUtilities.m
+++ b/ReactiveCocoa/RACObjCRuntimeUtilities.m
@@ -3,6 +3,11 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+void _rac_objc_setAssociatedObject(const void* object, const void* key, id value, objc_AssociationPolicy policy) {
+	__unsafe_unretained id obj = (__bridge typeof(obj)) object;
+	objc_setAssociatedObject(obj, key, value, policy);
+}
+
 NSString * const RACSelectorSignalErrorDomain = @"RACSelectorSignalErrorDomain";
 const NSInteger RACSelectorSignalErrorMethodSwizzlingRace = 1;
 const NSExceptionName RACSwizzleException = @"RACSwizzleException";

--- a/ReactiveCocoaTests/KeyValueObservingSpec.swift
+++ b/ReactiveCocoaTests/KeyValueObservingSpec.swift
@@ -154,6 +154,19 @@ class KeyValueObservingSpec: QuickSpec {
 				expect(weakOriginalInner).to(beNil())
 			}
 
+			describe("special tests") {
+				it("should not crash an Operation") {
+					// Related issue:
+					// https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3329
+					func invoke() {
+						let op = Operation()
+						op.reactive.values(forKeyPath: "isFinished").start()
+					}
+
+					invoke()
+				}
+			}
+
 			describe("thread safety") {
 				var testObject: ObservableObject!
 				var concurrentQueue: DispatchQueue!

--- a/ReactiveCocoaTests/KeyValueObservingSpec.swift
+++ b/ReactiveCocoaTests/KeyValueObservingSpec.swift
@@ -154,17 +154,15 @@ class KeyValueObservingSpec: QuickSpec {
 				expect(weakOriginalInner).to(beNil())
 			}
 
-			describe("special tests") {
-				it("should not crash an Operation") {
-					// Related issue:
-					// https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3329
-					func invoke() {
-						let op = Operation()
-						op.reactive.values(forKeyPath: "isFinished").start()
-					}
-
-					invoke()
+			it("should not crash an Operation") {
+				// Related issue:
+				// https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3329
+				func invoke() {
+					let op = Operation()
+					op.reactive.values(forKeyPath: "isFinished").start()
 				}
+
+				invoke()
 			}
 
 			describe("thread safety") {


### PR DESCRIPTION
Fixes #3329.

`Lifetime` deallocates too late in the deallocation chain - literally before KVO observation info is verified, and the memory is released. It _somehow_ causes issues when using the KVO API with `Operation`. So [let's follow ReactiveObjC and have `-dealloc` swizzled](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/580).

Implementation Notes
1. ~~`_racLifetimeNewDeallocImplementation` cannot be implemented in Swift AFAICT, as Swift does not respect the `__unsafe_unretained` label and would insert retain/release calls. While it does not matter in #3302, it messes with the ObjC deallocation chain in this case. `objc_msgSendSuper` also somehow does not behave as intended...~~
2. We need to know "perceived class" instead of the runtime real class, as KVO's `-dealloc` cannot be swizzled (somehow). `-class` is the thing, but it is unavailable in Swift. `type(of:)` returns the runtime subclasses. So the `AnyObject` message sending is used (also in #3302).
3. Managed to almost implement it completely in Swift, except that it needs a trampoline for `objc_setAssociatedObject` to avoid ARC retain and release on the object. Apparently when imported to Swift it has been wrapped with a thunk which inserted the calls.

The method can be moved to the runtime subclass after #3302 is landed.