### PR TITLE
Add reactive UISearchBar

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -184,6 +184,8 @@
 		BEE020661D637B0000DF261F /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B696FB801A7640C00075236D /* TestError.swift */; };
 		BFA6B94D1A7604D400C846D1 /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
 		BFA6B94E1A7604D500C846D1 /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
+		BFCF775F1DFAD8A50058006E /* UISearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF775E1DFAD8A50058006E /* UISearchBar.swift */; };
+		BFCF77621DFAD9440058006E /* UISearchBarSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF77601DFAD9120058006E /* UISearchBarSpec.swift */; };
 		CD0C45DE1CC9A288009F5BF0 /* DynamicProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */; };
 		CD0C45DF1CC9A288009F5BF0 /* DynamicProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */; };
 		CD0C45E01CC9A288009F5BF0 /* DynamicProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */; };
@@ -362,6 +364,8 @@
 		BE330A181D634F5900806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = "build/Debug-appletvos/ReactiveSwift.framework"; sourceTree = "<group>"; };
 		BE330A1A1D634F5F00806963 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = "build/Debug-appletvos/ReactiveSwift.framework"; sourceTree = "<group>"; };
 		BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProducerNimbleMatchers.swift; sourceTree = "<group>"; };
+		BFCF775E1DFAD8A50058006E /* UISearchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISearchBar.swift; sourceTree = "<group>"; };
+		BFCF77601DFAD9120058006E /* UISearchBarSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISearchBarSpec.swift; sourceTree = "<group>"; };
 		CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicProperty.swift; sourceTree = "<group>"; };
 		CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaActionSpec.swift; sourceTree = "<group>"; };
 		CDC42E2E1AE7AB8B00965373 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -550,6 +554,7 @@
 				9A1D062B1D93EA7E00ACF44C /* UIImageViewSpec.swift */,
 				9A1D062C1D93EA7E00ACF44C /* UILabelSpec.swift */,
 				9A1D062D1D93EA7E00ACF44C /* UIProgressViewSpec.swift */,
+				BFCF77601DFAD9120058006E /* UISearchBarSpec.swift */,
 				9A1D062E1D93EA7E00ACF44C /* UISegmentedControlSpec.swift */,
 				53AC46CE1DD6FC0000C799E1 /* UISliderSpec.swift */,
 				531866F91DD7925600D1285F /* UIStepperSpec.swift */,
