### PR TITLE
Continuous UITextField signals now react to all editing events.

### DIFF
--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -20,7 +20,7 @@ extension Reactive where Base: UITextField {
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {
-		return controlEvents(.editingChanged).map { $0.text }
+		return controlEvents(.allEditingEvents).map { $0.text }
 	}
 	
 	/// Sets the attributed text of the text field.
@@ -45,7 +45,7 @@ extension Reactive where Base: UITextField {
 	///
 	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
 	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
-		return controlEvents(.editingChanged).map { $0.attributedText }
+		return controlEvents(.allEditingEvents).map { $0.attributedText }
 	}
 
 	/// Sets the secure text entry attribute on the text field.

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -37,15 +37,17 @@ class UITextFieldSpec: QuickSpec {
 		}
 
 		it("should emit user initiated changes to its text value continuously") {
-			textField.text = "Test"
-
 			var latestValue: String?
 			textField.reactive.continuousTextValues.observeValues { text in
 				latestValue = text
 			}
 
-			textField.sendActions(for: .editingChanged)
-			expect(latestValue) == textField.text
+			for event in UIControlEvents.editingEvents {
+				textField.text = "Test \(event)"
+
+				textField.sendActions(for: event)
+				expect(latestValue) == textField.text
+			}
 		}
 		
 		it("should accept changes from bindings to its attributed text value") {
@@ -77,15 +79,17 @@ class UITextFieldSpec: QuickSpec {
 		}
 		
 		it("should emit user initiated changes to its attributed text value continuously") {
-			textField.attributedText = NSAttributedString(string: "Test")
-			
 			var latestValue: NSAttributedString?
 			textField.reactive.continuousAttributedTextValues.observeValues { attributedText in
 				latestValue = attributedText
 			}
-			
-			textField.sendActions(for: .editingChanged)
-			expect(latestValue?.string) == textField.attributedText?.string
+
+			for event in UIControlEvents.editingEvents {
+				textField.attributedText = NSAttributedString(string: "Test \(event)")
+
+				textField.sendActions(for: event)
+				expect(latestValue?.string) == textField.attributedText?.string
+			}
 		}
 
 		it("should accept changes from bindings to its secureTextEntry attribute") {
@@ -109,5 +113,11 @@ class UITextFieldSpec: QuickSpec {
 			observer.send(value: UIColor.blue)
 			expect(textField.textColor == UIColor.red) == false
 		}
+	}
+}
+
+extension UIControlEvents {
+	fileprivate static var editingEvents: [UIControlEvents] {
+		return [.allEditingEvents, .editingDidBegin, .editingChanged, .editingDidEndOnExit, .editingDidEnd]
 	}
 }


### PR DESCRIPTION
Fixes #3423.

~~Note: macOS test is expected to fail due to the merged #3433.~~