### PR TITLE
Add pressed signal for NSButton

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		004FD0071E26CDB300A03A82 /* NSButtonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004FD0061E26CDB300A03A82 /* NSButtonSpec.swift */; };
 		006518761E26865800C3139A /* NSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006518751E26865800C3139A /* NSButton.swift */; };
 		3BCAAC7A1DEE19BC00B30335 /* UIRefreshControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */; };
 		3BCAAC7D1DEE1A2D00B30335 /* UIRefreshControlSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCAAC7B1DEE1A2300B30335 /* UIRefreshControlSpec.swift */; };
@@ -307,6 +308,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		004FD0061E26CDB300A03A82 /* NSButtonSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSButtonSpec.swift; sourceTree = "<group>"; };
 		006518751E26865800C3139A /* NSButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSButton.swift; sourceTree = "<group>"; };
 		3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIRefreshControl.swift; sourceTree = "<group>"; };
 		3BCAAC7B1DEE1A2300B30335 /* UIRefreshControlSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIRefreshControlSpec.swift; sourceTree = "<group>"; };
@@ -630,6 +632,7 @@
 				4ABEFE2C1DCFD0180066A8C2 /* NSTableViewSpec.swift */,
 				9A6AAA271DB8F7EB0013AAEA /* ReusableComponentsSpec.swift */,
 				D9558AB51DFF7B90003254E1 /* NSPopUpButtonSpec.swift */,
+				004FD0061E26CDB300A03A82 /* NSButtonSpec.swift */,
 			);
 			path = AppKit;
 			sourceTree = "<group>";
@@ -1274,6 +1277,7 @@
 				9ADFE5A11DBFFBCF001E11F7 /* LifetimeSpec.swift in Sources */,
 				4ABEFE331DCFD0630066A8C2 /* NSCollectionViewSpec.swift in Sources */,
 				B696FB811A7640C00075236D /* TestError.swift in Sources */,
+				004FD0071E26CDB300A03A82 /* NSButtonSpec.swift in Sources */,
 				D9558AB91DFF86C0003254E1 /* NSPopUpButtonSpec.swift in Sources */,
 				BFA6B94D1A7604D400C846D1 /* SignalProducerNimbleMatchers.swift in Sources */,
 				9A24A8451DE142A400987AF9 /* SwizzlingSpec.swift in Sources */,

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		006518761E26865800C3139A /* NSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006518751E26865800C3139A /* NSButton.swift */; };
 		3BCAAC7A1DEE19BC00B30335 /* UIRefreshControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */; };
 		3BCAAC7D1DEE1A2D00B30335 /* UIRefreshControlSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCAAC7B1DEE1A2300B30335 /* UIRefreshControlSpec.swift */; };
 		419139461DB910570043C9D1 /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419139431DB910570043C9D1 /* UIGestureRecognizer.swift */; };
@@ -306,6 +307,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		006518751E26865800C3139A /* NSButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSButton.swift; sourceTree = "<group>"; };
 		3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIRefreshControl.swift; sourceTree = "<group>"; };
 		3BCAAC7B1DEE1A2300B30335 /* UIRefreshControlSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIRefreshControlSpec.swift; sourceTree = "<group>"; };
 		419139431DB910570043C9D1 /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -559,6 +561,7 @@
 				9ADE4A951DA6F018005C2AC8 /* NSTextField.swift */,
 				9A6AAA251DB8F5280013AAEA /* ReusableComponents.swift */,
 				D9558AB71DFF805A003254E1 /* NSPopUpButton.swift */,
+				006518751E26865800C3139A /* NSButton.swift */,
 			);
 			path = AppKit;
 			sourceTree = "<group>";
@@ -1237,6 +1240,7 @@
 				9A1D05E01D93E99100ACF44C /* NSObject+Association.swift in Sources */,
 				538DCB791DCA5E6C00332880 /* NSLayoutConstraint.swift in Sources */,
 				9AE7C2A41DDD7F5100F7534C /* ObjC+Messages.swift in Sources */,
+				006518761E26865800C3139A /* NSButton.swift in Sources */,
 				9A54A21B1DE00D09001739B3 /* ObjC+Selector.swift in Sources */,
 				9AA0BD8A1DDE153A00531FCF /* ObjC+Constants.swift in Sources */,
 				9A6AAA261DB8F5280013AAEA /* ReusableComponents.swift in Sources */,

