### PR TITLE
Animation for BindingTargets

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -264,6 +264,9 @@
 		D0A2260F1A72F16D00D33B74 /* DynamicPropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A2260D1A72F16D00D33B74 /* DynamicPropertySpec.swift */; };
 		D9558AB81DFF805A003254E1 /* NSPopUpButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9558AB71DFF805A003254E1 /* NSPopUpButton.swift */; };
 		D9558AB91DFF86C0003254E1 /* NSPopUpButtonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9558AB51DFF7B90003254E1 /* NSPopUpButtonSpec.swift */; };
+		EAD598651E828AD70013F94C /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD598641E828AD70013F94C /* Animation.swift */; };
+		EAD598661E828AD70013F94C /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD598641E828AD70013F94C /* Animation.swift */; };
+		EAD598671E828AD70013F94C /* Animation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD598641E828AD70013F94C /* Animation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -471,6 +474,7 @@
 		D0A2260D1A72F16D00D33B74 /* DynamicPropertySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = DynamicPropertySpec.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D9558AB51DFF7B90003254E1 /* NSPopUpButtonSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPopUpButtonSpec.swift; sourceTree = "<group>"; };
 		D9558AB71DFF805A003254E1 /* NSPopUpButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPopUpButton.swift; sourceTree = "<group>"; };
+		EAD598641E828AD70013F94C /* Animation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -614,6 +618,7 @@
 				9A1D05FA1D93E9F100ACF44C /* UITextField.swift */,
 				9A1D05FB1D93E9F100ACF44C /* UITextView.swift */,
 				9A1D05FC1D93E9F100ACF44C /* UIView.swift */,
+				EAD598641E828AD70013F94C /* Animation.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -1178,6 +1183,7 @@
 				9AA0BD841DDE03F500531FCF /* ObjC+RuntimeSubclassing.swift in Sources */,
 				9AD0F06D1D48BA4800ADFAB7 /* NSObject+KeyValueObserving.swift in Sources */,
 				9A1D06211D93EA0100ACF44C /* UIView.swift in Sources */,
+				EAD598671E828AD70013F94C /* Animation.swift in Sources */,
 				538DCB7B1DCA5E6C00332880 /* NSLayoutConstraint.swift in Sources */,
 				9AA0BD9B1DDE7A2200531FCF /* ObjCRuntimeAliases.m in Sources */,
 				9ADE4A941DA6EA40005C2AC8 /* NSObject+ReactiveExtensionsProvider.swift in Sources */,
@@ -1261,6 +1267,7 @@
 				9A1D05E21D93E99100ACF44C /* NSObject+Association.swift in Sources */,
 				4A0E11011D2A92720065D310 /* NSObject+Lifetime.swift in Sources */,
 				9AE7C2A61DDD7F5100F7534C /* ObjC+Messages.swift in Sources */,
+				EAD598661E828AD70013F94C /* Animation.swift in Sources */,
 				9AD0F06C1D48BA4800ADFAB7 /* NSObject+KeyValueObserving.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1373,6 +1380,7 @@
 				538DCB7A1DCA5E6C00332880 /* NSLayoutConstraint.swift in Sources */,
 				9A1D06001D93EA0000ACF44C /* UIBarButtonItem.swift in Sources */,
 				9AA0BD991DDE7A2200531FCF /* ObjCRuntimeAliases.m in Sources */,
+				EAD598651E828AD70013F94C /* Animation.swift in Sources */,
 				9A1D05FF1D93EA0000ACF44C /* UIActivityIndicatorView.swift in Sources */,
 				9A54A21C1DE00D09001739B3 /* ObjC+Selector.swift in Sources */,
 				9AA0BD8B1DDE153A00531FCF /* ObjC+Constants.swift in Sources */,

