### PR TITLE
DelegateProxy bugfixes + test cases

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -153,6 +153,9 @@
 		9A7488491E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
 		9A74884A1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
 		9A74884B1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
+		9A892D8F1E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */; };
+		9A892D901E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */; };
+		9A892D911E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */; };
 		9A9A129A1DC7A97100D10223 /* UIGestureRecognizerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4191394B1DBA002C0043C9D1 /* UIGestureRecognizerSpec.swift */; };
 		9A9DFEE51DA7B5500039EE1B /* NSObject+Intercepting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D065A1D93EC6E00ACF44C /* NSObject+Intercepting.swift */; };
 		9A9DFEE91DA7EFB60039EE1B /* AssociationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */; };
@@ -398,6 +401,7 @@
 		9A6AAA271DB8F7EB0013AAEA /* ReusableComponentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponentsSpec.swift; sourceTree = "<group>"; };
 		9A6AAA291DB8F7F10013AAEA /* ReusableComponentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponentsSpec.swift; sourceTree = "<group>"; };
 		9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxy.swift; sourceTree = "<group>"; };
+		9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxySpec.swift; sourceTree = "<group>"; };
 		9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationSpec.swift; sourceTree = "<group>"; };
 		9AA0BD771DDE03DE00531FCF /* ObjC+Runtime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+Runtime.swift"; sourceTree = "<group>"; };
 		9AA0BD801DDE03F500531FCF /* ObjC+RuntimeSubclassing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+RuntimeSubclassing.swift"; sourceTree = "<group>"; };
@@ -783,6 +787,7 @@
 				538DCB771DCA5E3200332880 /* Shared */,
 				9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */,
 				CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */,
+				9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* DynamicPropertySpec.swift */,
 				B696FB801A7640C00075236D /* TestError.swift */,
 				9A1E72B91D4DE96500CC20C3 /* KeyValueObservingSpec.swift */,
@@ -1227,6 +1232,7 @@
 				9A1D06371D93EA7E00ACF44C /* UIActivityIndicatorViewSpec.swift in Sources */,
 				9A6AAA2F1DB903A40013AAEA /* ReusableComponentsSpec.swift in Sources */,
 				538DCB7F1DCA5E9B00332880 /* NSLayoutConstraintSpec.swift in Sources */,
+				9A892D911E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */,
 				9A1D06471D93EA7E00ACF44C /* UILabelSpec.swift in Sources */,
 				9A1D06391D93EA7E00ACF44C /* UIBarButtonItemSpec.swift in Sources */,
 				7DFBED6D1CDB8F7D00EE435B /* SignalProducerNimbleMatchers.swift in Sources */,
@@ -1321,6 +1327,7 @@
 				9ADFE5A11DBFFBCF001E11F7 /* LifetimeSpec.swift in Sources */,
 				4ABEFE331DCFD0630066A8C2 /* NSCollectionViewSpec.swift in Sources */,
 				B696FB811A7640C00075236D /* TestError.swift in Sources */,
+				9A892D8F1E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */,
 				004FD0071E26CDB300A03A82 /* NSButtonSpec.swift in Sources */,
 				D9558AB91DFF86C0003254E1 /* NSPopUpButtonSpec.swift in Sources */,
 				BFA6B94D1A7604D400C846D1 /* SignalProducerNimbleMatchers.swift in Sources */,
@@ -1406,6 +1413,7 @@
 				9A24A8461DE142A500987AF9 /* SwizzlingSpec.swift in Sources */,
 				9A1D063E1D93EA7E00ACF44C /* UIControl+EnableSendActionsForControlEvents.swift in Sources */,
 				4191394E1DBA01A00043C9D1 /* UIGestureRecognizerSpec.swift in Sources */,
+				9A892D901E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */,
 				531866FA1DD7925600D1285F /* UIStepperSpec.swift in Sources */,
 				9A1D06361D93EA7E00ACF44C /* UIActivityIndicatorViewSpec.swift in Sources */,
 				9A1D06461D93EA7E00ACF44C /* UILabelSpec.swift in Sources */,

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -39,7 +39,7 @@ internal class DelegateProxy<Delegate: NSObjectProtocol>: NSObject {
 			return true
 		}
 
-		return forwardee?.responds(to: selector) ?? super.responds(to: selector)
+		return (forwardee?.responds(to: selector) ?? false) || super.responds(to: selector)
 	}
 }
 

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -99,11 +99,11 @@ extension DelegateProxy {
 
 			instance.associations.setValue(proxy, forKey: key)
 
+			// `proxy.forwardee` would invoke the original setter regardless of
+			// `original` being `nil` or not.
 			let original = unsafeBitCast(getterImpl, to: Getter.self)(instance, getter) as! Delegate?
 			proxy.forwardee = original
 
-			unsafeBitCast(originalSetterImpl, to: Setter.self)(instance, setter, proxy)
-			
 			return proxy
 		}
 	}

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -70,9 +70,9 @@ extension DelegateProxy {
 				return proxy
 			}
 