--- a/ReactiveCocoa/AppKit/NSButton.swift
+++ b/ReactiveCocoa/AppKit/NSButton.swift
@@ -4,8 +4,24 @@ import AppKit
 
 extension Reactive where Base: NSButton {
 
-	public var pressed: Signal<Base, NoError> {
-		return trigger.map { [unowned base = self.base] in base }
+	internal var associatedAction: Atomic<(action: CocoaAction<Base>, disposable: Disposable?)?> {
+		return associatedValue { _ in Atomic(nil) }
 	}
 
+	public var pressed: CocoaAction<Base>? {
+		get {
+			return associatedAction.value?.action
+		}
+
+		nonmutating set {
+			base.target = newValue
+			base.action = newValue.map { _ in CocoaAction<Base>.selector }
+			associatedAction
+				.swap(newValue.map { action in
+					let disposable = isEnabled <~ action.isEnabled
+					return (action, disposable)
+				})?
+				.disposable?.dispose()
+		}
+	}
 }

--- a/ReactiveCocoa/AppKit/NSButton.swift
+++ b/ReactiveCocoa/AppKit/NSButton.swift
@@ -14,11 +14,13 @@ extension Reactive where Base: NSButton {
 		}
 
 		nonmutating set {
-			base.target = newValue
-			base.action = newValue.map { _ in CocoaAction<Base>.selector }
 			associatedAction
 				.swap(newValue.map { action in
-					let disposable = isEnabled <~ action.isEnabled
+					let disposable = CompositeDisposable()
+					disposable += isEnabled <~ action.isEnabled
+					disposable += trigger.observeValues { [unowned base = self.base] in
+						action.execute(base)
+					}
 					return (action, disposable)
 				})?
 				.disposable?.dispose()

--- a/ReactiveCocoa/AppKit/NSButton.swift
+++ b/ReactiveCocoa/AppKit/NSButton.swift
@@ -1,0 +1,11 @@
+import ReactiveSwift
+import enum Result.NoError
+import AppKit
+
+extension Reactive where Base: NSButton {
+
+	public var pressed: Signal<Base, NoError> {
+		return trigger.map { [unowned base = self.base] in base }
+	}
+
+}

--- a/ReactiveCocoa/AppKit/NSControl.swift
+++ b/ReactiveCocoa/AppKit/NSControl.swift
@@ -92,7 +92,7 @@ extension Reactive where Base: NSControl {
 
 	/// A trigger signal that sends a `next` event for every action messages
 	/// received from the control, and completes when the control deinitializes.
-	private var trigger: Signal<(), NoError> {
+	internal var trigger: Signal<(), NoError> {
 		return associatedValue { base in
 			let (signal, observer) = Signal<(), NoError>.pipe()
 

--- a/ReactiveCocoa/AppKit/NSControl.swift
+++ b/ReactiveCocoa/AppKit/NSControl.swift
@@ -92,7 +92,7 @@ extension Reactive where Base: NSControl {
 
 	/// A trigger signal that sends a `next` event for every action messages
 	/// received from the control, and completes when the control deinitializes.
-	internal var trigger: Signal<(), NoError> {
+	private var trigger: Signal<(), NoError> {
 		return associatedValue { base in
 			let (signal, observer) = Signal<(), NoError>.pipe()
 

--- a/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
@@ -1,0 +1,40 @@
+import Quick
+import Nimble
+import ReactiveSwift
+import ReactiveCocoa
+import AppKit
+import enum Result.NoError
+
+class NSButtonSpec: QuickSpec {
+	override func spec() {
+		var button: NSButton!
+		weak var _button: NSButton?
+
+		beforeEach {
+			button = NSButton(frame: .zero)
+			_button = button
+		}
+
+		afterEach {
+			button = nil
+			expect(_button).to(beNil())
+		}
+
+		it("should execute the `pressed` action upon receiving a click") {
+			button.isEnabled = true
+
+			let pressed = MutableProperty(false)
+			let action = Action<(), Bool, NoError> { _ in
+				SignalProducer(value: true)
+			}
+
+			pressed <~ SignalProducer(action.values)
+			button.reactive.pressed = CocoaAction(action)
+			expect(pressed.value) == false
+
+			button.performClick(nil)
+			expect(pressed.value) == true
+		}
+	}
+}
+

--- a/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
@@ -37,8 +37,10 @@ class NSButtonSpec: QuickSpec {
 			button.isEnabled = true
 
 			let pressed = MutableProperty(false)
+
+			let (executionSignal, observer) = Signal<Bool, NoError>.pipe()
 			let action = Action<(), Bool, NoError> { _ in
-				SignalProducer(value: true)
+				SignalProducer(executionSignal)
 			}
 
 			pressed <~ SignalProducer(action.values)
@@ -46,6 +48,12 @@ class NSButtonSpec: QuickSpec {
 			expect(pressed.value) == false
 
 			button.performClick(nil)
+			expect(button.isEnabled) == false
+
+			observer.send(value: true)
+			observer.sendCompleted()
+
+			expect(button.isEnabled) == true
 			expect(pressed.value) == true
 		}
 	}

--- a/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
@@ -20,6 +20,19 @@ class NSButtonSpec: QuickSpec {
 			expect(_button).to(beNil())
 		}
 
+		it("should accept changes from bindings to its enabling state") {
+			button.isEnabled = false
+
+			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			button.reactive.isEnabled <~ SignalProducer(pipeSignal)
+
+			observer.send(value: true)
+			expect(button.isEnabled) == true
+
+			observer.send(value: false)
+			expect(button.isEnabled) == false
+		}
+
 		it("should execute the `pressed` action upon receiving a click") {
 			button.isEnabled = true
 


### PR DESCRIPTION
I thought a simple way to get this done would be to just make the `trigger` property on NSControl `internal` rather than `private` so that it could be accessed by an NSButton extension and then the signal would just return itself. If there is a way that you all would prefer to have this done, I am happy to make changes, but this seems to work nicely too! 🚀 