### PR TITLE
Hide the NSControl interception.

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		9AE7C2A51DDD7F5100F7534C /* ObjC+Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE7C2A31DDD7F5100F7534C /* ObjC+Messages.swift */; };
 		9AE7C2A61DDD7F5100F7534C /* ObjC+Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE7C2A31DDD7F5100F7534C /* ObjC+Messages.swift */; };
 		9AE7C2A71DDD7F5100F7534C /* ObjC+Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE7C2A31DDD7F5100F7534C /* ObjC+Messages.swift */; };
+		9AED64C51E496A3700321004 /* ActionProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AED64C41E496A3700321004 /* ActionProxy.swift */; };
 		9AF0EA751D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */; };
 		9AF0EA761D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */; };
 		9AF0EA771D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */; };
@@ -416,6 +417,7 @@
 		9ADFE5A41DC0001C001E11F7 /* NSObject+Synchronizing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Synchronizing.swift"; sourceTree = "<group>"; };
 		9AE7C2A21DDD768500F7534C /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		9AE7C2A31DDD7F5100F7534C /* ObjC+Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+Messages.swift"; sourceTree = "<group>"; };
+		9AED64C41E496A3700321004 /* ActionProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionProxy.swift; sourceTree = "<group>"; };
 		9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+BindingTarget.swift"; sourceTree = "<group>"; };
 		A97451331B3A935E00F48E55 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Application.xcconfig"; sourceTree = "<group>"; };
 		A97451341B3A935E00F48E55 /* watchOS-Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Base.xcconfig"; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 		9A1D05E91D93E9F100ACF44C /* AppKit */ = {
 			isa = PBXGroup;
 			children = (
+				9AED64C41E496A3700321004 /* ActionProxy.swift */,
 				4ABEFE2F1DCFD0530066A8C2 /* NSCollectionView.swift */,
 				9ADE4A881DA6D206005C2AC8 /* NSControl.swift */,
 				4ABEFE2A1DCFD0030066A8C2 /* NSTableView.swift */,
@@ -1281,6 +1284,7 @@
 				006518761E26865800C3139A /* NSButton.swift in Sources */,
 				9A54A21B1DE00D09001739B3 /* ObjC+Selector.swift in Sources */,
 				9AA0BD8A1DDE153A00531FCF /* ObjC+Constants.swift in Sources */,
+				9AED64C51E496A3700321004 /* ActionProxy.swift in Sources */,
 				9A6AAA261DB8F5280013AAEA /* ReusableComponents.swift in Sources */,
 				9AA0BD7C1DDE03DE00531FCF /* ObjC+Runtime.swift in Sources */,
 				9ADFE5A51DC0001C001E11F7 /* NSObject+Synchronizing.swift in Sources */,

--- a/ReactiveCocoa/AppKit/ActionProxy.swift
+++ b/ReactiveCocoa/AppKit/ActionProxy.swift
@@ -19,11 +19,7 @@ internal final class ActionProxy<Owner: AnyObject> {
 	// In AppKit, action messages always have only one parameter.
 	@objc func consume(_ sender: Any?) {
 		if let action = action {
-			if let target = target {
-				_ = target.perform(action, with: sender)
-			} else {
-				NSApp.sendAction(action, to: nil, from: sender)
-			}
+			NSApp.sendAction(action, to: target, from: sender)
 		}
 
 		observer.send(value: owner)

--- a/ReactiveCocoa/AppKit/ActionProxy.swift
+++ b/ReactiveCocoa/AppKit/ActionProxy.swift
@@ -1,0 +1,104 @@
+import AppKit
+import ReactiveSwift
+import enum Result.NoError
+
+internal final class ActionProxy<Owner: AnyObject> {
+	internal weak var target: AnyObject?
+	internal var action: Selector?
+	internal let signal: Signal<Owner, NoError>
+
+	private let observer: Signal<Owner, NoError>.Observer
+	private unowned let owner: Owner
+
+	internal init(owner: Owner, lifetime: Lifetime) {
+		self.owner = owner
+		(signal, observer) = Signal<Owner, NoError>.pipe()
+		lifetime.ended.observeCompleted(observer.sendCompleted)
+	}
+
+	// In AppKit, action messages always have only one parameter.
+	@objc func consume(_ sender: Any?) {
+		if let action = action {
+			if let target = target {
+				_ = target.perform(action, with: sender)
+			} else {
+				NSApp.sendAction(action, to: nil, from: sender)
+			}
+		}
+
+		observer.send(value: owner)
+	}
+}
+
+private let hasSwizzledKey = AssociationKey<Bool>(default: false)
+
+@objc internal protocol ActionMessageSending: class {
+	weak var target: AnyObject? { get set }
+	var action: Selector? { get set }
+}
+
+extension Reactive where Base: NSObject, Base: ActionMessageSending {
+	internal var proxy: ActionProxy<Base> {
+		let key = AssociationKey<ActionProxy<Base>?>((#function as StaticString))
+
+		return base.synchronized {
+			if let proxy = base.associations.value(forKey: key) {
+				return proxy
+			}
+
+			let proxy = ActionProxy<Base>(owner: base, lifetime: lifetime)
+			base.associations.setValue(proxy, forKey: key)
+
+			proxy.target = base.target
+			proxy.action = base.action
+
+			base.target = proxy
+			base.action = #selector(proxy.consume(_:))
+
+			// Swizzle the instance only after setting up the proxy.
+			let subclass: AnyClass = swizzleClass(base)
+
+			let targetSetter = #selector(setter: base.target)
+			let actionSetter = #selector(setter: base.action)
+
+			// Swizzle the original setters, and redirect subsequent target and action
+			// assignments to the proxy.
+			try! ReactiveCocoa.synchronized(subclass) {
+				print(subclass)
+				let subclassAssociations = Associations(subclass as AnyObject)
+
+				if !subclassAssociations.value(forKey: hasSwizzledKey) {
+					subclassAssociations.setValue(true, forKey: hasSwizzledKey)
+
+					let targetSetterMethod = class_getInstanceMethod(subclass, targetSetter)
+					let targetSetterTypeEncoding = method_getTypeEncoding(targetSetterMethod)!
+
+					let newTargetSetterImpl: @convention(block) (NSObject, AnyObject?) -> Void = { object, target in
+						let proxy = object.associations.value(forKey: key)!
+						proxy.target = target
+					}
+
+					class_replaceMethod(subclass,
+					                    targetSetter,
+					                    imp_implementationWithBlock(newTargetSetterImpl as Any),
+					                    targetSetterTypeEncoding)
+
+					let actionSetterMethod = class_getInstanceMethod(subclass, actionSetter)
+					let actionSetterTypeEncoding = method_getTypeEncoding(actionSetterMethod)!
+
+					let newActionSetterImpl: @convention(block) (NSObject, Selector?) -> Void = { object, selector in
+						let proxy = object.associations.value(forKey: key)!
+						proxy.action = selector
+					}
+
+					class_replaceMethod(subclass,
+					                    actionSetter,
+					                    imp_implementationWithBlock(newActionSetterImpl as Any),
+					                    actionSetterTypeEncoding)
+				}
+			}
+			
+			return proxy
+		}
+	}
+}

--- a/ReactiveCocoa/AppKit/NSButton.swift
+++ b/ReactiveCocoa/AppKit/NSButton.swift
@@ -20,9 +20,7 @@ extension Reactive where Base: NSButton {
 					action = newValue.map { action in
 						let disposable = CompositeDisposable()
 						disposable += isEnabled <~ action.isEnabled
-						disposable += trigger.observeValues { [unowned base = self.base] in
-							action.execute(base)
-						}
+						disposable += proxy.signal.observeValues(action.execute)
 						return (action, disposable)
 					}
 			}
@@ -31,7 +29,7 @@ extension Reactive where Base: NSButton {
 
 	/// A signal of integer states (On, Off, Mixed), emitted by the button.
 	public var states: Signal<Int, NoError> {
-		return trigger.map { [unowned base = self.base] in base.state }
+		return proxy.signal.map { $0.state }
 	}
 
 	/// Sets the button's state

--- a/ReactiveCocoa/AppKit/NSButton.swift
+++ b/ReactiveCocoa/AppKit/NSButton.swift
@@ -20,7 +20,7 @@ extension Reactive where Base: NSButton {
 					action = newValue.map { action in
 						let disposable = CompositeDisposable()
 						disposable += isEnabled <~ action.isEnabled
-						disposable += proxy.signal.observeValues(action.execute)
+						disposable += proxy.invoked.observeValues(action.execute)
 						return (action, disposable)
 					}
 			}
@@ -29,7 +29,7 @@ extension Reactive where Base: NSButton {
 
 	/// A signal of integer states (On, Off, Mixed), emitted by the button.
 	public var states: Signal<Int, NoError> {
-		return proxy.signal.map { $0.state }
+		return proxy.invoked.map { $0.state }
 	}
 
 	/// Sets the button's state

--- a/ReactiveCocoa/AppKit/NSControl.swift
+++ b/ReactiveCocoa/AppKit/NSControl.swift
@@ -17,7 +17,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `NSAttributedString`, emitted by the control.
 	public var attributedStringValues: Signal<NSAttributedString, NoError> {
-		return proxy.signal.map { $0.attributedStringValue }
+		return proxy.invoked.map { $0.attributedStringValue }
 	}
 
 	/// Sets the value of the control with a `Bool`.
@@ -27,7 +27,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Bool`, emitted by the control.
 	public var boolValues: Signal<Bool, NoError> {
-		return proxy.signal.map { $0.integerValue != NSOffState }
+		return proxy.invoked.map { $0.integerValue != NSOffState }
 	}
 
 	/// Sets the value of the control with a `Double`.
@@ -37,7 +37,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Double`, emitted by the control.
 	public var doubleValues: Signal<Double, NoError> {
-		return proxy.signal.map { $0.doubleValue }
+		return proxy.invoked.map { $0.doubleValue }
 	}
 
 	/// Sets the value of the control with a `Float`.
@@ -47,7 +47,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Float`, emitted by the control.
 	public var floatValues: Signal<Float, NoError> {
-		return proxy.signal.map { $0.floatValue }
+		return proxy.invoked.map { $0.floatValue }
 	}
 
 	/// Sets the value of the control with an `Int32`.
@@ -57,7 +57,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Int32`, emitted by the control.
 	public var intValues: Signal<Int32, NoError> {
-		return proxy.signal.map { $0.intValue }
+		return proxy.invoked.map { $0.intValue }
 	}
 
 	/// Sets the value of the control with an `Int`.
@@ -67,7 +67,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Int`, emitted by the control.
 	public var integerValues: Signal<Int, NoError> {
-		return proxy.signal.map { $0.integerValue }
+		return proxy.invoked.map { $0.integerValue }
 	}
 
 	/// Sets the value of the control.
@@ -77,7 +77,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Any?`, emitted by the control.
 	public var objectValues: Signal<Any?, NoError> {
-		return proxy.signal.map { $0.objectValue }
+		return proxy.invoked.map { $0.objectValue }
 	}
 
 	/// Sets the value of the control with a `String`.
@@ -87,7 +87,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `String`, emitted by the control.
 	public var stringValues: Signal<String, NoError> {
-		return proxy.signal.map { $0.stringValue }
+		return proxy.invoked.map { $0.stringValue }
 	}
 }
 

--- a/ReactiveCocoa/AppKit/NSControl.swift
+++ b/ReactiveCocoa/AppKit/NSControl.swift
@@ -2,6 +2,8 @@ import ReactiveSwift
 import enum Result.NoError
 import AppKit
 
+extension NSControl: ActionMessageSending {}
+
 extension Reactive where Base: NSControl {
 	/// Sets whether the control is enabled.
 	public var isEnabled: BindingTarget<Bool> {
@@ -15,7 +17,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `NSAttributedString`, emitted by the control.
 	public var attributedStringValues: Signal<NSAttributedString, NoError> {
-		return trigger.map { [unowned base = self.base] in base.attributedStringValue }
+		return proxy.signal.map { $0.attributedStringValue }
 	}
 
 	/// Sets the value of the control with a `Bool`.
@@ -25,9 +27,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Bool`, emitted by the control.
 	public var boolValues: Signal<Bool, NoError> {
-		return trigger.map { [unowned base = self.base] in
-			return base.integerValue == NSOffState ? false : true
-		}
+		return proxy.signal.map { $0.integerValue != NSOffState }
 	}
 
 	/// Sets the value of the control with a `Double`.
@@ -37,7 +37,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Double`, emitted by the control.
 	public var doubleValues: Signal<Double, NoError> {
-		return trigger.map { [unowned base = self.base] in base.doubleValue }
+		return proxy.signal.map { $0.doubleValue }
 	}
 
 	/// Sets the value of the control with a `Float`.
@@ -47,7 +47,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Float`, emitted by the control.
 	public var floatValues: Signal<Float, NoError> {
-		return trigger.map { [unowned base = self.base] in base.floatValue }
+		return proxy.signal.map { $0.floatValue }
 	}
 
 	/// Sets the value of the control with an `Int32`.
@@ -57,7 +57,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Int32`, emitted by the control.
 	public var intValues: Signal<Int32, NoError> {
-		return trigger.map { [unowned base = self.base] in base.intValue }
+		return proxy.signal.map { $0.intValue }
 	}
 
 	/// Sets the value of the control with an `Int`.
@@ -67,7 +67,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Int`, emitted by the control.
 	public var integerValues: Signal<Int, NoError> {
-		return trigger.map { [unowned base = self.base] in base.integerValue }
+		return proxy.signal.map { $0.integerValue }
 	}
 
 	/// Sets the value of the control.
@@ -77,7 +77,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `Any?`, emitted by the control.
 	public var objectValues: Signal<Any?, NoError> {
-		return trigger.map { [unowned base = self.base] in base.objectValue }
+		return proxy.signal.map { $0.objectValue }
 	}
 
 	/// Sets the value of the control with a `String`.
@@ -87,26 +87,7 @@ extension Reactive where Base: NSControl {
 
 	/// A signal of values in `String`, emitted by the control.
 	public var stringValues: Signal<String, NoError> {
-		return trigger.map { [unowned base = self.base] in base.stringValue }
-	}
-
-	/// A trigger signal that sends a `next` event for every action messages
-	/// received from the control, and completes when the control deinitializes.
-	internal var trigger: Signal<(), NoError> {
-		return associatedValue { base in
-			let (signal, observer) = Signal<(), NoError>.pipe()
-
-			let receiver = CocoaTarget(observer)
-			base.target = receiver
-			base.action = #selector(receiver.sendNext)
-
-			lifetime.ended.observeCompleted {
-				_ = receiver
-				observer.sendCompleted()
-			}
-
-			return signal
-		}
+		return proxy.signal.map { $0.stringValue }
 	}
 }
 

--- a/ReactiveCocoa/AppKit/NSPopUpButton.swift
+++ b/ReactiveCocoa/AppKit/NSPopUpButton.swift
@@ -6,7 +6,7 @@ extension Reactive where Base: NSPopUpButton {
 	
 	/// A signal of selected indexes
 	public var selectedIndexes: Signal<Int, NoError> {
-		return proxy.signal.map { $0.indexOfSelectedItem }
+		return proxy.invoked.map { $0.indexOfSelectedItem }
 	}
 	
 	/// Sets the button with an index.
@@ -18,7 +18,7 @@ extension Reactive where Base: NSPopUpButton {
 	
 	/// A signal of selected title
 	public var selectedTitles: Signal<String, NoError> {
-		return proxy.signal.map { $0.titleOfSelectedItem }.skipNil()
+		return proxy.invoked.map { $0.titleOfSelectedItem }.skipNil()
 	}
 	
 	/// Sets the button with title.
@@ -30,13 +30,13 @@ extension Reactive where Base: NSPopUpButton {
 	}
 
 	public var selectedItems: Signal<NSMenuItem, NoError> {
-		return proxy.signal.map { $0.selectedItem }.skipNil()
+		return proxy.invoked.map { $0.selectedItem }.skipNil()
 	}
 
 
 	/// A signal of selected tags
 	public var selectedTags: Signal<Int, NoError> {
-		return proxy.signal.map { $0.selectedTag() }
+		return proxy.invoked.map { $0.selectedTag() }
 	}
 
 	/// Sets the selected tag

--- a/ReactiveCocoa/AppKit/NSPopUpButton.swift
+++ b/ReactiveCocoa/AppKit/NSPopUpButton.swift
@@ -6,10 +6,7 @@ extension Reactive where Base: NSPopUpButton {
 	
 	/// A signal of selected indexes
 	public var selectedIndexes: Signal<Int, NoError> {
-		return self.integerValues
-			.map { [unowned base = self.base] _ -> Int in
-				return base.indexOfSelectedItem
-			}
+		return proxy.signal.map { $0.indexOfSelectedItem }
 	}
 	
 	/// Sets the button with an index.
@@ -21,11 +18,7 @@ extension Reactive where Base: NSPopUpButton {
 	
 	/// A signal of selected title
 	public var selectedTitles: Signal<String, NoError> {
-		return self.objectValues
-			.map { [unowned base = self.base] _ -> String? in
-				return base.titleOfSelectedItem
-			}
-			.skipNil()
+		return proxy.signal.map { $0.titleOfSelectedItem }.skipNil()
 	}
 	
 	/// Sets the button with title.
@@ -37,20 +30,13 @@ extension Reactive where Base: NSPopUpButton {
 	}
 
 	public var selectedItems: Signal<NSMenuItem, NoError> {
-		return self.objectValues
-			.map { [unowned base = self.base] _ -> NSMenuItem? in
-				return base.selectedItem
-			}
-			.skipNil()
+		return proxy.signal.map { $0.selectedItem }.skipNil()
 	}
 
 
 	/// A signal of selected tags
 	public var selectedTags: Signal<Int, NoError> {
-		return self.integerValues
-			.map { [unowned base = self.base] _ -> Int in
-				return base.selectedTag()
-		}
+		return proxy.signal.map { $0.selectedTag() }
 	}
 
 	/// Sets the selected tag

--- a/ReactiveCocoa/AppKit/NSSegmentedControl.swift
+++ b/ReactiveCocoa/AppKit/NSSegmentedControl.swift
@@ -10,7 +10,7 @@ extension Reactive where Base: NSSegmentedControl {
 
 	/// A signal of indexes of selections emitted by the segmented control.
 	public var selectedSegments: Signal<Int, NoError> {
-		return proxy.signal.map { $0.selectedSegment }
+		return proxy.invoked.map { $0.selectedSegment }
 	}
 
 	/// The below are provided for cross-platform compatibility

--- a/ReactiveCocoa/AppKit/NSSegmentedControl.swift
+++ b/ReactiveCocoa/AppKit/NSSegmentedControl.swift
@@ -10,7 +10,7 @@ extension Reactive where Base: NSSegmentedControl {
 
 	/// A signal of indexes of selections emitted by the segmented control.
 	public var selectedSegments: Signal<Int, NoError> {
-		return trigger.map { [unowned base = self.base] in base.selectedSegment }
+		return proxy.signal.map { $0.selectedSegment }
 	}
 
 	/// The below are provided for cross-platform compatibility

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -75,6 +75,8 @@ extension DelegateProxy {
 				proxy.forwardee = (delegate as! Delegate)
 			}
 
+			// Hide the original setter, and redirect subsequent delegate assignment
+			// to the proxy.
 			instance.swizzle((setter, newSetterImpl), key: hasSwizzledKey)
 
 			// Set the proxy as the delegate.

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -70,33 +70,15 @@ extension DelegateProxy {
 				return proxy
 			}
 
-			let subclass: AnyClass = swizzleClass(instance)
-
-			// Hide the original setter, and redirect subsequent delegate assignment
-			// to the proxy.
-			try! ReactiveCocoa.synchronized(subclass) {
-				let subclassAssociations = Associations(subclass as AnyObject)
-
-				if !subclassAssociations.value(forKey: hasSwizzledKey) {
-					subclassAssociations.setValue(true, forKey: hasSwizzledKey)
-
-					let method = class_getInstanceMethod(subclass, setter)
-					let typeEncoding = method_getTypeEncoding(method)!
-
-					let newSetterImpl: @convention(block) (NSObject, NSObject) -> Void = { object, delegate in
-						let proxy = object.associations.value(forKey: key)!
-						proxy.forwardee = (delegate as! Delegate)
-					}
-
-					class_replaceMethod(subclass,
-					                    setter,
-					                    imp_implementationWithBlock(newSetterImpl as Any),
-					                    typeEncoding)
-				}
+			let newSetterImpl: @convention(block) (NSObject, NSObject) -> Void = { object, delegate in
+				let proxy = object.associations.value(forKey: key)!
+				proxy.forwardee = (delegate as! Delegate)
 			}
 
+			instance.swizzle((setter, newSetterImpl), key: hasSwizzledKey)
+
 			// Set the proxy as the delegate.
-			let realClass: AnyClass = class_getSuperclass(subclass)
+			let realClass: AnyClass = class_getSuperclass(object_getClass(instance))
 			let originalSetterImpl: IMP = class_getMethodImplementation(realClass, setter)
 			let getterImpl: IMP = class_getMethodImplementation(realClass, getter)
 

--- a/ReactiveCocoa/ObjC+RuntimeSubclassing.swift
+++ b/ReactiveCocoa/ObjC+RuntimeSubclassing.swift
@@ -8,11 +8,21 @@ fileprivate let runtimeSubclassedKey = AssociationKey(default: false)
 fileprivate let knownRuntimeSubclassKey = AssociationKey<AnyClass?>(default: nil)
 
 extension NSObject {
+	/// Swizzle the given selectors.
+	///
+	/// - warning: The swizzling **does not** apply on a per-instance basis. In
+	///            other words, repetitive swizzling of the same selector would
+	///            overwrite previous swizzling attempts, despite a different
+	///            instance being supplied.
+	///
+	/// - parameters:
+	///   - pairs: Tuples of selectors and the respective implementions to be
+	///            swapped in.
+	///   - key: An association key which determines if the swizzling has already
+	///          been performed.
 	internal func swizzle(_ pairs: (Selector, Any)..., key hasSwizzledKey: AssociationKey<Bool>) {
 		let subclass: AnyClass = swizzleClass(self)
 
-		// Hide the original setter, and redirect subsequent delegate assignment
-		// to the proxy.
 		try! ReactiveCocoa.synchronized(subclass) {
 			let subclassAssociations = Associations(subclass as AnyObject)
 
@@ -34,6 +44,11 @@ extension NSObject {
 ///
 /// - note: If the instance has already been isa-swizzled, the swizzling happens
 ///         in place in the runtime subclass created by external parties.
+///
+/// - warning: The swizzling **does not** apply on a per-instance basis. In
+///            other words, repetitive swizzling of the same selector would
+///            overwrite previous swizzling attempts, despite a different
+///            instance being supplied.
 ///
 /// - parameters:
 ///   - instance: The instance to be swizzled.

--- a/ReactiveCocoaTests/AppKit/NSControlSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSControlSpec.swift
@@ -130,6 +130,56 @@ class NSControlSpec: QuickSpec {
 				expect(valuesB) == [true, false]
 				expect(valuesC) == [1, 0]
 			}
+
+			it("should not overwrite the existing target") {
+				let target = TestTarget()
+				control.target = target
+				control.action = #selector(target.execute)
+
+				control.performClick(nil)
+				expect(target.counter) == 1
+
+				var signalCounter = 0
+				control.reactive.integerValues.observeValues { _ in signalCounter += 1 }
+				expect(control.target).toNot(beIdenticalTo(target))
+
+				control.performClick(nil)
+				expect(signalCounter) == 1
+				expect(target.counter) == 2
+
+				control.performClick(nil)
+				expect(signalCounter) == 2
+				expect(target.counter) == 3
+			}
+
+			it("should not overwrite the proxy") {
+				var signalCounter = 0
+				control.reactive.integerValues.observeValues { _ in signalCounter += 1 }
+
+				control.performClick(nil)
+				expect(signalCounter) == 1
+
+				let target = TestTarget()
+				control.target = target
+				control.action = #selector(target.execute)
+
+				control.performClick(nil)
+				expect(signalCounter) == 2
+				expect(target.counter) == 1
+
+
+				control.performClick(nil)
+				expect(signalCounter) == 3
+				expect(target.counter) == 2
+			}
 		}
+	}
+}
+
+private final class TestTarget {
+	var counter = 0
+
+	@objc func execute(_ sender: Any?) {
+		counter += 1
 	}
 }


### PR DESCRIPTION
Similar to #3385.

A new protocol `ActionMessageSending` is introduced. Conforming `NSObject` subclasses would automatically gain a lazily-initialised proxy via `Self.reactive.proxy`, and the instances would have their `target` and `action` setters redirected to the proxy.

Like any interception API, concurrent use has undefined behaviour, though AppKit components should be manipulated on the main thread anyway.