-			let newSetterImpl: @convention(block) (NSObject, NSObject) -> Void = { object, delegate in
+			let newSetterImpl: @convention(block) (NSObject, AnyObject?) -> Void = { object, delegate in
 				let proxy = object.associations.value(forKey: key)!
-				proxy.forwardee = (delegate as! Delegate)
+				proxy.forwardee = (delegate as! Delegate?)
 			}
 
 			// Hide the original setter, and redirect subsequent delegate assignment
@@ -84,8 +84,8 @@ extension DelegateProxy {
 			let originalSetterImpl: IMP = class_getMethodImplementation(realClass, setter)
 			let getterImpl: IMP = class_getMethodImplementation(realClass, getter)
 
-			typealias Setter = @convention(c) (AnyObject, Selector, AnyObject) -> Void
-			typealias Getter = @convention(c) (AnyObject, Selector) -> NSObject?
+			typealias Setter = @convention(c) (NSObject, Selector, AnyObject?) -> Void
+			typealias Getter = @convention(c) (NSObject, Selector) -> AnyObject?
 
 			// As Objective-C classes may cache the information of their delegate at
 			// the time the delegates are set, the information has to be "flushed"

--- a/ReactiveCocoaTests/DelegateProxySpec.swift
+++ b/ReactiveCocoaTests/DelegateProxySpec.swift
@@ -1,0 +1,216 @@
+import Quick
+import Nimble
+import enum Result.NoError
+import ReactiveSwift
+@testable import ReactiveCocoa
+
+@objc protocol ObjectDelegate: NSObjectProtocol {
+	func foo()
+	@objc optional func bar()
+	@objc optional func nop()
+}
+
+class Object: NSObject {
+	var delegateSetCount = 0
+	var delegateSelectors: [Selector] = []
+
+	weak var delegate: ObjectDelegate? {
+		didSet {
+			delegateSetCount += 1
+			delegateSelectors = Array()
+
+			if delegate?.responds(to: #selector(ObjectDelegate.foo)) ?? false {
+				delegateSelectors.append(#selector(ObjectDelegate.foo))
+			}
+
+			if delegate?.responds(to: #selector(ObjectDelegate.bar)) ?? false {
+				delegateSelectors.append(#selector(ObjectDelegate.bar))
+			}
+
+			if delegate?.responds(to: #selector(ObjectDelegate.nop)) ?? false {
+				delegateSelectors.append(#selector(ObjectDelegate.nop))
+			}
+		}
+	}
+
+	deinit {
+		// Mimic the behavior of clearing delegates of some Cocoa classes.
+		delegate = nil
+	}
+}
+
+class ObjectDelegateCounter: NSObject, ObjectDelegate {
+	var fooCounter = 0
+	var nopCounter = 0
+
+	func foo() {
+		fooCounter += 1
+	}
+
+	func nop() {
+		nopCounter += 1
+	}
+}
+
+class ObjectDelegateProxy: DelegateProxy<ObjectDelegate>, ObjectDelegate {
+	func foo() {
+		forwardee?.foo()
+	}
+
+	func bar() {
+		forwardee?.bar?()
+	}
+}
+
+class DelegateProxySpec: QuickSpec {
+	override func spec() {
+		describe("DelegateProxy") {
+			var object: Object!
+			var proxy: DelegateProxy<ObjectDelegate>!
+
+			beforeEach {
+				object = Object()
+				proxy = ObjectDelegateProxy.proxy(for: object,
+				                                  setter: #selector(setter: object.delegate),
+				                                  getter: #selector(getter: object.delegate))
+			}
+
+			afterEach {
+				weak var weakObject = object
+
+				object = nil
+				expect(weakObject).to(beNil())
+			}
+
+			it("should be automatically set as the object's delegate.") {
+				expect(object.delegate).to(beIdenticalTo(proxy))
+			}
+
+			it("should respond to the protocol requirement checks.") {
+				expect(proxy.responds(to: #selector(ObjectDelegate.foo))) == true
+				expect(proxy.responds(to: #selector(ObjectDelegate.bar))) == true
+				expect(proxy.responds(to: #selector(ObjectDelegate.nop))) == false
+			}
+
+			it("should complete its signals when the object deinitializes") {
+				var isCompleted = false
+
+				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				foo.observeCompleted { isCompleted = true }
+
+				expect(isCompleted) == false
+
+				object = nil
+				expect(isCompleted) == true
+			}
+
+			it("should interrupt the observers if the object has already deinitialized") {
+				var isInterrupted = false
+
+				object = nil
+
+				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				foo.observeInterrupted { isInterrupted = true }
+
+				expect(isInterrupted) == true
+			}
+
+			it("should emit a `value` event whenever any delegate method is invoked.") {
+				var fooCount = 0
+				var barCount = 0
+
+				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				foo.observeValues { fooCount += 1 }
+
+				let bar: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.bar))
+				bar.observeValues { barCount += 1 }
+
+				expect(fooCount) == 0
+				expect(barCount) == 0
+
+				object.delegate?.foo()
+				object.delegate?.bar?()
+				expect(fooCount) == 1
+				expect(barCount) == 1
+
+				object.delegate?.foo()
+				expect(fooCount) == 2
+
+				object.delegate?.bar?()
+				expect(barCount) == 2
+			}
+
+			it("should accomodate forwardee changes when responding to the protocol requirement checks.") {
+				expect(proxy.responds(to: #selector(ObjectDelegate.nop))) == false
+
+				let forwardee = ObjectDelegateCounter()
+				proxy.forwardee = forwardee
+				expect(proxy.responds(to: #selector(ObjectDelegate.nop))) == true
+
+				proxy.forwardee = nil
+				expect(proxy.responds(to: #selector(ObjectDelegate.nop))) == false
+			}
+
+			it("should invoke the method on the forwardee.") {
+				let forwardee = ObjectDelegateCounter()
+				proxy.forwardee = forwardee
+
+				var fooCount = 0
+
+				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				foo.observeValues { fooCount += 1 }
+
+				expect(fooCount) == 0
+				expect(forwardee.fooCounter) == 0
+
+				object.delegate?.foo()
+				expect(fooCount) == 1
+				expect(forwardee.fooCounter) == 1
+
+				object.delegate?.foo()
+				expect(fooCount) == 2
+				expect(forwardee.fooCounter) == 2
+			}
+
+			it("should emit a `value` event for an optional requirement even if the forwardee does not implement it.") {
+				let forwardee = ObjectDelegateCounter()
+				proxy.forwardee = forwardee
+
+				var barCount = 0
+
+				let bar: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.bar))
+				bar.observeValues { barCount += 1 }
+
+				object.delegate?.bar?()
+				expect(barCount) == 1
+			}
+
+			it("should invoke an optional requirement on the forwardee even if it does not implement it.") {
+				let forwardee = ObjectDelegateCounter()
+				proxy.forwardee = forwardee
+
+				expect(forwardee.nopCounter) == 0
+
+				object.delegate?.nop?()
+				expect(forwardee.nopCounter) == 1
+			}
+
+			it("should invoke the original delegate setter whenever the forwardee is updated.") {
+				// The expected initial count is accounted for the proxy setup.
+				expect(object.delegateSetCount) == 1
+				expect(object.delegateSelectors) == [#selector(ObjectDelegate.foo), #selector(ObjectDelegate.bar)]
+
+				let forwardee = ObjectDelegateCounter()
+				proxy.forwardee = forwardee
+				expect(object.delegateSetCount) == 2
+				expect(object.delegateSelectors) == [#selector(ObjectDelegate.foo), #selector(ObjectDelegate.bar), #selector(ObjectDelegate.nop)]
+				expect(object.delegate).to(beIdenticalTo(proxy))
+
+				proxy.forwardee = nil
+				expect(object.delegateSetCount) == 3
+				expect(object.delegateSelectors) == [#selector(ObjectDelegate.foo), #selector(ObjectDelegate.bar)]
+				expect(object.delegate).to(beIdenticalTo(proxy))
+			}
+		}
+	}
+}


### PR DESCRIPTION
1. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3425/commits/6b38abc1efc8863e71877de4d38a805e3b359cdd fixed the crash when setting `DelegateProxy.forwardee` to `nil`.

2. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3425/commits/d0b874fccd096718eac8a06d1f0eeed7ed847ebe changed `DelegateProxy` to always complete its signals when the delegator has deinitialized. The current version would not have the signals completed if the proxy is retained externally (w.r.t. `DelegateProxy.proxy`).

3. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3425/commits/a9631a05742247edd7a50e6603e8fa029fe62320 fixed a false negative in `DelegateProxy.responds(to:)`, which causes it not reporting an implemented requirement in a circumstance.

4. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3425/commits/79add39d676e62e9870d667de3d882bfc72e5b9a added a bunch of test cases for `DelegateProxy`.

5. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3425/commits/f21fb2bb8eb4df674a045c0f5bc51dd49f471642 was a minor refactoring.