### PR TITLE
Revamped `DelegateProxy` for public API exposure.

### DIFF
--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -1,40 +1,87 @@
 import ReactiveSwift
 import enum Result.NoError
 
-internal class DelegateProxy<Delegate: NSObjectProtocol>: NSObject {
-	internal weak var forwardee: Delegate? {
+extension Reactive where Base: NSObject, Base: DelegateProxyProtocol {
+	/// Create a signal which sends a `next` event at the end of every invocation
+	/// of `selector` on the object.
+	///
+	/// It completes when the object deinitializes.
+	///
+	/// - note: Observers to the resulting signal should not call the method
+	///         specified by the selector.
+	///
+	/// - parameters:
+	///   - selector: The selector to observe.
+	///
+	/// - returns:
+	///   A trigger signal.
+	public func trigger(for selector: Selector) -> Signal<(), NoError> {
+		let proxy = base.proxy
+		proxy.interceptedSelectors.insert(selector)
+		proxy.originalSetter(proxy)
+
+		return (proxy as NSObject)
+			.reactive
+			.trigger(for: selector)
+			.take(during: proxy.lifetime)
+	}
+
+	/// Create a signal which sends a `next` event, containing an array of bridged
+	/// arguments, at the end of every invocation of `selector` on the object.
+	///
+	/// It completes when the object deinitializes.
+	///
+	/// - note: Observers to the resulting signal should not call the method
+	///         specified by the selector.
+	///
+	/// - parameters:
+	///   - selector: The selector to observe.
+	///
+	/// - returns:
+	///   A signal that sends an array of bridged arguments.
+	public func signal(for selector: Selector) -> Signal<[Any?], NoError> {
+		let proxy = base.proxy
+		proxy.interceptedSelectors.insert(selector)
+		proxy.originalSetter(proxy)
+
+		return (proxy as NSObject)
+			.reactive
+			.signal(for: selector)
+			.take(during: proxy.lifetime)
+	}
+}
+
+public protocol DelegateProxyProtocol: class {
+	associatedtype Delegate: NSObjectProtocol
+
+	var proxy: DelegateProxy<Delegate> { get }
+}
+
+public class DelegateProxy<Delegate: NSObjectProtocol>: NSObject, DelegateProxyProtocol {
+	public weak var forwardee: Delegate? {
 		didSet {
 			originalSetter(self)
 		}
 	}
 
-	internal var interceptedSelectors: Set<Selector> = []
+	fileprivate var interceptedSelectors: Set<Selector> = []
+	fileprivate let originalSetter: (AnyObject) -> Void
+	fileprivate let lifetime: Lifetime
 
-	private let lifetime: Lifetime
-	private let originalSetter: (AnyObject) -> Void
+	public var proxy: DelegateProxy<Delegate> {
+		return self
+	}
 
-	required init(lifetime: Lifetime, _ originalSetter: @escaping (AnyObject) -> Void) {
+	public required init(lifetime: Lifetime, _ originalSetter: @escaping (AnyObject) -> Void) {
 		self.lifetime = lifetime
 		self.originalSetter = originalSetter
 	}
 
-	override func forwardingTarget(for selector: Selector!) -> Any? {
+	public override func forwardingTarget(for selector: Selector!) -> Any? {
 		return interceptedSelectors.contains(selector) ? nil : forwardee
 	}
 
-	func intercept(_ selector: Selector) -> Signal<(), NoError> {
-		interceptedSelectors.insert(selector)
-		originalSetter(self)
-		return self.reactive.trigger(for: selector).take(during: lifetime)
-	}
-
-	func intercept(_ selector: Selector) -> Signal<[Any?], NoError> {
-		interceptedSelectors.insert(selector)
-		originalSetter(self)
-		return self.reactive.signal(for: selector).take(during: lifetime)
-	}
-
-	override func responds(to selector: Selector!) -> Bool {
+	public override func responds(to selector: Selector!) -> Bool {
 		if interceptedSelectors.contains(selector) {
 			return true
 		}
@@ -50,7 +97,17 @@ extension DelegateProxy {
 	//        through a protocol would result in the following error messages:
 	//        1. PHI node operands are not the same type as the result!
 	//        2. LLVM ERROR: Broken function found, compilation aborted!
-	internal static func proxy<P: DelegateProxy<Delegate>>(
+	/// Initialize a proxy for `Delegate`, and install it into the given instance.
+	///
+	/// - parameters:
+	///   - instance: The instance to be intercepted by the proxy.
+	///   - setter: The selector of the delegate setter.
+	///   - getter: The selector of the delegate getter.
+	///   - key: A unique key which identifies the proxy.
+	///
+	/// - returns:
+	///   The delegate proxy.
+	public static func proxy<P: DelegateProxy<Delegate>>(
 		for instance: NSObject,
 		setter: Selector,
 		getter: Selector,

--- a/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
@@ -37,7 +37,7 @@ extension Reactive where Base: UIPickerView {
 	/// - returns:
 	///   A trigger signal.
 	public var selections: Signal<(row: Int, component: Int), NoError> {
-		return proxy.intercept(#selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)))
+		return proxy.reactive.signal(for: #selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)))
 			.map { (row: $0[1] as! Int, component: $0[2] as! Int) }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -29,7 +29,7 @@ extension Reactive where Base: UISearchBar {
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
-		return proxy.intercept(#selector(UISearchBarDelegate.searchBarTextDidEndEditing))
+		return proxy.reactive.trigger(for: #selector(UISearchBarDelegate.searchBarTextDidEndEditing))
 			.map { [unowned base] in base.text }
 	}
 
@@ -37,7 +37,7 @@ extension Reactive where Base: UISearchBar {
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {
-		return proxy.intercept(#selector(UISearchBarDelegate.searchBar(_:textDidChange:)))
+		return proxy.reactive.trigger(for: #selector(UISearchBarDelegate.searchBar(_:textDidChange:)))
 			.map { [unowned base] in base.text }
 	}
 	

--- a/ReactiveCocoaTests/DelegateProxySpec.swift
+++ b/ReactiveCocoaTests/DelegateProxySpec.swift
@@ -95,7 +95,7 @@ class DelegateProxySpec: QuickSpec {
 			it("should complete its signals when the object deinitializes") {
 				var isCompleted = false
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), NoError> = proxy.reactive.trigger(for: #selector(ObjectDelegate.foo))
 				foo.observeCompleted { isCompleted = true }
 
 				expect(isCompleted) == false
@@ -109,7 +109,7 @@ class DelegateProxySpec: QuickSpec {
 
 				object = nil
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), NoError> = proxy.reactive.trigger(for: #selector(ObjectDelegate.foo))
 				foo.observeInterrupted { isInterrupted = true }
 
 				expect(isInterrupted) == true
@@ -119,10 +119,10 @@ class DelegateProxySpec: QuickSpec {
 				var fooCount = 0
 				var barCount = 0
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), NoError> = proxy.reactive.trigger(for: #selector(ObjectDelegate.foo))
 				foo.observeValues { fooCount += 1 }
 
-				let bar: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.bar))
+				let bar: Signal<(), NoError> = proxy.reactive.trigger(for: #selector(ObjectDelegate.bar))
 				bar.observeValues { barCount += 1 }
 
 				expect(fooCount) == 0
@@ -157,7 +157,7 @@ class DelegateProxySpec: QuickSpec {
 
 				var fooCount = 0
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), NoError> = proxy.reactive.trigger(for: #selector(ObjectDelegate.foo))
 				foo.observeValues { fooCount += 1 }
 
 				expect(fooCount) == 0
@@ -178,7 +178,7 @@ class DelegateProxySpec: QuickSpec {
 
 				var barCount = 0
 
-				let bar: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.bar))
+				let bar: Signal<(), NoError> = proxy.reactive.trigger(for: #selector(ObjectDelegate.bar))
 				bar.observeValues { barCount += 1 }
 
 				object.delegate?.bar?()


### PR DESCRIPTION
#### Changes
1. `DelegateProxy` is now public.

2. Replaced the `DelegateProxy.intercept` methods with overloads of `DelegateProxy.reactive.trigger(for:)` and `DelegateProxy.reactive.signal(for:)`.