### PR TITLE
Improved delegate interception for UISearchBar.

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -145,6 +145,10 @@
 		9A6AAA2B1DB8F85C0013AAEA /* ReusableComponentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6AAA271DB8F7EB0013AAEA /* ReusableComponentsSpec.swift */; };
 		9A6AAA2E1DB903A20013AAEA /* ReusableComponentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6AAA291DB8F7F10013AAEA /* ReusableComponentsSpec.swift */; };
 		9A6AAA2F1DB903A40013AAEA /* ReusableComponentsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6AAA291DB8F7F10013AAEA /* ReusableComponentsSpec.swift */; };
+		9A7488481E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
+		9A7488491E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
+		9A74884A1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
+		9A74884B1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
 		9A9A129A1DC7A97100D10223 /* UIGestureRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4191394B1DBA002C0043C9D1 /* UIGestureRecognizerSpec.swift */; };
 		9A9DFEE51DA7B5500039EE1B /* NSObject+Intercepting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D065A1D93EC6E00ACF44C /* NSObject+Intercepting.swift */; };
 		9A9DFEE91DA7EFB60039EE1B /* AssociationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */; };
@@ -382,6 +386,7 @@
 		9A6AAA251DB8F5280013AAEA /* ReusableComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponents.swift; sourceTree = "<group>"; };
 		9A6AAA271DB8F7EB0013AAEA /* ReusableComponentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponentsSpec.swift; sourceTree = "<group>"; };
 		9A6AAA291DB8F7F10013AAEA /* ReusableComponentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponentsSpec.swift; sourceTree = "<group>"; };
+		9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxy.swift; sourceTree = "<group>"; };
 		9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationSpec.swift; sourceTree = "<group>"; };
 		9AA0BD771DDE03DE00531FCF /* ObjC+Runtime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+Runtime.swift"; sourceTree = "<group>"; };
 		9AA0BD801DDE03F500531FCF /* ObjC+RuntimeSubclassing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+RuntimeSubclassing.swift"; sourceTree = "<group>"; };
@@ -713,6 +718,7 @@
 				9ADE4A7B1DA44A9E005C2AC8 /* CocoaAction.swift */,
 				9A2E425D1DAA6737006D909F /* CocoaTarget.swift */,
 				CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */,
+				9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */,
 				9ADE4A901DA6EA40005C2AC8 /* NSObject+ReactiveExtensionsProvider.swift */,
 				9AD0F0691D48BA4800ADFAB7 /* NSObject+KeyValueObserving.swift */,
 				9A1D065A1D93EC6E00ACF44C /* NSObject+Intercepting.swift */,
@@ -1140,6 +1146,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A74884B1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */,
 				9A1D06131D93EA0100ACF44C /* UIBarItem.swift in Sources */,
 				9A1D061F1D93EA0100ACF44C /* UITextField.swift in Sources */,
 				4ABEFE261DCFCF640066A8C2 /* UICollectionView.swift in Sources */,
@@ -1219,6 +1226,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A2E42601DAA6737006D909F /* CocoaTarget.swift in Sources */,
+				9A74884A1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */,
 				9A9DFEE51DA7B5500039EE1B /* NSObject+Intercepting.swift in Sources */,
 				9A54A21D1DE00D09001739B3 /* ObjC+Selector.swift in Sources */,
 				9AB15C7C1E26CD9A00997378 /* Deprecations+Removals.swift in Sources */,
@@ -1250,6 +1258,7 @@
 				9AA0BD8F1DDE29F800531FCF /* NSObject+ObjCRuntime.swift in Sources */,
 				9A1D05E01D93E99100ACF44C /* NSObject+Association.swift in Sources */,
 				538DCB791DCA5E6C00332880 /* NSLayoutConstraint.swift in Sources */,
+				9A7488481E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */,
 				9AE7C2A41DDD7F5100F7534C /* ObjC+Messages.swift in Sources */,
 				006518761E26865800C3139A /* NSButton.swift in Sources */,
 				9A54A21B1DE00D09001739B3 /* ObjC+Selector.swift in Sources */,
@@ -1307,6 +1316,7 @@
 				9A1D060D1D93EA0000ACF44C /* UITextField.swift in Sources */,
 				9AB15C7B1E26CD9A00997378 /* Deprecations+Removals.swift in Sources */,
 				9A6AAA231DB8F51C0013AAEA /* ReusableComponents.swift in Sources */,