@@ -604,11 +609,12 @@
 			isa = PBXGroup;
 			children = (
 				9A1D05F21D93E9F100ACF44C /* UIDatePicker.swift */,
+				9AAD49871DED2C350068EC9B /* UIKeyboard.swift */,
+				3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */,
+				BFCF775E1DFAD8A50058006E /* UISearchBar.swift */,
 				53AC46CB1DD6F97400C799E1 /* UISlider.swift */,
 				531866F71DD7920400D1285F /* UIStepper.swift */,
 				9A1D05F71D93E9F100ACF44C /* UISwitch.swift */,
-				9AAD49871DED2C350068EC9B /* UIKeyboard.swift */,
-				3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -1200,6 +1206,7 @@
 				9A1D060D1D93EA0000ACF44C /* UITextField.swift in Sources */,
 				9A6AAA231DB8F51C0013AAEA /* ReusableComponents.swift in Sources */,
 				9A1D060E1D93EA0000ACF44C /* UITextView.swift in Sources */,
+				BFCF775F1DFAD8A50058006E /* UISearchBar.swift in Sources */,
 				9A1D06061D93EA0000ACF44C /* UIImageView.swift in Sources */,
 				9AF0EA761D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */,
 				CD0C45DF1CC9A288009F5BF0 /* DynamicProperty.swift in Sources */,
@@ -1239,6 +1246,7 @@
 			files = (
 				9A1D06581D93EA7E00ACF44C /* UIViewSpec.swift in Sources */,
 				9AAD498A1DED2F380068EC9B /* UIKeyboardSpec.swift in Sources */,
+				BFCF77621DFAD9440058006E /* UISearchBarSpec.swift in Sources */,
 				D0A2260F1A72F16D00D33B74 /* DynamicPropertySpec.swift in Sources */,
 				BFA6B94E1A7604D500C846D1 /* SignalProducerNimbleMatchers.swift in Sources */,
 				B696FB821A7640C00075236D /* TestError.swift in Sources */,

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -32,9 +32,9 @@ extension Reactive where Base: UISearchBar {
 
 	/// A signal of text values emitted by the search bar upon end of editing.
 	///
-	/// - important: Creating this `Signal` requires the reactive extension
-	///	  provider to become the `delegate` of the search bar. Setting your own 
-	///   `delegate` is not supported and will result in a runtime error.
+	/// - important: Creating this Signal will make the reactive extension
+	///   provider the delegate of the search bar. Setting your own delegate is
+	///   not supported and will result in a runtime error.
 	///
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
@@ -45,9 +45,9 @@ extension Reactive where Base: UISearchBar {
 
 	/// A signal of text values emitted by the search bar upon any changes.
 	///
-	/// - important: Creating this `Signal` requires the reactive extension
-	///	  provider to become the `delegate` of the search bar. Setting your own
-	///   `delegate` is not supported and will result in a runtime error.
+	/// - important: Creating this Signal will make the reactive extension 
+	///   provider the delegate of the search bar. Setting your own delegate is 
+	///   not supported and will result in a runtime error.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -1,0 +1,48 @@
+import ReactiveSwift
+import enum Result.NoError
+import UIKit
+
+private class ReactiveUISearchBarDelegate: NSObject, UISearchBarDelegate {
+
+	@objc func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {}
+	@objc func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {}
+}
+
+private var delegateKey: UInt8 = 0
+
+extension Reactive where Base: UISearchBar {
+
+	private var delegate: ReactiveUISearchBarDelegate {
+		if let delegate = objc_getAssociatedObject(base, &delegateKey) as? ReactiveUISearchBarDelegate {
+			return delegate
+		}
+
+		let delegate = ReactiveUISearchBarDelegate()
+		base.delegate = delegate
+		objc_setAssociatedObject(base, &delegateKey, delegate, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+		return delegate
+	}
+
+	/// Sets the text of the search bar.
+	public var text: BindingTarget<String?> {
+		return makeBindingTarget { $0.text = $1 }
+	}
+
+	/// A signal of text values emitted by the search bar upon end of editing.
+	///
+	/// - note: To observe text values that change on all editing events,
+	///   see `continuousTextValues`.
+	public var textValues: Signal<String?, NoError> {
+		return delegate.reactive.trigger(for: #selector(UISearchBarDelegate.searchBarTextDidEndEditing))
+			.map { [unowned base] in base.text }
+	}
+
+	/// A signal of text values emitted by the search bar upon any changes.
+	///
+	/// - note: To observe text values only when editing ends, see `textValues`.
+	public var continuousTextValues: Signal<String?, NoError> {
+		return delegate.reactive.trigger(for: #selector(UISearchBarDelegate.searchBar(_:textDidChange:)))
+			.map { [unowned base] in base.text }
+	}
+	
+}

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -15,6 +15,8 @@ extension Reactive where Base: UISearchBar {
 	private var delegate: ReactiveUISearchBarDelegate {
 		if let delegate = objc_getAssociatedObject(base, &delegateKey) as? ReactiveUISearchBarDelegate {
 			return delegate
+		} else if let _ = base.delegate {
+			fatalError("Cannot use reactive values on UISearchBar with a custom delegate!")
 		}
 
 		let delegate = ReactiveUISearchBarDelegate()
@@ -30,6 +32,10 @@ extension Reactive where Base: UISearchBar {
 
 	/// A signal of text values emitted by the search bar upon end of editing.
 	///
+	/// - important: Creating this `Signal` requires the reactive extension
+	///	  provider to become the `delegate` of the search bar. Setting your own 
+	///   `delegate` is not supported and will result in a runtime error.
+	///
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
@@ -38,6 +44,10 @@ extension Reactive where Base: UISearchBar {
 	}
 
 	/// A signal of text values emitted by the search bar upon any changes.
+	///
+	/// - important: Creating this `Signal` requires the reactive extension
+	///	  provider to become the `delegate` of the search bar. Setting your own
+	///   `delegate` is not supported and will result in a runtime error.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {

--- a/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
@@ -1,0 +1,69 @@
+import ReactiveSwift
+import ReactiveCocoa
+import UIKit
+import Quick
+import Nimble
+import enum Result.NoError
+
+class UISearchBarSpec: QuickSpec {
+	override func spec() {
+		var searchBar: UISearchBar!
+		weak var _searchBar: UISearchBar?
+
+
+		beforeEach {
+			autoreleasepool {
+				searchBar = UISearchBar(frame: .zero)
+				_searchBar = searchBar
+			}
+		}
+
+		afterEach {
+			autoreleasepool {
+				searchBar = nil
+			}
+			expect(_searchBar).toEventually(beNil())
+		}
+
+		it("should accept changes from bindings to its text value") {
+			let firstChange = "first"
+			let secondChange = "second"
+
+			searchBar.text = ""
+
+			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			searchBar.reactive.text <~ SignalProducer(signal: pipeSignal)
+
+			observer.send(value: firstChange)
+			expect(searchBar.text) == firstChange
+
+			observer.send(value: secondChange)
+			expect(searchBar.text) == secondChange
+		}
+
+		it("should emit user initiated changes to its text value when the editing ends") {
+			searchBar.text = "Test"
+
+			var latestValue: String?
+			searchBar.reactive.textValues.observeValues { text in
+				latestValue = text
+			}
+
+			searchBar.delegate!.searchBarTextDidEndEditing!(searchBar)
+
+			expect(latestValue) == searchBar.text
+		}
+
+		it("should emit user initiated changes to its text value continuously") {
+			searchBar.text = "newValue"
+
+			var latestValue: String?
+			searchBar.reactive.continuousTextValues.observeValues { text in
+				latestValue = text
+			}
+
+			searchBar.delegate!.searchBar!(searchBar, textDidChange: "newValue")
+			expect(latestValue) == "newValue"
+		}
+	}
+}


### PR DESCRIPTION
`UISearchBar` supports a number of properties (and events via its delegate) – these are probably the minimum required:

- [x] Add `text` binding
- [x] Add `text` values signal
- [x] Add continuous `text` values signal



This requires becoming the delegate of the search bar, so this should probably be documented somewhere. 