--- a/ReactiveCocoa/UIKit/Animation.swift
+++ b/ReactiveCocoa/UIKit/Animation.swift
@@ -1,0 +1,104 @@
+//
+//  Animation.swift
+//  ReactiveCocoa
+//
+//  Created by Brendan Conron on 3/22/17.
+//  Copyright © 2017 GitHub. All rights reserved.
+//
+
+import Foundation
+import ReactiveSwift
+import Result
+import UIKit
+
+extension BindingTarget {
+
+	/// Binds a source to a target, updating and animating the target's value to the latest 
+	/// value sent by the source with the given duration, delay, and animation options.
+	///
+	/// - note: The binding will automatically terminate when the target is
+	///         deinitialized, or when the source sends a `completed` event.
+	///
+	/// - warning: Due to the nature of how `NSLayoutConstraint` is animated by
+	///            calling `view.layoutIfNeeded()`, using this method on 
+	///            `NSLayoutConstraint`'s `reactive.constant` property will not work
+	///            and may have unexpected behavior.
+	///
+	///````
+	/// let label = UILabel(frame: CGRect(width: 100, height: 100)
+	/// let disposable = label.reactive.alpha.animate(SignalProducer(value: 0), withDuration: 2)
+	///
+	/// // Terminate animation early before the signal's `completed` event.
+	/// disposable.dispose()
+	///````
+	///
+	/// - Parameters:
+	///   - source: A source to bind.
+	///   - duration: Duration of the animation.
+	///   - delay: Delay to apply.
+	///   - options: Animation options.
+	/// - Returns: A disposable that can be used to terminate binding before the
+	///			   deinitialization of the target of the source's `completed`
+    ///            event.
+	@discardableResult
+	public func animate<Source: BindingSource>(
+		source: Source,
+		withDuration duration: TimeInterval,
+		delay: TimeInterval = 0,
+		options: UIViewAnimationOptions = [])
+		-> Disposable? where Value == Source.Value, Source.Error == NoError {
+			let action = bindingTarget.action
+			return source.observe(Observer(value: { value in
+				UIView.animate(withDuration: duration, delay: delay, options: options, animations: {
+					action(value)
+
+				}, completion: nil)
+			}), during: bindingTarget.lifetime)
+	}
+
+}
+
+extension BindingTarget where Value: OptionalProtocol {
+
+	/// Binds a source to a target, updating and animating the target's value to the latest
+	/// value sent by the source with the given duration, delay, and animation options.
+	///
+	/// - note: The binding will automatically terminate when the target is
+	///         deinitialized, or when the source sends a `completed` event.
+	///
+	/// - warning: Due to the nature of how `NSLayoutConstraint` is animated by
+	///            calling `view.layoutIfNeeded()`, using this method on
+	///            `NSLayoutConstraint`'s `reactive.constant` property will not work
+	///            and may have unexpected behavior.
+	///
+	///````
+	/// let label = UILabel(frame: CGRect(width: 100, height: 100)
+	/// let disposable = label.reactive.alpha.animate(SignalProducer(value: 0), withDuration: 2)
+	///
+	/// // Terminate animation early before the signal's `completed` event.
+	/// disposable.dispose()
+	///````
+	///
+	/// - Parameters:
+	///   - source: A source to bind.
+	///   - duration: Duration of the animation.
+	///   - delay: Delay to apply.
+	///   - options: Animation options.
+	/// - Returns: A disposable that can be used to terminate binding before the
+	///			   deinitialization of the target of the source's `completed`
+	///            event.
+	@discardableResult
+	public func animate<Source: BindingSource>(
+		source: Source,
+		withDuration duration: TimeInterval,
+		delay: TimeInterval = 0, options:
+		UIViewAnimationOptions = [])
+		-> Disposable? where Value: OptionalProtocol, Source.Value == Value.Wrapped, Source.Error == NoError {
+			let action = bindingTarget.action
+			return source.observe(Observer(value: { value in
+				UIView.animate(withDuration: duration, delay: delay, options: options, animations: {
+					action(Value(reconstructing: value))
+				}, completion: nil)
+			}), during: bindingTarget.lifetime)
+	}
+}

