### PR TITLE
Add UIPickerView reactive extensions

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -230,8 +230,10 @@
 		BF4335681E02EF0600AC88DD /* UIScrollViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4335661E02EEDE00AC88DD /* UIScrollViewSpec.swift */; };
 		BFA6B94D1A7604D400C846D1 /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
 		BFA6B94E1A7604D500C846D1 /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
+		BFBD68451E48DBD3003CB580 /* UIPickerViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBD68431E48DA21003CB580 /* UIPickerViewSpec.swift */; };
 		BFCF775F1DFAD8A50058006E /* UISearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF775E1DFAD8A50058006E /* UISearchBar.swift */; };
 		BFCF77621DFAD9440058006E /* UISearchBarSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCF77601DFAD9120058006E /* UISearchBarSpec.swift */; };
+		BFE1458A1E439AB000208736 /* UIPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE145881E43991A00208736 /* UIPickerView.swift */; };
 		CD0C45DE1CC9A288009F5BF0 /* DynamicProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */; };
 		CD0C45DF1CC9A288009F5BF0 /* DynamicProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */; };
 		CD0C45E01CC9A288009F5BF0 /* DynamicProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */; };
@@ -431,8 +433,10 @@
 		BF4335641E02AC7600AC88DD /* UIScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIScrollView.swift; sourceTree = "<group>"; };
 		BF4335661E02EEDE00AC88DD /* UIScrollViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIScrollViewSpec.swift; sourceTree = "<group>"; };
 		BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProducerNimbleMatchers.swift; sourceTree = "<group>"; };
+		BFBD68431E48DA21003CB580 /* UIPickerViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIPickerViewSpec.swift; sourceTree = "<group>"; };
 		BFCF775E1DFAD8A50058006E /* UISearchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISearchBar.swift; sourceTree = "<group>"; };
 		BFCF77601DFAD9120058006E /* UISearchBarSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISearchBarSpec.swift; sourceTree = "<group>"; };
+		BFE145881E43991A00208736 /* UIPickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIPickerView.swift; sourceTree = "<group>"; };
 		CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicProperty.swift; sourceTree = "<group>"; };
 		CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaActionSpec.swift; sourceTree = "<group>"; };
 		CDC42E2E1AE7AB8B00965373 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -628,6 +632,7 @@
 				4191394B1DBA002C0043C9D1 /* UIGestureRecognizerSpec.swift */,
 				9A1D062B1D93EA7E00ACF44C /* UIImageViewSpec.swift */,
 				9A1D062C1D93EA7E00ACF44C /* UILabelSpec.swift */,
+				BFBD68431E48DA21003CB580 /* UIPickerViewSpec.swift */,
 				9A1D062D1D93EA7E00ACF44C /* UIProgressViewSpec.swift */,
 				BF4335661E02EEDE00AC88DD /* UIScrollViewSpec.swift */,
 				BFCF77601DFAD9120058006E /* UISearchBarSpec.swift */,
