### PR TITLE
Disable the MapView deallocation check for macOS.

### DIFF
--- a/ReactiveCocoaTests/Shared/MKMapViewSpec.swift
+++ b/ReactiveCocoaTests/Shared/MKMapViewSpec.swift
@@ -18,9 +18,15 @@ class MKMapViewSpec: QuickSpec {
 
 		afterEach {
 			mapView = nil
+			// FIXME: SDK_ISSUE
+			//
+			// Temporarily disabled since the expectation keeps failing with
+			// Xcode 8.3 and macOS Sierra 10.12.4.
+			#if !os(macOS)
 			// using toEventually(beNil()) here
 			// since it takes time to release MKMapView
 			expect(_mapView).toEventually(beNil())
+			#endif
 		}
 
 		it("should accept changes from bindings to its map type") {


### PR DESCRIPTION
Apparently all the updated branches and local retries just keep failing on this. ☹️