### PR TITLE
Support for native Swift object values in `AnyObject` properties in RAC KVO API.

### DIFF
--- a/ReactiveCocoa/NSObject+Lifetime.swift
+++ b/ReactiveCocoa/NSObject+Lifetime.swift
@@ -10,6 +10,27 @@ fileprivate let lifetimeKey = AssociationKey<Lifetime?>(default: nil)
 /// Holds the `Lifetime.Token` of the object.
 fileprivate let lifetimeTokenKey = AssociationKey<Lifetime.Token?>(default: nil)
 
+internal func lifetime(of object: AnyObject) -> Lifetime {
+	if let object = object as? NSObject {
+		return object.reactive.lifetime
+	}
+
+	return synchronized(object) {
+		let associations = Associations(object)
+
+		if let lifetime = associations.value(forKey: lifetimeKey) {
+			return lifetime
+		}
+
+		let (lifetime, token) = Lifetime.make()
+
+		associations.setValue(token, forKey: lifetimeTokenKey)
+		associations.setValue(lifetime, forKey: lifetimeKey)
+
+		return lifetime
+	}
+}
+
 extension Reactive where Base: NSObject {
 	/// Returns a lifetime that ends when the object is deallocated.
 	@nonobjc public var lifetime: Lifetime {


### PR DESCRIPTION
Turns out ObjC association works with Swift objects too, which enables proper handling of weak properties with direct key paths. Root and intermediate nodes in a nested key path are not covered, since native Swift object does not support ObjC KVC anyway.

This applies only to `AnyObject` properties, which may hold a native Swift object that can receive ObjC message without inheriting `NSObject`.