@@ -689,6 +694,7 @@
 			children = (
 				9A1D05F21D93E9F100ACF44C /* UIDatePicker.swift */,
 				9AAD49871DED2C350068EC9B /* UIKeyboard.swift */,
+				BFE145881E43991A00208736 /* UIPickerView.swift */,
 				3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */,
 				BFCF775E1DFAD8A50058006E /* UISearchBar.swift */,
 				53AC46CB1DD6F97400C799E1 /* UISlider.swift */,
@@ -1351,6 +1357,7 @@
 				9AA0BD901DDE29F800531FCF /* NSObject+ObjCRuntime.swift in Sources */,
 				419139461DB910570043C9D1 /* UIGestureRecognizer.swift in Sources */,
 				9AA0BD7D1DDE03DE00531FCF /* ObjC+Runtime.swift in Sources */,
+				BFE1458A1E439AB000208736 /* UIPickerView.swift in Sources */,
 				9A1D060A1D93EA0000ACF44C /* UISwitch.swift in Sources */,
 				9A1D065C1D93EC6E00ACF44C /* NSObject+Intercepting.swift in Sources */,
 				9A1D06071D93EA0000ACF44C /* UILabel.swift in Sources */,
@@ -1385,6 +1392,7 @@
 				D0A2260F1A72F16D00D33B74 /* DynamicPropertySpec.swift in Sources */,
 				BFA6B94E1A7604D500C846D1 /* SignalProducerNimbleMatchers.swift in Sources */,
 				B696FB821A7640C00075236D /* TestError.swift in Sources */,
+				BFBD68451E48DBD3003CB580 /* UIPickerViewSpec.swift in Sources */,
 				9A1D064C1D93EA7E00ACF44C /* UISwitchSpec.swift in Sources */,
 				4ABEFE281DCFCFA90066A8C2 /* UICollectionViewSpec.swift in Sources */,
 				9A1D06441D93EA7E00ACF44C /* UIImageViewSpec.swift in Sources */,

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -26,6 +26,12 @@ internal class DelegateProxy<Delegate: NSObjectProtocol>: NSObject {
 		return self.reactive.trigger(for: selector)
 	}
 
+	func intercept(_ selector: Selector) -> Signal<[Any?], NoError> {
+		interceptedSelectors.insert(selector)
+		originalSetter(self)
+		return self.reactive.signal(for: selector)
+	}
+
 	override func responds(to selector: Selector!) -> Bool {
 		if interceptedSelectors.contains(selector) {
 			return true

--- a/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
@@ -1,0 +1,43 @@
+import ReactiveSwift
+import enum Result.NoError
+import UIKit
+
+private class PickerViewDelegateProxy: DelegateProxy<UIPickerViewDelegate>, UIPickerViewDelegate {
+	@objc func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+		forwardee?.pickerView?(pickerView, didSelectRow: row, inComponent: component)
+	}
+}
+
+extension Reactive where Base: UIPickerView {
+
+	private var proxy: PickerViewDelegateProxy {
+		return .proxy(for: base,
+		              setter: #selector(setter: base.delegate),
+		              getter: #selector(getter: base.delegate))
+	}
+
+	/// Sets the selected row in the specified component, without animating the
+	/// position.
+	public func selectedRow(inComponent component: Int) -> BindingTarget<Int> {
+		return makeBindingTarget { $0.selectRow($1, inComponent: component, animated: false) }
+	}
+
+	/// Reloads all components
+	public var reloadAllComponents: BindingTarget<()> {
+		return makeBindingTarget { base, _ in base.reloadAllComponents() }
+	}
+
+	/// Reloads the specified component
+	public var reloadComponent: BindingTarget<Int> {
+		return makeBindingTarget { $0.reloadComponent($1) }
+	}
+
+	/// Create a signal which sends a `value` event for each row selection
+	///
+	/// - returns:
+	///   A trigger signal.
+	public var selections: Signal<(Int, Int), NoError> {
+		return proxy.intercept(#selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)))
+			.map { ($0[1] as! Int, $0[2] as! Int) }
+	}
+}

--- a/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
@@ -8,11 +8,6 @@ private class PickerViewDelegateProxy: DelegateProxy<UIPickerViewDelegate>, UIPi
 	}
 }
 
-public struct UIPickerViewSelection {
-	public let row: Int
-	public let component: Int
-}
-
 extension Reactive where Base: UIPickerView {
 
 	private var proxy: PickerViewDelegateProxy {
@@ -41,8 +36,8 @@ extension Reactive where Base: UIPickerView {
 	///
 	/// - returns:
 	///   A trigger signal.
-	public var selections: Signal<UIPickerViewSelection, NoError> {
+	public var selections: Signal<(row: Int, component: Int), NoError> {
 		return proxy.intercept(#selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)))
-			.map { UIPickerViewSelection(row: $0[1] as! Int, component: $0[2] as! Int) }
+			.map { (row: $0[1] as! Int, component: $0[2] as! Int) }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
@@ -8,6 +8,11 @@ private class PickerViewDelegateProxy: DelegateProxy<UIPickerViewDelegate>, UIPi
 	}
 }
 
+public struct UIPickerViewSelection {
+	public let row: Int
+	public let component: Int
+}
+
 extension Reactive where Base: UIPickerView {
 
 	private var proxy: PickerViewDelegateProxy {
@@ -36,8 +41,8 @@ extension Reactive where Base: UIPickerView {
 	///
 	/// - returns:
 	///   A trigger signal.
-	public var selections: Signal<(Int, Int), NoError> {
+	public var selections: Signal<UIPickerViewSelection, NoError> {
 		return proxy.intercept(#selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)))
-			.map { ($0[1] as! Int, $0[2] as! Int) }
+			.map { UIPickerViewSelection(row: $0[1] as! Int, component: $0[2] as! Int) }
 	}
 }

--- a/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
@@ -1,0 +1,153 @@
+import ReactiveSwift
+import ReactiveCocoa
+import UIKit
+import Quick
+import Nimble
+import enum Result.NoError
+
+private final class PickerDataSource: NSObject, UIPickerViewDataSource {
+	@objc func numberOfComponents(in pickerView: UIPickerView) -> Int {
+		return 2
+	}
+
+	@objc func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+		return 4
+	}
+}
+
+final class UIPickerViewSpec: QuickSpec {
+	override func spec() {
+		var dataSource: UIPickerViewDataSource!
+		var pickerView: TestPickerView!
+		weak var _pickerView: UIPickerView?
+
+		beforeEach {
+			autoreleasepool {
+				dataSource = PickerDataSource()
+
+				pickerView = TestPickerView()
+				pickerView.dataSource = dataSource
+				pickerView.reloadAllComponents()
+				_pickerView = pickerView
+			}
+		}
+
+		afterEach {
+			autoreleasepool {
+				dataSource = nil
+				pickerView = nil
+			}
+			expect(_pickerView).toEventually(beNil())
+		}
+
+		it("should accept changes from bindings to selected rows") {
+
+			let (pipeSignal, observer) = Signal<Int, NoError>.pipe()
+			pickerView.reactive.selectedRow(inComponent: 0) <~ SignalProducer(pipeSignal)
+
+			let (anotherPipeSignal, anotherObserver) = Signal<Int, NoError>.pipe()
+			pickerView.reactive.selectedRow(inComponent: 1) <~ SignalProducer(anotherPipeSignal)
+
+			observer.send(value: 1)
+			expect(pickerView.selectedRow(inComponent: 0)) == 1
+
+			anotherObserver.send(value: 3)
+			expect(pickerView.selectedRow(inComponent: 1)) == 3
+
+			observer.send(value: 2)
+			expect(pickerView.selectedRow(inComponent: 0)) == 2
+		}
+
+		it("should emit user initiated changes for row selection") {
+			var latestValue = (0, 0)
+			pickerView.reactive.selections.observeValues {
+				latestValue = $0
+			}
+
+			pickerView.selectRow(1, inComponent: 0, animated: false)
+			pickerView.delegate!.pickerView!(pickerView, didSelectRow: 1, inComponent: 0)
+			expect(latestValue.0) == pickerView.selectedRow(inComponent: 0)
+			expect(latestValue.1) == 0
+
+			pickerView.selectRow(2, inComponent: 1, animated: false)
+			pickerView.delegate!.pickerView!(pickerView, didSelectRow: 2, inComponent: 1)
+			expect(latestValue.0) == pickerView.selectedRow(inComponent: 1)
+			expect(latestValue.1) == 1
+		}
+
+		it("invokes reloadAllComponents whenever the bound signal sends a value") {
+			let (signal, observer) = Signal<(), NoError>.pipe()
+
+			var reloadAllComponentsCount = 0
+
+			pickerView.reloadAllComponentsSignal.observeValues {
+				reloadAllComponentsCount += 1
+			}
+
+			pickerView.reactive.reloadAllComponents <~ signal
+
+			observer.send(value: ())
+			observer.send(value: ())
+
+			expect(reloadAllComponentsCount) == 2
+		}
+
+		it("invokes reloadComponent whenever the bound signal sends a value") {
+			let (signal, observer) = Signal<Int, NoError>.pipe()
+
+			var reloadFirstComponentCount = 0
+			var reloadSecondComponentCount = 0
+
+			pickerView.reloadComponentSignal.observeValues { component in
+				if (component == 0) {
+					reloadFirstComponentCount += 1
+				} else if (component == 1) {
+					reloadSecondComponentCount += 1
+				}
+			}
+
+			pickerView.reactive.reloadComponent <~ signal
+
+			observer.send(value: 3)
+			expect(reloadFirstComponentCount) == 0
+			expect(reloadSecondComponentCount) == 0
+
+			observer.send(value: 0)
+			observer.send(value: 0)
+			expect(reloadFirstComponentCount) == 2
+
+			observer.send(value: 1)
+			expect(reloadSecondComponentCount) == 1
+		}
+	}
+}
+
+private final class TestPickerView: UIPickerView {
+	let reloadAllComponentsSignal: Signal<(), NoError>
+	private let reloadAllComponentsObserver: Signal<(), NoError>.Observer
+
+	let reloadComponentSignal: Signal<Int, NoError>
+	private let reloadComponentObserver: Signal<Int, NoError>.Observer
+
+	init() {
+		(reloadAllComponentsSignal, reloadAllComponentsObserver) = Signal.pipe()
+		(reloadComponentSignal, reloadComponentObserver) = Signal.pipe()
+		super.init(frame: .zero)
+	}
+
+	required init?(coder aDecoder: NSCoder) {
+		(reloadAllComponentsSignal, reloadAllComponentsObserver) = Signal.pipe()
+		(reloadComponentSignal, reloadComponentObserver) = Signal.pipe()
+		super.init(coder: aDecoder)
+	}
+
+	override func reloadAllComponents() {
+		super.reloadAllComponents()
+		reloadAllComponentsObserver.send(value: ())
+	}
+
+	override func reloadComponent(_ component: Int) {
+		super.reloadComponent(component)
+		reloadComponentObserver.send(value: component)
+	}
+}

--- a/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
@@ -59,20 +59,20 @@ final class UIPickerViewSpec: QuickSpec {
 		}
 
 		it("should emit user initiated changes for row selection") {
-			var latestValue = (0, 0)
+			var latestValue: UIPickerViewSelection!
 			pickerView.reactive.selections.observeValues {
 				latestValue = $0
 			}
 
 			pickerView.selectRow(1, inComponent: 0, animated: false)
 			pickerView.delegate!.pickerView!(pickerView, didSelectRow: 1, inComponent: 0)
-			expect(latestValue.0) == pickerView.selectedRow(inComponent: 0)
-			expect(latestValue.1) == 0
+			expect(latestValue.component) == 0
+			expect(latestValue.row) == 1
 
 			pickerView.selectRow(2, inComponent: 1, animated: false)
 			pickerView.delegate!.pickerView!(pickerView, didSelectRow: 2, inComponent: 1)
-			expect(latestValue.0) == pickerView.selectedRow(inComponent: 1)
-			expect(latestValue.1) == 1
+			expect(latestValue.component) == 1
+			expect(latestValue.row) == 2
 		}
 
 		it("invokes reloadAllComponents whenever the bound signal sends a value") {

--- a/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
@@ -59,7 +59,7 @@ final class UIPickerViewSpec: QuickSpec {
 		}
 
 		it("should emit user initiated changes for row selection") {
-			var latestValue: UIPickerViewSelection!
+			var latestValue: (row: Int, component: Int)!
 			pickerView.reactive.selections.observeValues {
 				latestValue = $0
 			}


### PR DESCRIPTION
This adds support for proxying selectors with arguments in `ProxyDelegate` and uses this to provide `selections` on the `reactive` extension for `UIPickerView`.

I have added tests for the reactive extensions but not for the proxying behaviour (see [UISearchBarSpec](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/14d36c7c1bfd7e95af5862ac0328d679774d0b8e/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift#L69-L107)). I can add these if necessary.