### PR TITLE
Update ReactiveSwift to 1.0.0-rc.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.1
+osx_image: xcode8.2
 before_install: true
 install: true
 git:
@@ -25,7 +25,8 @@ matrix:
       env:
         - XCODE_SDK=iphonesimulator
         - XCODE_ACTION="build-for-testing test-without-building"
-        - XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 6s"
+        - XCODE_DESTINATION="platform=iOS Simulator,id=31E6604A-19AA-4B68-B560-C33C584BC80D" # iPhone 6s, iOS 10.2
+#        - XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 6s,OS=10.2"
 #        - XCODE_PLAYGROUND_TARGET="x86_64-apple-ios9.3"
 #        - PLAYGROUND="ReactiveCocoa-iOS.playground"
     - xcode_scheme: ReactiveCocoa-tvOS

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.4"
+github "ReactiveCocoa/ReactiveSwift" "1.0.0-rc.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Quick/Nimble" "v5.1.1"
 github "Quick/Quick" "v1.0.0"
-github "antitypical/Result" "3.0.0"
+github "antitypical/Result" "3.1.0"
 github "jspahrsummers/xcconfigs" "3d9d99634cae6d586e272543d527681283b33eb0"
-github "ReactiveCocoa/ReactiveSwift" "1.0.0-alpha.4"
+github "ReactiveCocoa/ReactiveSwift" "1.0.0-rc.1"

--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -23,5 +23,5 @@ Pod::Spec.new do |s|
   s.watchos.exclude_files = "ReactiveCocoa/Shared/*.{swift}"
   s.module_map = "ReactiveCocoa/module.modulemap"
   
-  s.dependency 'ReactiveSwift', '~> 1.0.0-alpha.4'
+  s.dependency 'ReactiveSwift', '~> 1.0.0-rc.1'
 end

--- a/ReactiveCocoa/UIKit/UIBarButtonItem.swift
+++ b/ReactiveCocoa/UIKit/UIBarButtonItem.swift
@@ -3,7 +3,7 @@ import UIKit
 
 extension Reactive where Base: UIBarButtonItem {
 	/// The current associated action of `self`.
-	private var associatedAction: Atomic<(action: CocoaAction<Base>, disposable: Disposable)?> {
+	private var associatedAction: Atomic<(action: CocoaAction<Base>, disposable: Disposable?)?> {
 		return associatedValue { _ in Atomic(nil) }
 	}
 
@@ -23,7 +23,7 @@ extension Reactive where Base: UIBarButtonItem {
 						let disposable = isEnabled <~ action.isEnabled
 						return (action, disposable)
 				})?
-				.disposable.dispose()
+				.disposable?.dispose()
 		}
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIRefreshControl.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIRefreshControl.swift
@@ -25,7 +25,7 @@ extension Reactive where Base: UIRefreshControl {
 		}
 
 		nonmutating set {
-			let disposable = newValue.map { isRefreshing <~ $0.isExecuting }
+			let disposable = newValue.flatMap { isRefreshing <~ $0.isExecuting }
 			setAction(newValue, for: .valueChanged, disposable: disposable)
 		}
 	}

