### PR TITLE
Fixed an occurrence of exception due to key path tail observers not being detached.

### DIFF
--- a/ReactiveCocoa/NSObject+KeyValueObserving.swift
+++ b/ReactiveCocoa/NSObject+KeyValueObserving.swift
@@ -110,13 +110,13 @@ extension KeyValueObserver {
 		//
 		// Attempting to observe non-weak properties using dynamic getters will
 		// result in broken behavior, so don't even try.
-		let shouldObserveDeinit = keyPathHead.withCString { cString -> Bool in
+		let (shouldObserveDeinit, isWeak) = keyPathHead.withCString { cString -> (Bool, Bool) in
 			if let propertyPointer = class_getProperty(type(of: object), cString) {
 				let attributes = PropertyAttributes(property: propertyPointer)
-				return attributes.isObject && attributes.isWeak && attributes.objectClass != NSClassFromString("Protocol") && !attributes.isBlock
+				return (attributes.isObject && attributes.objectClass != NSClassFromString("Protocol") && !attributes.isBlock, attributes.isWeak)
 			}
 
-			return false
+			return (false, false)
 		}
 
 		// Establish the observation.
@@ -137,7 +137,12 @@ extension KeyValueObserver {
 
 				if shouldObserveDeinit {
 					let disposable = value.reactive.lifetime.ended.observeCompleted {
-						action(nil)
+						if isWeak {
+							action(nil)
+						}
+
+						// Detach the key path tail observers eagarly.
+						headSerialDisposable.inner = nil
 					}
 					headDisposable += disposable
 				}

--- a/ReactiveCocoaTests/KeyValueObservingSpec.swift
+++ b/ReactiveCocoaTests/KeyValueObservingSpec.swift
@@ -144,8 +144,30 @@ class KeyValueObservingSpec: QuickSpec {
 				expect(values) == [0, 1, 0, 10]
 			}
 
+			it("should not retain the replaced value") {
+				let parentObject = NestedObservableObject()
+
+				autoreleasepool {
+					_ = parentObject.reactive
+						.values(forKeyPath: "rac_object")
+						.start()
+				}
+
+				weak var weakOriginalInner: ObservableObject? = parentObject.rac_object
+				expect(weakOriginalInner).toNot(beNil())
+
+				parentObject.rac_object = ObservableObject()
+				expect(weakOriginalInner).to(beNil())
+			}
+
 			it("should not retain replaced value in a nested key path") {
 				let parentObject = NestedObservableObject()
+
+				autoreleasepool {
+					_ = parentObject.reactive
+						.values(forKeyPath: "rac_object.rac_value")
+						.start()
+				}
 
 				weak var weakOriginalInner: ObservableObject? = parentObject.rac_object
 				expect(weakOriginalInner).toNot(beNil())


### PR DESCRIPTION
A spun-off from #3413.

This happens specifically when a nested key path is being observed, for example `parent.child`, where `parent` is being replaced by a new object.

`KeyValueObserver` is not eager enough to clean up the tails, causing the then-deallocated object (the original `parent`) to have still observers attached, and eventually the KVO exception.

A new test case was also added for non-nested key path, just in case.