### PR TITLE
Add `isSecureTextEntry` binding to UITextField.

### DIFF
--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -42,4 +42,9 @@ extension Reactive where Base: UITextField {
 	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
 		return controlEvents(.editingChanged).map { $0.attributedText }
 	}
+
+	/// Sets the secure text entry attribute on the text field.
+	public var isSecureTextEntry: BindingTarget<Bool> {
+		return makeBindingTarget { $0.isSecureTextEntry = $1 }
+	}
 }

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -87,5 +87,16 @@ class UITextFieldSpec: QuickSpec {
 			textField.sendActions(for: .editingChanged)
 			expect(latestValue?.string) == textField.attributedText?.string
 		}
+
+		it("should accept changes from bindings to its secureTextEntry attribute") {
+			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			textField.reactive.isSecureTextEntry <~ pipeSignal
+
+			observer.send(value: true)
+			expect(textField.isSecureTextEntry) == true
+
+			observer.send(value: false)
+			expect(textField.isSecureTextEntry) == false
+		}
 	}
 }


### PR DESCRIPTION
It's common in apps to allow users to switch the password entry field to plaintext, in order to help them spot typos they may have made while inputting them.

This PR makes it easier by exposing `isSecureTextEntry` property of `UITextField` (technically of `UITextInputTraits` protocol) in a reactive way.