--- a/ReactiveCocoaTests/UIKit/UIActivityIndicatorViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIActivityIndicatorViewSpec.swift
@@ -21,7 +21,7 @@ class UIActivityIndicatorSpec: QuickSpec {
 
 		it("should accept changes from bindings to its animating state") {
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			activityIndicatorView.reactive.isAnimating <~ SignalProducer(signal: pipeSignal)
+			activityIndicatorView.reactive.isAnimating <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(activityIndicatorView.isAnimating) == true

--- a/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
@@ -27,7 +27,7 @@ class UIBarButtonItemSpec: QuickSpec {
 
 		it("should accept changes from bindings to its enabling state") {
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			barButtonItem.reactive.isEnabled <~ SignalProducer(signal: pipeSignal)
+			barButtonItem.reactive.isEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: false)
 			expect(barButtonItem.isEnabled) == false
@@ -38,7 +38,7 @@ class UIBarButtonItemSpec: QuickSpec {
 
 		it("should accept changes from bindings to its title") {
 			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
-			barButtonItem.reactive.title <~ SignalProducer(signal: pipeSignal)
+			barButtonItem.reactive.title <~ SignalProducer(pipeSignal)
 
 			observer.send(value: "title")
 			expect(barButtonItem.title) == "title"
@@ -49,7 +49,7 @@ class UIBarButtonItemSpec: QuickSpec {
 
 		it("should accept changes from bindings to its image") {
 			let (pipeSignal, observer) = Signal<UIImage?, NoError>.pipe()
-			barButtonItem.reactive.image <~ SignalProducer(signal: pipeSignal)
+			barButtonItem.reactive.image <~ SignalProducer(pipeSignal)
 
 			let image = UIImage()
 			expect(image).notTo(beNil())

--- a/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
@@ -25,7 +25,7 @@ class UIButtonSpec: QuickSpec {
 			let secondTitle = "Second title"
 
 			let (pipeSignal, observer) = Signal<String, NoError>.pipe()
-			button.reactive.title <~ SignalProducer(signal: pipeSignal)
+			button.reactive.title <~ SignalProducer(pipeSignal)
 			button.setTitle("", for: .selected)
 			button.setTitle("", for: .highlighted)
 
@@ -49,7 +49,7 @@ class UIButtonSpec: QuickSpec {
 				SignalProducer(value: true)
 			}
 
-			pressed <~ SignalProducer(signal: action.values)
+			pressed <~ SignalProducer(action.values)
 
 			button.reactive.pressed = CocoaAction(action)
 			expect(pressed.value) == false

--- a/ReactiveCocoaTests/UIKit/UIControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIControlSpec.swift
@@ -23,7 +23,7 @@ class UIControlSpec: QuickSpec {
 			control.isEnabled = false
 
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			control.reactive.isEnabled <~ SignalProducer(signal: pipeSignal)
+			control.reactive.isEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(control.isEnabled) == true
@@ -36,7 +36,7 @@ class UIControlSpec: QuickSpec {
 			control.isSelected = false
 
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			control.reactive.isSelected <~ SignalProducer(signal: pipeSignal)
+			control.reactive.isSelected <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(control.isSelected) == true
@@ -49,7 +49,7 @@ class UIControlSpec: QuickSpec {
 			control.isHighlighted = false
 
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			control.reactive.isHighlighted <~ SignalProducer(signal: pipeSignal)
+			control.reactive.isHighlighted <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(control.isHighlighted) == true
@@ -64,8 +64,8 @@ class UIControlSpec: QuickSpec {
 
 			let (pipeSignalSelected, observerSelected) = Signal<Bool, NoError>.pipe()
 			let (pipeSignalEnabled, observerEnabled) = Signal<Bool, NoError>.pipe()
-			control.reactive.isSelected <~ SignalProducer(signal: pipeSignalSelected)
-			control.reactive.isEnabled <~ SignalProducer(signal: pipeSignalEnabled)
+			control.reactive.isSelected <~ SignalProducer(pipeSignalSelected)
+			control.reactive.isEnabled <~ SignalProducer(pipeSignalEnabled)
 
 			observerSelected.send(value: true)
 			observerEnabled.send(value: true)

--- a/ReactiveCocoaTests/UIKit/UIImageViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIImageViewSpec.swift
@@ -25,7 +25,7 @@ class UIImageViewSpec: QuickSpec {
 			let secondChange = UIImage()
 
 			let (pipeSignal, observer) = Signal<UIImage?, NoError>.pipe()
-			imageView.reactive.image <~ SignalProducer(signal: pipeSignal)
+			imageView.reactive.image <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(imageView.image) == firstChange
@@ -39,7 +39,7 @@ class UIImageViewSpec: QuickSpec {
 			let secondChange = UIImage()
 
 			let (pipeSignal, observer) = Signal<UIImage?, NoError>.pipe()
-			imageView.reactive.highlightedImage <~ SignalProducer(signal: pipeSignal)
+			imageView.reactive.highlightedImage <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(imageView.highlightedImage) == firstChange

--- a/ReactiveCocoaTests/UIKit/UILabelSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UILabelSpec.swift
@@ -27,7 +27,7 @@ class UILabelSpec: QuickSpec {
 			label.text = ""
 
 			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
-			label.reactive.text <~ SignalProducer(signal: pipeSignal)
+			label.reactive.text <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(label.text) == firstChange
@@ -46,7 +46,7 @@ class UILabelSpec: QuickSpec {
 			label.attributedText = NSAttributedString(string: "")
 
 			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
-			label.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+			label.reactive.attributedText <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(label.attributedText) == firstChange
@@ -63,7 +63,7 @@ class UILabelSpec: QuickSpec {
 
 			let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
 			label.textColor = UIColor.black
-			label.reactive.textColor <~ SignalProducer(signal: pipeSignal)
+			label.reactive.textColor <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(label.textColor) == firstChange

--- a/ReactiveCocoaTests/UIKit/UIProgressViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIProgressViewSpec.swift
@@ -27,7 +27,7 @@ class UIProgressViewSpec: QuickSpec {
 			progressView.progress = 1.0
 
 			let (pipeSignal, observer) = Signal<Float, NoError>.pipe()
-			progressView.reactive.progress <~ SignalProducer(signal: pipeSignal)
+			progressView.reactive.progress <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(progressView.progress) ≈ firstChange

--- a/ReactiveCocoaTests/UIKit/UIRefreshControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIRefreshControlSpec.swift
@@ -21,7 +21,7 @@ class UIRefreshControlSpec: QuickSpec {
 
 		it("should accept changes from bindings to its refreshing state") {
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			refreshControl.reactive.isRefreshing <~ SignalProducer(signal: pipeSignal)
+			refreshControl.reactive.isRefreshing <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(refreshControl.isRefreshing) == true
@@ -32,7 +32,7 @@ class UIRefreshControlSpec: QuickSpec {
 
 		it("should accept changes from bindings to its attributed title state") {
 			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
-			refreshControl.reactive.attributedTitle <~ SignalProducer(signal: pipeSignal)
+			refreshControl.reactive.attributedTitle <~ SignalProducer(pipeSignal)
 
 			let string = NSAttributedString(string: "test")
 
@@ -55,7 +55,7 @@ class UIRefreshControlSpec: QuickSpec {
 				SignalProducer(value: true)
 			}
 
-			refreshed <~ SignalProducer(signal: action.values)
+			refreshed <~ SignalProducer(action.values)
 
 			refreshControl.reactive.refresh = CocoaAction(action)
 			expect(refreshed.value) == false

--- a/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
@@ -32,7 +32,7 @@ class UISearchBarSpec: QuickSpec {
 			searchBar.text = ""
 
 			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
-			searchBar.reactive.text <~ SignalProducer(signal: pipeSignal)
+			searchBar.reactive.text <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(searchBar.text) == firstChange

--- a/ReactiveCocoaTests/UIKit/UISegmentedControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISegmentedControlSpec.swift
@@ -12,7 +12,7 @@ class UISegmentedControlSpec: QuickSpec {
 			expect(s.numberOfSegments) == 3
 
 			let (pipeSignal, observer) = Signal<Int, NoError>.pipe()
-			s.reactive.selectedSegmentIndex <~ SignalProducer(signal: pipeSignal)
+			s.reactive.selectedSegmentIndex <~ SignalProducer(pipeSignal)
 
 			expect(s.selectedSegmentIndex) == UISegmentedControlNoSegment
 

--- a/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
@@ -16,19 +16,14 @@ class UISwitchSpec: QuickSpec {
 
 		afterEach {
 			toggle = nil
-
-			// Disabled due to an issue of the iOS SDK.
-			// Please refer to https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3251
-			// for more information.
-			//
-			// expect(_toggle).to(beNil())
+			expect(_toggle).to(beNil())
 		}
 
 		it("should accept changes from bindings to its `isOn` state") {
 			toggle.isOn = false
 
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			toggle.reactive.isOn <~ SignalProducer(signal: pipeSignal)
+			toggle.reactive.isOn <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(toggle.isOn) == true

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -55,7 +55,7 @@ class UITextFieldSpec: QuickSpec {
 			textField.attributedText = NSAttributedString(string: "")
 			
 			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
-			textField.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+			textField.reactive.attributedText <~ SignalProducer(pipeSignal)
 			
 			observer.send(value: firstChange)
 			expect(textField.attributedText?.string) == firstChange.string

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -59,7 +59,7 @@ class UITextViewSpec: QuickSpec {
 			textView.attributedText = NSAttributedString(string: "")
 			
 			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
-			textView.reactive.attributedText <~ SignalProducer(signal: pipeSignal)
+			textView.reactive.attributedText <~ SignalProducer(pipeSignal)
 			
 			observer.send(value: firstChange)
 			expect(textView.attributedText) == firstChange

--- a/ReactiveCocoaTests/UIKit/UIViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIViewSpec.swift
@@ -24,7 +24,7 @@ class UIViewSpec: QuickSpec {
 			view.isHidden = true
 
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			view.reactive.isHidden <~ SignalProducer(signal: pipeSignal)
+			view.reactive.isHidden <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(view.isHidden) == true
@@ -40,7 +40,7 @@ class UIViewSpec: QuickSpec {
 			let secondChange = CGFloat(0.7)
 
 			let (pipeSignal, observer) = Signal<CGFloat, NoError>.pipe()
-			view.reactive.alpha <~ SignalProducer(signal: pipeSignal)
+			view.reactive.alpha <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
 			expect(view.alpha) ≈ firstChange
@@ -53,7 +53,7 @@ class UIViewSpec: QuickSpec {
 			view.isUserInteractionEnabled = true
 
 			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
-			view.reactive.isUserInteractionEnabled <~ SignalProducer(signal: pipeSignal)
+			view.reactive.isUserInteractionEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
 			expect(view.isUserInteractionEnabled) == true
@@ -66,7 +66,7 @@ class UIViewSpec: QuickSpec {
 			view.backgroundColor = .white
 
 			let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
-			view.reactive.backgroundColor <~ SignalProducer(signal: pipeSignal)
+			view.reactive.backgroundColor <~ SignalProducer(pipeSignal)
 
 			observer.send(value: .yellow)
 			expect(view.backgroundColor) == .yellow


### PR DESCRIPTION
Note: The iOS 10.2 SDK has fixed #3251.