### PR TITLE
Reentrance support in `CocoaTarget.invoke`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master
+*Please put new entries at the top.
+
+1. Resigning first responder when reacting to a `UITextField` signal no longer deadlocks. (#3453)
+
 # 5.0
 
 ### Table of Contents

--- a/ReactiveCocoa/CocoaTarget.swift
+++ b/ReactiveCocoa/CocoaTarget.swift
@@ -4,16 +4,52 @@ import enum Result.NoError
 
 /// A target that accepts action messages.
 internal final class CocoaTarget<Value>: NSObject {
+	private enum State {
+		case idle
+		case sending
+		case invokeAfterSending
+	}
+
 	private let observer: Observer<Value, NoError>
 	private let transform: (Any?) -> Value
-	
+
+	private var state: State
+
 	internal init(_ observer: Observer<Value, NoError>, transform: @escaping (Any?) -> Value) {
 		self.observer = observer
 		self.transform = transform
+		self.state = .idle
 	}
-	
-	@objc internal func sendNext(_ receiver: Any?) {
-		observer.send(value: transform(receiver))
+
+	/// Broadcast the action message to all observers.
+	///
+	/// Reentrancy is supported, and the action message would be deferred until the
+	/// delivery of the current message has completed. Deferred messages would be
+	/// coalesced.
+	///
+	/// - note: It should only be invoked on the main queue.
+	///
+	/// - parameters:
+	///   - sender: The object which sends the action message.
+	@objc internal func invoke(_ sender: Any?) {
+		switch state {
+		case .idle:
+			state = .sending
+			observer.send(value: transform(sender))
+
+			while state == .invokeAfterSending {
+				state = .sending
+				observer.send(value: transform(sender))
+			}
+
+			state = .idle
+
+		case .sending:
+			state = .invokeAfterSending
+
+		case .invokeAfterSending:
+			break
+		}
 	}
 }
 

--- a/ReactiveCocoa/UIKit/UIControl.swift
+++ b/ReactiveCocoa/UIKit/UIControl.swift
@@ -50,7 +50,7 @@ extension Reactive where Base: UIControl {
 		return Signal { observer in
 			let receiver = CocoaTarget(observer) { $0 as! Base }
 			base.addTarget(receiver,
-			               action: #selector(receiver.sendNext),
+			               action: #selector(receiver.invoke),
 			               for: controlEvents)
 
 			let disposable = lifetime.ended.observeCompleted(observer.sendCompleted)
@@ -59,7 +59,7 @@ extension Reactive where Base: UIControl {
 				disposable?.dispose()
 
 				base?.removeTarget(receiver,
-				                   action: #selector(receiver.sendNext),
+				                   action: #selector(receiver.invoke),
 				                   for: controlEvents)
 			}
 		}

--- a/ReactiveCocoa/UIKit/UIGestureRecognizer.swift
+++ b/ReactiveCocoa/UIKit/UIGestureRecognizer.swift
@@ -11,13 +11,13 @@ extension Reactive where Base: UIGestureRecognizer {
 			let receiver = CocoaTarget<Base>(observer) { gestureRecognizer in
 				return gestureRecognizer as! Base
 			}
-			base.addTarget(receiver, action: #selector(receiver.sendNext))
+			base.addTarget(receiver, action: #selector(receiver.invoke))
 			
 			let disposable = lifetime.ended.observeCompleted(observer.sendCompleted)
 			
 			return ActionDisposable { [weak base = self.base] in
 				disposable?.dispose()
-				base?.removeTarget(receiver, action: #selector(receiver.sendNext))
+				base?.removeTarget(receiver, action: #selector(receiver.invoke))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3452.

WIP:
- [x] Full buffering implementation.
- [x] ~~Test coverage for `UIGestureRecognizer` (flipping `isEnabled` in observers).~~ _Cancellation in `UIGestureRecognizer` does not result in recursion._