### PR TITLE
Mention the necessary import of ReactiveSwift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ In version 5.0, we split ReactiveCocoa into multiple repositories for reasons ex
 
 **If you’re using both the Swift and Objective-C APIs**, you likely require both ReactiveCocoa and [ReactiveObjCBridge][], which depend on [ReactiveSwift][] and [ReactiveObjC][].
 
+**Attention:** If youre using ReactiveCocoa, you'll most likely need to import ReactiveSwift as well when using classes or operators that are implemented in ReactiveSwift.
+
 #### ReactiveCocoa
 The ReactiveCocoa library is newly focused on Swift and the UI layers of Apple’s platforms, building on the work of [Rex](https://github.com/neilpa/Rex).
 

--- a/Documentation/DebuggingTechniques.md
+++ b/Documentation/DebuggingTechniques.md
@@ -2,6 +2,10 @@
 
 This document lists debugging techniques and infrastructure helpful for debugging ReactiveCocoa applications.
 
+#### Use of unresolved operator '<~' or <Class> not found in RAC 5
+
+Since the split into ReactiveCocoa and ReactiveSwift, you'll need to `import ReactiveSwift` as well when using classes or operators that are implemented in ReactiveSwift.
+
 #### Unscrambling Swift compiler errors
 
 Type inferrence can be a source of hard-to-debug compiler errors. There are two potential places to be wrong when type inferrence used:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ __ReactiveCocoa__ wraps various aspects of Cocoa frameworks with the declarative
 	nameLabel.reactive.text <~ person.name
 	```
 
+	_Note_: You'll need to import ReactiveSwift as well to make use of the `<~` operator.
+
 1. **Controls and User Interactions**
 
 	Interactive UI components expose [`Signal`][]s for control events


### PR DESCRIPTION
I see this issue coming up time and again, like

* http://stackoverflow.com/questions/41155298/use-of-unresolved-operator
* https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3192
* https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3188

When updating fro RAC 4 to RAC 5, its often not clear that its necessary to import ReactiveSwift as well. 

I just added a quick note about that in some places where I think it's most appropriate