--- a/ReactiveCocoa/UIKit/Animation.swift
+++ b/ReactiveCocoa/UIKit/Animation.swift
@@ -11,94 +11,99 @@ import ReactiveSwift
 import Result
 import UIKit
 
-extension BindingTarget {
+#if os(iOS) || os(tvOS)
 
-	/// Binds a source to a target, updating and animating the target's value to the latest 
-	/// value sent by the source with the given duration, delay, and animation options.
-	///
-	/// - note: The binding will automatically terminate when the target is
-	///         deinitialized, or when the source sends a `completed` event.
-	///
-	/// - warning: Due to the nature of how `NSLayoutConstraint` is animated by
-	///            calling `view.layoutIfNeeded()`, using this method on 
-	///            `NSLayoutConstraint`'s `reactive.constant` property will not work
-	///            and may have unexpected behavior.
-	///
-	///````
-	/// let label = UILabel(frame: CGRect(width: 100, height: 100)
-	/// let disposable = label.reactive.alpha.animate(SignalProducer(value: 0), withDuration: 2)
-	///
-	/// // Terminate animation early before the signal's `completed` event.
-	/// disposable.dispose()
-	///````
-	///
-	/// - Parameters:
-	///   - source: A source to bind.
-	///   - duration: Duration of the animation.
-	///   - delay: Delay to apply.
-	///   - options: Animation options.
-	/// - Returns: A disposable that can be used to terminate binding before the
-	///			   deinitialization of the target of the source's `completed`
-    ///            event.
-	@discardableResult
-	public func animate<Source: BindingSource>(
-		source: Source,
-		withDuration duration: TimeInterval,
-		delay: TimeInterval = 0,
-		options: UIViewAnimationOptions = [])
-		-> Disposable? where Value == Source.Value, Source.Error == NoError {
-			let action = bindingTarget.action
-			return source.observe(Observer(value: { value in
-				UIView.animate(withDuration: duration, delay: delay, options: options, animations: {
-					action(value)
+	extension BindingTarget {
 
-				}, completion: nil)
-			}), during: bindingTarget.lifetime)
+		/// Binds a source to a target, updating and animating the target's value to the latest
+		/// value sent by the source with the given duration, delay, and animation options.
+		///
+		/// - note: The binding will automatically terminate when the target is
+		///         deinitialized, or when the source sends a `completed` event.
+		///
+		/// - warning: Due to the nature of how `NSLayoutConstraint` is animated by
+		///            calling `view.layoutIfNeeded()`, using this method on
+		///            `NSLayoutConstraint`'s `reactive.constant` property will not work
+		///            and may have unexpected behavior.
+		///
+		///````
+		/// let label = UILabel(frame: CGRect(width: 100, height: 100)
+		/// let disposable = label.reactive.alpha.animate(SignalProducer(value: 0), withDuration: 2)
+		///
+		/// // Terminate animation early before the signal's `completed` event.
+		/// disposable.dispose()
+		///````
+		///
+		/// - Parameters:
+		///   - source: A source to bind.
+		///   - duration: Duration of the animation.
+		///   - delay: Delay to apply.
+		///   - options: Animation options.
+		/// - Returns: A disposable that can be used to terminate binding before the
+		///			   deinitialization of the target of the source's `completed`
+		///            event.
+		@discardableResult
+		public func animate<Source: BindingSource>(
+			source: Source,
+			withDuration duration: TimeInterval,
+			delay: TimeInterval = 0,
+			options: UIViewAnimationOptions = [])
+			-> Disposable? where Value == Source.Value, Source.Error == NoError {
+				let action = bindingTarget.action
+				return source.observe(Observer(value: { value in
+					UIView.animate(withDuration: duration, delay: delay, options: options, animations: {
+						action(value)
+
+					}, completion: nil)
+				}), during: bindingTarget.lifetime)
+		}
+
 	}
 
-}
+	extension BindingTarget where Value: OptionalProtocol {
 
-extension BindingTarget where Value: OptionalProtocol {
-
-	/// Binds a source to a target, updating and animating the target's value to the latest
-	/// value sent by the source with the given duration, delay, and animation options.
-	///
-	/// - note: The binding will automatically terminate when the target is
-	///         deinitialized, or when the source sends a `completed` event.
-	///
-	/// - warning: Due to the nature of how `NSLayoutConstraint` is animated by
-	///            calling `view.layoutIfNeeded()`, using this method on
-	///            `NSLayoutConstraint`'s `reactive.constant` property will not work
-	///            and may have unexpected behavior.
-	///
-	///````
-	/// let label = UILabel(frame: CGRect(width: 100, height: 100)
-	/// let disposable = label.reactive.alpha.animate(SignalProducer(value: 0), withDuration: 2)
-	///
-	/// // Terminate animation early before the signal's `completed` event.
-	/// disposable.dispose()
-	///````
-	///
-	/// - Parameters:
-	///   - source: A source to bind.
-	///   - duration: Duration of the animation.
-	///   - delay: Delay to apply.
-	///   - options: Animation options.
-	/// - Returns: A disposable that can be used to terminate binding before the
-	///			   deinitialization of the target of the source's `completed`
-	///            event.
-	@discardableResult
-	public func animate<Source: BindingSource>(
-		source: Source,
-		withDuration duration: TimeInterval,
-		delay: TimeInterval = 0, options:
-		UIViewAnimationOptions = [])
-		-> Disposable? where Value: OptionalProtocol, Source.Value == Value.Wrapped, Source.Error == NoError {
-			let action = bindingTarget.action
-			return source.observe(Observer(value: { value in
-				UIView.animate(withDuration: duration, delay: delay, options: options, animations: {
-					action(Value(reconstructing: value))
-				}, completion: nil)
-			}), during: bindingTarget.lifetime)
+		/// Binds a source to a target, updating and animating the target's value to the latest
+		/// value sent by the source with the given duration, delay, and animation options.
+		///
+		/// - note: The binding will automatically terminate when the target is
+		///         deinitialized, or when the source sends a `completed` event.
+		///
+		/// - warning: Due to the nature of how `NSLayoutConstraint` is animated by
+		///            calling `view.layoutIfNeeded()`, using this method on
+		///            `NSLayoutConstraint`'s `reactive.constant` property will not work
+		///            and may have unexpected behavior.
+		///
+		///````
+		/// let label = UILabel(frame: CGRect(width: 100, height: 100)
+		/// let disposable = label.reactive.alpha.animate(SignalProducer(value: 0), withDuration: 2)
+		///
+		/// // Terminate animation early before the signal's `completed` event.
+		/// disposable.dispose()
+		///````
+		///
+		/// - Parameters:
+		///   - source: A source to bind.
+		///   - duration: Duration of the animation.
+		///   - delay: Delay to apply.
+		///   - options: Animation options.
+		/// - Returns: A disposable that can be used to terminate binding before the
+		///			   deinitialization of the target of the source's `completed`
+		///            event.
+		@discardableResult
+		public func animate<Source: BindingSource>(
+			source: Source,
+			withDuration duration: TimeInterval,
+			delay: TimeInterval = 0, options:
+			UIViewAnimationOptions = [])
+			-> Disposable? where Value: OptionalProtocol, Source.Value == Value.Wrapped, Source.Error == NoError {
+				let action = bindingTarget.action
+				return source.observe(Observer(value: { value in
+					UIView.animate(withDuration: duration, delay: delay, options: options, animations: {
+						action(Value(reconstructing: value))
+					}, completion: nil)
+				}), during: bindingTarget.lifetime)
+		}
 	}
-}
+
+
+#endif


### PR DESCRIPTION
This PR is a proposal for animatable signals by adding a small extension on `BindingTarget`. Targets now have `animate(source:withDuration:delay:options:)` methods, one for non-optional and one for optional handling, that can be called to animate any values through the pipeline.

This does not work with `NSLayoutConstraint` however due to the nature of how it's animated using `view.layoutIfNeeded` instead of applying the value directly. I'm open to any ideas on how to go about implementing that. 