### PR TITLE
Bypass the message forwarding for common method signatures.

### DIFF
--- a/ReactiveCocoa/ObjC+Messages.swift
+++ b/ReactiveCocoa/ObjC+Messages.swift
@@ -14,10 +14,16 @@ internal let NSMethodSignature: AnyClass = NSClassFromString("NSMethodSignature"
 // An alias for `-class`, which is unavailable in Swift.
 	@objc(class)
 	var objcClass: AnyClass! { get }
+
+	@objc(class)
+	static var objcClass: AnyClass! { get }
 }
 
 // Methods of `NSInvocation`.
 @objc internal protocol ObjCInvocation {
+	@objc(setTarget:)
+	func setUnmanagedTarget(_ target: Unmanaged<NSObject>)
+
 	@objc(setSelector:)
 	func setSelector(_ selector: Selector)
 
@@ -26,6 +32,9 @@ internal let NSMethodSignature: AnyClass = NSClassFromString("NSMethodSignature"
 
 	@objc(getArgument:atIndex:)
 	func copy(to buffer: UnsafeMutableRawPointer?, forArgumentAt index: Int)
+
+	@objc(setArgument:atIndex:)
+	func copy(from buffer: UnsafeMutableRawPointer?, forArgumentAt index: Int)
 
 	func invoke()
 

--- a/ReactiveCocoaTests/InterceptingPerformanceTests.swift
+++ b/ReactiveCocoaTests/InterceptingPerformanceTests.swift
@@ -1,8 +1,9 @@
 import XCTest
 @testable import ReactiveCocoa
 import ReactiveSwift
+import enum Result.NoError
 
-private let iterationCount = 5000
+private let iterationCount = 50000
 
 private final class Receiver1: NSObject {
 	dynamic func message() {}
@@ -61,6 +62,24 @@ class InterceptingTests: XCTestCase {
 		receiver6.reactive.values(forKeyPath: #keyPath(Receiver6.value)).start()
 	}
 
+	func testSimpleSignal() {
+		class TestObject: NSObject {
+			let (trigger, observer) = Signal<(), NoError>.pipe()
+
+			dynamic func invoke() {
+				observer.send(value: ())
+			}
+		}
+
+		let object = TestObject()
+
+		measure {
+			for _ in 0 ..< iterationCount {
+				object.invoke()
+			}
+		}
+	}
+
 	func testInterceptedMessage() {
 		let receiver = Receiver1()
 		_ = receiver.reactive.trigger(for: #selector(receiver.message))
@@ -98,7 +117,7 @@ class InterceptingTests: XCTestCase {
 		}
 	}
 
-	func testRACKVOInterceptSetterThenGet() {
+	func testRACKVOInterceptGetterThenGet() {
 		let receiver = Receiver4()
 
 		_ = receiver.reactive.trigger(for: #selector(getter: receiver.value))
@@ -111,7 +130,7 @@ class InterceptingTests: XCTestCase {
 		}
 	}
 
-	func testKVORACInterceptSetterThenGet() {
+	func testKVORACInterceptGetterThenGet() {
 		let receiver = Receiver5()
 
 		receiver.reactive.values(forKeyPath: #keyPath(Receiver5.value)).start()
@@ -124,7 +143,7 @@ class InterceptingTests: XCTestCase {
 		}
 	}
 
-	func testJustKVOInterceptSetterThenSet() {
+	func testJustKVOInterceptGetterThenSet() {
 		let receiver = Receiver6()
 		receiver.reactive.values(forKeyPath: #keyPath(Receiver6.value)).start()
 

--- a/ReactiveCocoaTests/InterceptingSpec.swift
+++ b/ReactiveCocoaTests/InterceptingSpec.swift
@@ -681,15 +681,21 @@ class InterceptingSpec: QuickSpec {
 
 				call(offset: 0)
 				expect(arguments.count) == 1
-				validate(arguments: arguments[0], offset: 0)
+				if arguments.count >= 1 {
+					validate(arguments: arguments[0], offset: 0)
+				}
 
 				call(offset: 1)
 				expect(arguments.count) == 2
-				validate(arguments: arguments[1], offset: 1)
+				if arguments.count >= 1 {
+					validate(arguments: arguments[1], offset: 1)
+				}
 
 				call(offset: 2)
 				expect(arguments.count) == 3
-				validate(arguments: arguments[2], offset: 2)
+				if arguments.count >= 3 {
+					validate(arguments: arguments[2], offset: 2)
+				}
 			}
 
 			it("should send a value with bridged reference arguments") {
@@ -711,12 +717,14 @@ class InterceptingSpec: QuickSpec {
 
 				expect(arguments.count) == 1
 
-				expect((arguments[0][0] as! NSObject)) == token
-				expect(arguments[0][1] as! NSObject?) == token
-				expect(arguments[0][2] as! NSObject?) == token
-				expect(arguments[0][3] as! AnyClass is InterceptingSpec.Type) == true
-				expect(arguments[0][4] as! AnyClass? is InterceptingSpec.Type) == true
-				expect(arguments[0][5] as! AnyClass? is InterceptingSpec.Type) == true
+				if arguments.count >= 1 {
+					expect((arguments[0][0] as! NSObject)) == token
+					expect(arguments[0][1] as! NSObject?) == token
+					expect(arguments[0][2] as! NSObject?) == token
+					expect(arguments[0][3] as! AnyClass is InterceptingSpec.Type) == true
+					expect(arguments[0][4] as! AnyClass? is InterceptingSpec.Type) == true
+					expect(arguments[0][5] as! AnyClass? is InterceptingSpec.Type) == true
+				}
 
 				object.testReferences(nonnull: token,
 				                      nullable: nil,
@@ -727,12 +735,14 @@ class InterceptingSpec: QuickSpec {
 
 				expect(arguments.count) == 2
 
-				expect((arguments[1][0] as! NSObject)) == token
-				expect(arguments[1][1] as! NSObject?).to(beNil())
-				expect(arguments[1][2] as! NSObject?).to(beNil())
-				expect(arguments[1][3] as! AnyClass is InterceptingSpec.Type) == true
-				expect(arguments[1][4] as! AnyClass?).to(beNil())
-				expect(arguments[1][5] as! AnyClass?).to(beNil())
+				if arguments.count >= 2 {
+					expect((arguments[1][0] as! NSObject)) == token
+					expect(arguments[1][1] as! NSObject?).to(beNil())
+					expect(arguments[1][2] as! NSObject?).to(beNil())
+					expect(arguments[1][3] as! AnyClass is InterceptingSpec.Type) == true
+					expect(arguments[1][4] as! AnyClass?).to(beNil())
+					expect(arguments[1][5] as! AnyClass?).to(beNil())
+				}
 			}
 
 			it("should send a value with bridged struct arguments") {
@@ -759,15 +769,33 @@ class InterceptingSpec: QuickSpec {
 
 				call(offset: 0)
 				expect(arguments.count) == 1
-				validate(arguments: arguments[0], offset: 0)
+				if arguments.count >= 1 {
+					validate(arguments: arguments[0], offset: 0)
+				}
 
 				call(offset: 1)
 				expect(arguments.count) == 2
-				validate(arguments: arguments[1], offset: 1)
+				if arguments.count >= 2 {
+					validate(arguments: arguments[1], offset: 1)
+				}
 
 				call(offset: 2)
 				expect(arguments.count) == 3
-				validate(arguments: arguments[2], offset: 2)
+				if arguments.count >= 3 {
+					validate(arguments: arguments[2], offset: 2)
+				}
+			}
+
+			it("should emit the object being passed") {
+				let signal = object.reactive.signal(for: #selector(setter: object.objectValue))
+
+				var latestValue: Any?
+				signal.observeValues { latestValue = $0[0] }
+				expect(latestValue).to(beNil())
+
+				let array = NSArray()
+				object.objectValue = array
+				expect(latestValue).to(beIdenticalTo(array))
 			}
 
 			it("should complete when the object deinitializes") {


### PR DESCRIPTION
While Objective-C message forwarding is convenient as a method interception medium, it comes with a tangible overhead that might not be ideal in performance critical use sites, e.g. `prepareForReuse` and potential delegaet intercepting signals in collection views.

The PR includes concrete implementation templates for the following method signatures:

```
[0 arg]  v@:
[1 args] v@:c   v@:l   v@:q   v@:@
[2 args] v@:@q  v@:@l  v@:@d  v@:@f  v@:@@
[3 args] v@:@@q v@:@@@
```
This set of signatures covers common property setters and many critical collection delegate requirements. Note that so far it only works when `void` is the return type.

The method interception routines would use the generated implementation from these templates, instead of the ObjC forwarding chain. These templates still respect the RAC interoperability guarantees of method interception.

Delegate interception might benefit from this PR, should we reuse the method interception facility and `forwardingTarget(for:)` to implement a delegate proxy.

#### Benchmarks
InterceptingTest, 50000 iterations, Whole Module Optimization
macOS 10.12.2, i5 4258U

| Test | Substituted | RC1 | Speedup |
| ---- | ----------- | ---------- | ------- |
| Simple Signal* | 0.020 (8%) | 0.020 (8%) | - |
| No arguments (`v@:`) | 0.053 (16%) | 0.141 (6%) | 2.66x |
| RAC-KVO, 1 argument (`v@:q`) | 0.815 (4%)  | 1.017 (3%) | 1.25x |
| KVO-RAC, 1 argument (`v@:q`) | 0.810 (3%)  | 1.472 (3%) | 1.82x |

\* Emit a value to the `Signal` through a `dynamic` method.

In the two KVO interoperability tests, RAC only accounts for 5-15% of the CPU time in multiple runs. It also mitigated the regression due to the IMP cache thrashing in the KVO-RAC interoperability test.