+				9A7488491E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */,
 				9A1D060E1D93EA0000ACF44C /* UITextView.swift in Sources */,
 				BFCF775F1DFAD8A50058006E /* UISearchBar.swift in Sources */,
 				9A1D06061D93EA0000ACF44C /* UIImageView.swift in Sources */,

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -1,0 +1,106 @@
+import ReactiveSwift
+import enum Result.NoError
+
+internal class DelegateProxy<Delegate: NSObjectProtocol>: NSObject {
+	internal weak var forwardee: Delegate? {
+		didSet {
+			originalSetter(self)
+		}
+	}
+
+	internal var interceptedSelectors: Set<Selector> = []
+
+	private let originalSetter: (AnyObject) -> Void
+
+	required init(_ originalSetter: @escaping (AnyObject) -> Void) {
+		self.originalSetter = originalSetter
+	}
+
+	override func forwardingTarget(for selector: Selector!) -> Any? {
+		return interceptedSelectors.contains(selector) ? nil : forwardee
+	}
+
+	func intercept(_ selector: Selector) -> Signal<(), NoError> {
+		interceptedSelectors.insert(selector)
+		originalSetter(self)
+		return self.reactive.trigger(for: selector)
+	}
+
+	override func responds(to selector: Selector!) -> Bool {
+		if interceptedSelectors.contains(selector) {
+			return true
+		}
+
+		return forwardee?.responds(to: selector) ?? super.responds(to: selector)
+	}
+}
+
+private let hasSwizzledKey = AssociationKey<Bool>(default: false)
+
+internal protocol DelegateProxyProtocol: class {
+	associatedtype Delegate: NSObjectProtocol
+
+	weak var forwardee: Delegate? { get set }
+
+	init(_ originalSetter: @escaping (AnyObject) -> Void)
+}
+
+extension DelegateProxy: DelegateProxyProtocol {}
+
+extension DelegateProxyProtocol {
+	internal static func proxy(for instance: NSObject, setter: Selector, getter: Selector, _ key: AssociationKey<Self?>) -> Self {
+		return instance.synchronized {
+			if let proxy = instance.associations.value(forKey: key) {
+				return proxy
+			}
+
+			let subclass: AnyClass = swizzleClass(instance)
+
+			// Hide the original setter, and redirect subsequent delegate assignment
+			// to the proxy.
+			synchronized(subclass) {
+				let subclassAssociations = Associations(subclass as AnyObject)
+
+				if !subclassAssociations.value(forKey: hasSwizzledKey) {
+					subclassAssociations.setValue(true, forKey: hasSwizzledKey)
+
+					let method = class_getInstanceMethod(subclass, setter)
+					let typeEncoding = method_getTypeEncoding(method)!
+
+					let newSetterImpl: @convention(block) (NSObject, NSObject) -> Void = { object, delegate in
+						let proxy = object.associations.value(forKey: key)!
+						proxy.forwardee = (delegate as! Delegate)
+					}
+
+					class_replaceMethod(subclass,
+					                    setter,
+					                    imp_implementationWithBlock(newSetterImpl as Any),
+					                    typeEncoding)
+				}
+			}
+
+			// Set the proxy as the delegate.
+			let realClass: AnyClass = class_getSuperclass(subclass)
+			let originalSetterImpl = class_getMethodImplementation(realClass, setter)
+			let getterImpl = class_getMethodImplementation(realClass, getter)
+
+			typealias Setter = @convention(c) (AnyObject, Selector, AnyObject) -> Void
+			typealias Getter = @convention(c) (AnyObject, Selector) -> NSObject?
+
+			// As Objective-C classes may cache the information of their delegate at
+			// the time the delegates are set, the information has to be "flushed"
+			// whenever the proxy forwardee is replaced or a selector is intercepted.
+			let proxy = self.init { [weak instance] proxy in
+				guard let instance = instance else { return }
+				unsafeBitCast(originalSetterImpl, to: Setter.self)(instance, setter, proxy)
+			}
+
+			instance.associations.setValue(proxy, forKey: key)
+
+			proxy.forwardee = unsafeBitCast(getterImpl, to: Getter.self)(instance, getter) as! Delegate?
+			unsafeBitCast(originalSetterImpl, to: Setter.self)(instance, setter, proxy)
+			
+			return proxy
+		}
+	}
+}

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -26,10 +26,6 @@ extension Reactive where Base: UISearchBar {
 
 	/// A signal of text values emitted by the search bar upon end of editing.
 	///
-	/// - important: Creating this Signal will make the reactive extension
-	///   provider the delegate of the search bar. Setting your own delegate is
-	///   not supported and will result in a runtime error.
-	///
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
@@ -38,10 +34,6 @@ extension Reactive where Base: UISearchBar {
 	}
 
 	/// A signal of text values emitted by the search bar upon any changes.
-	///
-	/// - important: Creating this Signal will make the reactive extension 
-	///   provider the delegate of the search bar. Setting your own delegate is 
-	///   not supported and will result in a runtime error.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -12,14 +12,11 @@ private class SearchBarDelegateProxy: DelegateProxy<UISearchBarDelegate>, UISear
 	}
 }
 
-private let proxyKey = AssociationKey<SearchBarDelegateProxy?>()
-
 extension Reactive where Base: UISearchBar {
 	private var proxy: SearchBarDelegateProxy {
-		return SearchBarDelegateProxy.proxy(for: base,
-		                                    setter: #selector(setter: base.delegate),
-		                                    getter: #selector(getter: base.delegate),
-		                                    proxyKey)
+		return .proxy(for: base,
+		              setter: #selector(setter: base.delegate),
+		              getter: #selector(getter: base.delegate))
 	}
 
 	/// Sets the text of the search bar.


### PR DESCRIPTION
Note: Invoking `UISearchBar.delegate.set` and `Reactive<UISearchBar>.proxy` concurrently yields undefined behaviour in a similar way to method interception.