### PR TITLE
Improve the interoperability of all ObjC swizzling activities in the framework.

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		834DE1121E4120340099F4E5 /* NSSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834DE1111E4120340099F4E5 /* NSSegmentedControl.swift */; };
 		834DE1141E4122910099F4E5 /* NSSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834DE1131E4122910099F4E5 /* NSSlider.swift */; };
 		8392D8FD1DB93E5E00504ED4 /* NSImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8392D8FC1DB93E5E00504ED4 /* NSImageView.swift */; };
+		9A0726F31E912B610081F3F7 /* ActionProxySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0726F21E912B610081F3F7 /* ActionProxySpec.swift */; };
 		9A1D05E01D93E99100ACF44C /* NSObject+Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D05DF1D93E99100ACF44C /* NSObject+Association.swift */; };
 		9A1D05E11D93E99100ACF44C /* NSObject+Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D05DF1D93E99100ACF44C /* NSObject+Association.swift */; };
 		9A1D05E21D93E99100ACF44C /* NSObject+Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D05DF1D93E99100ACF44C /* NSObject+Association.swift */; };
@@ -371,6 +372,7 @@
 		834DE1111E4120340099F4E5 /* NSSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSSegmentedControl.swift; sourceTree = "<group>"; };
 		834DE1131E4122910099F4E5 /* NSSlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSSlider.swift; sourceTree = "<group>"; };
 		8392D8FC1DB93E5E00504ED4 /* NSImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSImageView.swift; sourceTree = "<group>"; };
+		9A0726F21E912B610081F3F7 /* ActionProxySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionProxySpec.swift; sourceTree = "<group>"; };
 		9A1D05DF1D93E99100ACF44C /* NSObject+Association.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Association.swift"; sourceTree = "<group>"; };
 		9A1D05EC1D93E9F100ACF44C /* UIActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorView.swift; sourceTree = "<group>"; };
 		9A1D05ED1D93E9F100ACF44C /* UIBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItem.swift; sourceTree = "<group>"; };
@@ -680,6 +682,7 @@
 		9ADE4A8C1DA6D94C005C2AC8 /* AppKit */ = {
 			isa = PBXGroup;
 			children = (
+				9A0726F21E912B610081F3F7 /* ActionProxySpec.swift */,
 				4ABEFE311DCFD05F0066A8C2 /* NSCollectionViewSpec.swift */,
 				9ADE4A8D1DA6D965005C2AC8 /* NSControlSpec.swift */,
 				4ABEFE2C1DCFD0180066A8C2 /* NSTableViewSpec.swift */,
@@ -1344,6 +1347,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				834DE1011E4109750099F4E5 /* NSImageViewSpec.swift in Sources */,
+				9A0726F31E912B610081F3F7 /* ActionProxySpec.swift in Sources */,
 				9A6AAA0E1DB6A4CF0013AAEA /* InterceptingSpec.swift in Sources */,
 				9A54A2111DDF5B4D001739B3 /* InterceptingPerformanceTests.swift in Sources */,
 				538DCB7D1DCA5E9B00332880 /* NSLayoutConstraintSpec.swift in Sources */,

--- a/ReactiveCocoa/AppKit/ActionProxy.swift
+++ b/ReactiveCocoa/AppKit/ActionProxy.swift
@@ -52,9 +52,8 @@ extension Reactive where Base: NSObject, Base: ActionMessageSending {
 			proxy.target = base.target
 			proxy.action = base.action
 
-			// The proxy must be associated after it is set as the target, since
-			// `base` may be an isa-swizzled instance that is using the injected
-			// setters below.
+			// Set the proxy as the new delegate with all dynamic interception bypassed
+			// by directly invoking setters in the original class.
 			typealias TargetSetter = @convention(c) (NSObject, Selector, AnyObject?) -> Void
 			typealias ActionSetter = @convention(c) (NSObject, Selector, Selector?) -> Void
 

--- a/ReactiveCocoa/AppKit/ActionProxy.swift
+++ b/ReactiveCocoa/AppKit/ActionProxy.swift
@@ -2,7 +2,7 @@ import AppKit
 import ReactiveSwift
 import enum Result.NoError
 
-internal final class ActionProxy<Owner: AnyObject> {
+internal final class ActionProxy<Owner: AnyObject>: NSObject {
 	internal weak var target: AnyObject?
 	internal var action: Selector?
 	internal let invoked: Signal<Owner, NoError>
@@ -19,7 +19,11 @@ internal final class ActionProxy<Owner: AnyObject> {
 	// In AppKit, action messages always have only one parameter.
 	@objc func invoke(_ sender: Any?) {
 		if let action = action {
-			NSApp.sendAction(action, to: target, from: sender)
+			if let app = NSApp {
+				app.sendAction(action, to: target, from: sender)
+			} else {
+				_ = target?.perform(action, with: sender)
+			}
 		}
 
 		observer.send(value: owner)

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -71,16 +71,19 @@ extension DelegateProxy {
 				return proxy
 			}
 
+			let invokeOriginalSetter: @convention(c) (NSObject, Selector, AnyObject?) -> Void = { object, selector, delegate in
+				typealias Setter = @convention(c) (NSObject, Selector, AnyObject?) -> Void
+				let impl = class_getMethodImplementation(object.objcClass, selector)
+				unsafeBitCast(impl, to: Setter.self)(object, selector, delegate)
+			}
+
 			let newSetterImpl: @convention(block) (NSObject, AnyObject?) -> Void = { object, delegate in
 				let proxyMap = object.associations.value(forKey: proxyMapKey)
 
 				if let proxy = proxyMap.first(where: { $0.0 == setter })?.1 as! DelegateProxy<Delegate>? {
 					proxy.forwardee = (delegate as! Delegate?)
 				} else {
-					typealias Setter = @convention(c) (NSObject, Selector, AnyObject?) -> Void
-					let impl = class_getMethodImplementation(object.objcClass, setter)
-					let delegateSetter = unsafeBitCast(impl, to: Setter.self)
-					delegateSetter(object, setter, delegate)
+					invokeOriginalSetter(object, setter, delegate)
 				}
 			}
 
@@ -88,28 +91,26 @@ extension DelegateProxy {
 			// to the proxy.
 			instance.swizzle((setter, newSetterImpl), key: hasSwizzledKey)
 
-			// Set the proxy as the delegate.
-			let realClass: AnyClass = class_getSuperclass(object_getClass(instance))
-			let originalSetterImpl: IMP = class_getMethodImplementation(realClass, setter)
-			let getterImpl: IMP = class_getMethodImplementation(realClass, getter)
-
-			typealias Setter = @convention(c) (NSObject, Selector, AnyObject?) -> Void
-			typealias Getter = @convention(c) (NSObject, Selector) -> AnyObject?
-
 			// As Objective-C classes may cache the information of their delegate at
 			// the time the delegates are set, the information has to be "flushed"
 			// whenever the proxy forwardee is replaced or a selector is intercepted.
 			let proxy = self.init(lifetime: instance.reactive.lifetime) { [weak instance] proxy in
 				guard let instance = instance else { return }
-				unsafeBitCast(originalSetterImpl, to: Setter.self)(instance, setter, proxy)
+				invokeOriginalSetter(instance, setter, proxy)
 			}
 
-			instance.associations.setValue(proxyMap + [(setter, proxy)], forKey: proxyMapKey)
+			typealias Getter = @convention(c) (NSObject, Selector) -> AnyObject?
+			let getterImpl: IMP = class_getMethodImplementation(object_getClass(instance), getter)
+			let original = unsafeBitCast(getterImpl, to: Getter.self)(instance, getter) as! Delegate?
 
 			// `proxy.forwardee` would invoke the original setter regardless of
 			// `original` being `nil` or not.
-			let original = unsafeBitCast(getterImpl, to: Getter.self)(instance, getter) as! Delegate?
 			proxy.forwardee = original
+
+			// The proxy must be associated after it is set as the target, since
+			// `base` may be an isa-swizzled instance that is using the injected
+			// setters above.
+			instance.associations.setValue(proxyMap + [(setter, proxy)], forKey: proxyMapKey)
 
 			return proxy
 		}

--- a/ReactiveCocoa/ObjC+RuntimeSubclassing.swift
+++ b/ReactiveCocoa/ObjC+RuntimeSubclassing.swift
@@ -33,7 +33,13 @@ extension NSObject {
 					let method = class_getInstanceMethod(subclass, selector)
 					let typeEncoding = method_getTypeEncoding(method)!
 
-					class_replaceMethod(subclass, selector, imp_implementationWithBlock(body), typeEncoding)
+					if method_getImplementation(method) == _rac_objc_msgForward {
+						let succeeds = class_addMethod(subclass, selector.interopAlias, imp_implementationWithBlock(body), typeEncoding)
+						precondition(succeeds, "RAC attempts to swizzle a selector that has message forwarding enabled with a runtime injected implementation. This is unsupported in the current version.")
+					} else {
+						let succeeds = class_addMethod(subclass, selector, imp_implementationWithBlock(body), typeEncoding)
+						precondition(succeeds, "RAC attempts to swizzle a selector that has already a runtime injected implementation. This is unsupported in the current version.")
+					}
 				}
 			}
 		}

--- a/ReactiveCocoa/ObjC+Selector.swift
+++ b/ReactiveCocoa/ObjC+Selector.swift
@@ -17,6 +17,11 @@ extension Selector {
 		return prefixing("rac1_")
 	}
 
+	/// An alias of `self`, used for delegate proxies.
+	internal var delegateProxyAlias: Selector {
+		return prefixing("rac2_")
+	}
+
 	internal func prefixing(_ prefix: StaticString) -> Selector {
 		let length = Int(strlen(utf8Start))
 		let prefixedLength = length + prefix.utf8CodeUnitCount

--- a/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
+++ b/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
@@ -1,0 +1,296 @@
+import Quick
+import Nimble
+import enum Result.NoError
+import ReactiveSwift
+@testable import ReactiveCocoa
+
+private class Object: NSObject, ActionMessageSending {
+	dynamic var objectValue: AnyObject? = nil
+
+	dynamic weak var target: AnyObject?
+	dynamic var action: Selector?
+
+	deinit {
+		target = nil
+		action = nil
+	}
+}
+
+private class Receiver: NSObject {
+	var counter = 0
+
+	func foo() {
+		counter += 1
+	}
+}
+
+class ActionProxySpec: QuickSpec {
+	override func spec() {
+		describe("DelegateProxy") {
+			var object: Object!
+			var proxy: ActionProxy<Object>!
+
+			beforeEach {
+				object = Object()
+				proxy = object.reactive.proxy
+			}
+
+			afterEach {
+				weak var weakObject = object
+
+				object = nil
+				expect(weakObject).to(beNil())
+			}
+
+			func sendMessage() {
+				_ = object.action.map { object.target?.perform($0, with: nil) }
+			}
+
+			it("should be automatically set as the object's delegate.") {
+				expect(object.target).to(beIdenticalTo(proxy))
+				expect(object.action) == #selector(proxy.invoke(_:))
+			}
+
+			it("should not be erased when the delegate is set with a new one.") {
+				object.target = nil
+				object.action = nil
+
+				expect(object.target).to(beIdenticalTo(proxy))
+				expect(object.action) == #selector(proxy.invoke(_:))
+
+				expect(proxy.target).to(beNil())
+				expect(proxy.action).to(beNil())
+
+				let counter = Receiver()
+				object.target = counter
+				object.action = #selector(counter.foo)
+
+				expect(object.target).to(beIdenticalTo(proxy))
+				expect(object.action) == #selector(proxy.invoke(_:))
+
+				expect(proxy.target).to(beIdenticalTo(counter))
+				expect(proxy.action) == #selector(counter.foo)
+			}
+
+			it("should complete its signals when the object deinitializes") {
+				var isCompleted = false
+				proxy.invoked.observeCompleted { isCompleted = true }
+
+				expect(isCompleted) == false
+
+				object = nil
+				expect(isCompleted) == true
+			}
+
+			it("should interrupt the observers if the object has already deinitialized") {
+				object = nil
+
+				var isInterrupted = false
+				proxy.invoked.observeInterrupted { isInterrupted = true }
+
+				expect(isInterrupted) == true
+			}
+
+			it("should emit a `value` event whenever an action message is sent.") {
+				var fooCount = 0
+				proxy.invoked.observeValues { _ in fooCount += 1 }
+
+				expect(fooCount) == 0
+
+				sendMessage()
+				expect(fooCount) == 1
+
+				sendMessage()
+				expect(fooCount) == 2
+			}
+
+			it("should pass through the action message to the forwardee.") {
+				let receiver = Receiver()
+				proxy.target = receiver
+				proxy.action = #selector(receiver.foo)
+
+				var fooCount = 0
+				proxy.invoked.observeValues { _ in fooCount += 1 }
+
+				expect(fooCount) == 0
+				expect(receiver.counter) == 0
+
+				sendMessage()
+				expect(fooCount) == 1
+				expect(receiver.counter) == 1
+
+				sendMessage()
+				expect(fooCount) == 2
+				expect(receiver.counter) == 2
+			}
+
+			describe("interoperability") {
+				var object: Object!
+				var proxy: ActionProxy<Object>!
+				var invocationCount = 0
+
+				beforeEach {
+					object = Object()
+					invocationCount = 0
+				}
+
+				func setProxy() {
+					proxy = object.reactive.proxy
+					proxy.invoked.observeValues { _ in invocationCount += 1 }
+				}
+
+				func sendMessage() {
+					_ = object.action.map { object.target?.perform($0, with: nil) }
+				}
+
+				it("should not affect instances sharing the same runtime subclass") {
+					_ = object.reactive.producer(forKeyPath: #keyPath(Object.objectValue)).start()
+					setProxy()
+					expect(object.target).to(beIdenticalTo(proxy))
+
+					// Another object without RAC swizzling.
+					let object2 = Object()
+					_ = object2.reactive.producer(forKeyPath: #keyPath(Object.objectValue)).start()
+
+					expect(object.objcClass).to(beIdenticalTo(object2.objcClass))
+
+					let className = NSStringFromClass(object_getClass(object))
+					expect(className).to(beginWith("NSKVONotifying_"))
+					expect(className).toNot(endWith("_RACSwift"))
+
+					object2.target = object
+					object2.action = #selector(AnyObject.perform(_:with:))
+
+					expect(object2.target).to(beIdenticalTo(object))
+					expect(object2.action) == #selector(AnyObject.perform(_:with:))
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by KVO.") {
+					_ = object.reactive.producer(forKeyPath: #keyPath(Object.objectValue)).start()
+					expect(object.target).to(beNil())
+
+					setProxy()
+					expect(object.target).to(beIdenticalTo(proxy))
+
+					sendMessage()
+					expect(invocationCount) == 1
+
+					object.target = nil
+					expect(object.target).to(beIdenticalTo(proxy))
+
+					sendMessage()
+					expect(invocationCount) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC.") {
+					_ = object.reactive.trigger(for: #selector(getter: Object.objectValue))
+					expect(object.target).to(beNil())
+
+					setProxy()
+					expect(object.target).to(beIdenticalTo(proxy))
+
+					sendMessage()
+					expect(invocationCount) == 1
+
+					object.target = nil
+					expect(object.target).to(beIdenticalTo(proxy))
+
+					sendMessage()
+					expect(invocationCount) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
+					var counter = 0
+
+					object.reactive
+						.trigger(for: #selector(setter: Object.target))
+						.observeValues { counter += 1 }
+					expect(object.target).to(beNil())
+
+					setProxy()
+					expect(object.target).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					sendMessage()
+					expect(invocationCount) == 1
+
+					object.target = nil
+					expect(object.target).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					sendMessage()
+					expect(invocationCount) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by RAC for intercepting the delegate setter.") {
+					expect(object.target).to(beNil())
+
+					setProxy()
+					expect(object.target).to(beIdenticalTo(proxy))
+
+					sendMessage()
+					expect(invocationCount) == 1
+
+					var counter = 0
+
+					object.reactive
+						.trigger(for: #selector(setter: Object.target))
+						.observeValues { counter += 1 }
+
+					object.target = nil
+					expect(object.target).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					sendMessage()
+					expect(invocationCount) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by KVO for observing the delegate key path.") {
+					var counter = 0
+
+					object.reactive
+						.signal(forKeyPath: #keyPath(Object.target))
+						.observeValues { _ in counter += 1 }
+					expect(object.target).to(beNil())
+
+					setProxy()
+					expect(object.target).to(beIdenticalTo(proxy))
+					expect(counter) == 0
+
+					sendMessage()
+					expect(invocationCount) == 1
+
+					object.target = nil
+					expect(object.target).to(beIdenticalTo(proxy))
+					expect(counter) == 0
+
+					sendMessage()
+					expect(invocationCount) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
+					expect(object.target).to(beNil())
+
+					setProxy()
+					expect(object.target).to(beIdenticalTo(proxy))
+
+					sendMessage()
+					expect(invocationCount) == 1
+
+					var counter = 0
+					
+					object.reactive
+						.signal(forKeyPath: #keyPath(Object.target))
+						.observeValues { _ in counter += 1 }
+					
+					object.target = nil
+					expect(object.target).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					sendMessage()
+					expect(invocationCount) == 2
+				}
+			}
+		}
+	}
+}

--- a/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
+++ b/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
@@ -199,7 +199,7 @@ class ActionProxySpec: QuickSpec {
 					expect(invocationCount) == 2
 				}
 
-				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
+				xit("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
 					var counter = 0
 
 					object.reactive
@@ -268,7 +268,7 @@ class ActionProxySpec: QuickSpec {
 					expect(invocationCount) == 2
 				}
 
-				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
+				xit("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
 					expect(object.target).to(beNil())
 
 					setProxy()

--- a/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
+++ b/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
@@ -199,7 +199,7 @@ class ActionProxySpec: QuickSpec {
 					expect(invocationCount) == 2
 				}
 
-				xit("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
 					var counter = 0
 
 					object.reactive
@@ -268,7 +268,7 @@ class ActionProxySpec: QuickSpec {
 					expect(invocationCount) == 2
 				}
 
-				xit("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
+				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
 					expect(object.target).to(beNil())
 
 					setProxy()

--- a/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
+++ b/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
@@ -26,7 +26,7 @@ private class Receiver: NSObject {
 
 class ActionProxySpec: QuickSpec {
 	override func spec() {
-		describe("DelegateProxy") {
+		describe("ActionProxy") {
 			var object: Object!
 			var proxy: ActionProxy<Object>!
 
@@ -208,8 +208,11 @@ class ActionProxySpec: QuickSpec {
 					expect(object.target).to(beNil())
 
 					setProxy()
+
+					// The assignment of the proxy should not be captured by the method
+					// interception logic.
 					expect(object.target).to(beIdenticalTo(proxy))
-					expect(counter) == 1
+					expect(counter) == 0
 
 					sendMessage()
 					expect(invocationCount) == 1
@@ -254,6 +257,8 @@ class ActionProxySpec: QuickSpec {
 					expect(object.target).to(beNil())
 
 					setProxy()
+
+					// The assignment of the proxy should not be captured by KVO.
 					expect(object.target).to(beIdenticalTo(proxy))
 					expect(counter) == 0
 

--- a/ReactiveCocoaTests/DelegateProxySpec.swift
+++ b/ReactiveCocoaTests/DelegateProxySpec.swift
@@ -296,7 +296,7 @@ class DelegateProxySpec: QuickSpec {
 					expect(fooCounter) == 2
 				}
 
-				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
+				xit("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
 					var counter = 0
 
 					object.reactive
@@ -365,7 +365,7 @@ class DelegateProxySpec: QuickSpec {
 					expect(fooCounter) == 2
 				}
 
-				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
+				xit("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
 					expect(object.delegate).to(beNil())
 
 					setProxy()

--- a/ReactiveCocoaTests/DelegateProxySpec.swift
+++ b/ReactiveCocoaTests/DelegateProxySpec.swift
@@ -296,7 +296,7 @@ class DelegateProxySpec: QuickSpec {
 					expect(fooCounter) == 2
 				}
 
-				xit("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
 					var counter = 0
 
 					object.reactive
@@ -365,7 +365,7 @@ class DelegateProxySpec: QuickSpec {
 					expect(fooCounter) == 2
 				}
 
-				xit("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
+				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
 					expect(object.delegate).to(beNil())
 
 					setProxy()

--- a/ReactiveCocoaTests/DelegateProxySpec.swift
+++ b/ReactiveCocoaTests/DelegateProxySpec.swift
@@ -4,17 +4,17 @@ import enum Result.NoError
 import ReactiveSwift
 @testable import ReactiveCocoa
 
-@objc protocol ObjectDelegate: NSObjectProtocol {
+@objc private protocol ObjectDelegate: NSObjectProtocol {
 	func foo()
 	@objc optional func bar()
 	@objc optional func nop()
 }
 
-class Object: NSObject {
+private class Object: NSObject {
 	var delegateSetCount = 0
 	var delegateSelectors: [Selector] = []
 
-	weak var delegate: ObjectDelegate? {
+	dynamic weak var delegate: ObjectDelegate? {
 		didSet {
 			delegateSetCount += 1
 			delegateSelectors = Array()
@@ -39,7 +39,7 @@ class Object: NSObject {
 	}
 }
 
-class ObjectDelegateCounter: NSObject, ObjectDelegate {
+private class ObjectDelegateCounter: NSObject, ObjectDelegate {
 	var fooCounter = 0
 	var nopCounter = 0
 
@@ -52,7 +52,7 @@ class ObjectDelegateCounter: NSObject, ObjectDelegate {
 	}
 }
 
-class ObjectDelegateProxy: DelegateProxy<ObjectDelegate>, ObjectDelegate {
+private class ObjectDelegateProxy: DelegateProxy<ObjectDelegate>, ObjectDelegate {
 	func foo() {
 		forwardee?.foo()
 	}
@@ -84,6 +84,17 @@ class DelegateProxySpec: QuickSpec {
 
 			it("should be automatically set as the object's delegate.") {
 				expect(object.delegate).to(beIdenticalTo(proxy))
+			}
+
+			it("should not be erased when the delegate is set with a new one.") {
+				object.delegate = nil
+				expect(object.delegate).to(beIdenticalTo(proxy))
+				expect(proxy.forwardee).to(beNil())
+
+				let counter = ObjectDelegateCounter()
+				object.delegate = counter
+				expect(object.delegate).to(beIdenticalTo(proxy))
+				expect(proxy.forwardee).to(beIdenticalTo(counter))
 			}
 
 			it("should respond to the protocol requirement checks.") {
@@ -210,6 +221,172 @@ class DelegateProxySpec: QuickSpec {
 				expect(object.delegateSetCount) == 3
 				expect(object.delegateSelectors) == [#selector(ObjectDelegate.foo), #selector(ObjectDelegate.bar)]
 				expect(object.delegate).to(beIdenticalTo(proxy))
+			}
+			
+			describe("interoperability") {
+				var object: Object!
+				var proxy: DelegateProxy<ObjectDelegate>!
+				var fooCounter = 0
+				
+				beforeEach {
+					object = Object()
+					fooCounter = 0
+				}
+
+				func setProxy() {
+					proxy = ObjectDelegateProxy.proxy(for: object,
+					                                  setter: #selector(setter: object.delegate),
+					                                  getter: #selector(getter: object.delegate))
+
+					let signal: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+					signal.observeValues { fooCounter += 1 }
+				}
+
+				it("should not affect instances sharing the same runtime subclass") {
+					_ = object.reactive.producer(forKeyPath: #keyPath(Object.delegateSetCount)).start()
+					setProxy()
+					expect(object.delegate).to(beIdenticalTo(proxy))
+
+					// Another object without RAC swizzling.
+					let object2 = Object()
+					_ = object2.reactive.producer(forKeyPath: #keyPath(Object.delegateSetCount)).start()
+
+					expect(object.objcClass).to(beIdenticalTo(object2.objcClass))
+
+					let className = NSStringFromClass(object_getClass(object))
+					expect(className).to(beginWith("NSKVONotifying_"))
+					expect(className).toNot(endWith("_RACSwift"))
+
+					let delegate = ObjectDelegateCounter()
+					object2.delegate = delegate
+					expect(object2.delegate).to(beIdenticalTo(delegate))
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by KVO.") {
+					_ = object.reactive.producer(forKeyPath: #keyPath(Object.delegateSetCount)).start()
+					expect(object.delegate).to(beNil())
+
+					setProxy()
+					expect(object.delegate).to(beIdenticalTo(proxy))
+
+					object.delegate?.foo()
+					expect(fooCounter) == 1
+
+					object.delegate = nil
+					expect(object.delegate).to(beIdenticalTo(proxy))
+
+					object.delegate?.foo()
+					expect(fooCounter) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC.") {
+					_ = object.reactive.trigger(for: #selector(getter: Object.delegateSetCount))
+					expect(object.delegate).to(beNil())
+
+					setProxy()
+					expect(object.delegate).to(beIdenticalTo(proxy))
+
+					object.delegate?.foo()
+					expect(fooCounter) == 1
+
+					object.delegate = nil
+					expect(object.delegate).to(beIdenticalTo(proxy))
+
+					object.delegate?.foo()
+					expect(fooCounter) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by RAC for intercepting the delegate setter.") {
+					var counter = 0
+
+					object.reactive
+						.trigger(for: #selector(setter: Object.delegate))
+						.observeValues { counter += 1 }
+					expect(object.delegate).to(beNil())
+
+					setProxy()
+					expect(object.delegate).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					object.delegate?.foo()
+					expect(fooCounter) == 1
+
+					object.delegate = nil
+					expect(object.delegate).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					object.delegate?.foo()
+					expect(fooCounter) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by RAC for intercepting the delegate setter.") {
+					expect(object.delegate).to(beNil())
+
+					setProxy()
+					expect(object.delegate).to(beIdenticalTo(proxy))
+
+					object.delegate?.foo()
+					expect(fooCounter) == 1
+
+					var counter = 0
+
+					object.reactive
+						.trigger(for: #selector(setter: Object.delegate))
+						.observeValues { counter += 1 }
+
+					object.delegate = nil
+					expect(object.delegate).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					object.delegate?.foo()
+					expect(fooCounter) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it has already been isa-swizzled by KVO for observing the delegate key path.") {
+					var counter = 0
+
+					object.reactive
+						.signal(forKeyPath: #keyPath(Object.delegate))
+						.observeValues { _ in counter += 1 }
+					expect(object.delegate).to(beNil())
+
+					setProxy()
+					expect(object.delegate).to(beIdenticalTo(proxy))
+					expect(counter) == 0
+
+					object.delegate?.foo()
+					expect(fooCounter) == 1
+
+					object.delegate = nil
+					expect(object.delegate).to(beIdenticalTo(proxy))
+					expect(counter) == 0
+
+					object.delegate?.foo()
+					expect(fooCounter) == 2
+				}
+
+				it("should be automatically set as the object's delegate even if it is subsequently isa-swizzled by KVO for observing the delegate key path.") {
+					expect(object.delegate).to(beNil())
+
+					setProxy()
+					expect(object.delegate).to(beIdenticalTo(proxy))
+
+					object.delegate?.foo()
+					expect(fooCounter) == 1
+
+					var counter = 0
+
+					object.reactive
+						.signal(forKeyPath: #keyPath(Object.delegate))
+						.observeValues { _ in counter += 1 }
+
+					object.delegate = nil
+					expect(object.delegate).to(beIdenticalTo(proxy))
+					expect(counter) == 1
+
+					object.delegate?.foo()
+					expect(fooCounter) == 2
+				}
 			}
 		}
 	}

--- a/ReactiveCocoaTests/DelegateProxySpec.swift
+++ b/ReactiveCocoaTests/DelegateProxySpec.swift
@@ -305,8 +305,11 @@ class DelegateProxySpec: QuickSpec {
 					expect(object.delegate).to(beNil())
 
 					setProxy()
+
+					// The assignment of the proxy should not be captured by the method
+					// interception logic.
 					expect(object.delegate).to(beIdenticalTo(proxy))
-					expect(counter) == 1
+					expect(counter) == 0
 
 					object.delegate?.foo()
 					expect(fooCounter) == 1
@@ -351,6 +354,8 @@ class DelegateProxySpec: QuickSpec {
 					expect(object.delegate).to(beNil())
 
 					setProxy()
+
+					// The assignment of the proxy should not be captured by KVO.
 					expect(object.delegate).to(beIdenticalTo(proxy))
 					expect(counter) == 0
 


### PR DESCRIPTION
Fixes #3432 and #3433.

Since fixing one with new test cases leads to another, it all ends up in the same branch. 😅

#### Highlights

1. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3435/commits/e8bfbfc40fade886f0458d07dfd7c45f7ab9cf11: Fixed an interoperability issue in the swizzling logic. The original implementation had not taken account of the existence of other swizzling users.

1. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3435/commits/b774210cba5c0579693c301ae95f5aa2fea7bbfa: Replaced the unreliable use of `#function` as keys with the setter selector, which is constant for a given proxy.

1. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3435/commits/d3b850e3c58302f796627d9ef38b0681e910f39b: Refined the DelegateProxy implementation, so that it always respects the latest implementation in the perceived class (in case it has been swizzled externally).

1. https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3435/commits/434227c25add109440397e8acf1442ab18d1d063: `ActionProxy` now guards for the absence of `NSApp`. Probably only relevant in tests.