### PR TITLE
Unified Action and Property binding API for UI controls.

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -151,6 +151,10 @@
 		9A54A21C1DE00D09001739B3 /* ObjC+Selector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A54A21A1DE00D09001739B3 /* ObjC+Selector.swift */; };
 		9A54A21D1DE00D09001739B3 /* ObjC+Selector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A54A21A1DE00D09001739B3 /* ObjC+Selector.swift */; };
 		9A54A21E1DE00D09001739B3 /* ObjC+Selector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A54A21A1DE00D09001739B3 /* ObjC+Selector.swift */; };
+		9A6523711ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6523701ED09B2E00C3BA8D /* BidirectionalBinding.swift */; };
+		9A6523721ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6523701ED09B2E00C3BA8D /* BidirectionalBinding.swift */; };
+		9A6523731ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6523701ED09B2E00C3BA8D /* BidirectionalBinding.swift */; };
+		9A6523741ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6523701ED09B2E00C3BA8D /* BidirectionalBinding.swift */; };
 		9A6AAA0E1DB6A4CF0013AAEA /* InterceptingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6AAA0D1DB6A4CF0013AAEA /* InterceptingSpec.swift */; };
 		9A6AAA0F1DB6A4CF0013AAEA /* InterceptingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6AAA0D1DB6A4CF0013AAEA /* InterceptingSpec.swift */; };
 		9A6AAA101DB6A4CF0013AAEA /* InterceptingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6AAA0D1DB6A4CF0013AAEA /* InterceptingSpec.swift */; };
@@ -245,6 +249,9 @@
 		9AF0EA761D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */; };
 		9AF0EA771D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */; };
 		9AF0EA781D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */; };
+		9AF77A6F1EEAD94F008D1F3A /* BidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF77A6E1EEAD94F008D1F3A /* BidirectionalBindingSpec.swift */; };
+		9AF77A701EEAD94F008D1F3A /* BidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF77A6E1EEAD94F008D1F3A /* BidirectionalBindingSpec.swift */; };
+		9AF77A711EEAD94F008D1F3A /* BidirectionalBindingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF77A6E1EEAD94F008D1F3A /* BidirectionalBindingSpec.swift */; };
 		A9B315C91B3940980001CB9C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		A9B315CA1B3940AB0001CB9C /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9EB3D201E94F08A002A9BCC /* UINavigationItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EB3D1C1E94ECAC002A9BCC /* UINavigationItem.swift */; };
@@ -460,6 +467,7 @@
 		9A2E425D1DAA6737006D909F /* CocoaTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaTarget.swift; sourceTree = "<group>"; };
 		9A54A2101DDF5B4D001739B3 /* InterceptingPerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterceptingPerformanceTests.swift; sourceTree = "<group>"; };
 		9A54A21A1DE00D09001739B3 /* ObjC+Selector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+Selector.swift"; sourceTree = "<group>"; };
+		9A6523701ED09B2E00C3BA8D /* BidirectionalBinding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BidirectionalBinding.swift; sourceTree = "<group>"; };
 		9A6AAA0D1DB6A4CF0013AAEA /* InterceptingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterceptingSpec.swift; sourceTree = "<group>"; };
 		9A6AAA221DB8F51C0013AAEA /* ReusableComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponents.swift; sourceTree = "<group>"; };
 		9A6AAA251DB8F5280013AAEA /* ReusableComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponents.swift; sourceTree = "<group>"; };
@@ -494,6 +502,7 @@
 		9AE7C2A31DDD7F5100F7534C /* ObjC+Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+Messages.swift"; sourceTree = "<group>"; };
 		9AED64C41E496A3700321004 /* ActionProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionProxy.swift; sourceTree = "<group>"; };
 		9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+BindingTarget.swift"; sourceTree = "<group>"; };
+		9AF77A6E1EEAD94F008D1F3A /* BidirectionalBindingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BidirectionalBindingSpec.swift; sourceTree = "<group>"; };
 		A97451331B3A935E00F48E55 /* watchOS-Application.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Application.xcconfig"; sourceTree = "<group>"; };
 		A97451341B3A935E00F48E55 /* watchOS-Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Base.xcconfig"; sourceTree = "<group>"; };
 		A97451351B3A935E00F48E55 /* watchOS-Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "watchOS-Framework.xcconfig"; sourceTree = "<group>"; };
@@ -860,6 +869,7 @@
 		D04725EC19E49ED7006002AA /* ReactiveCocoa */ = {
 			isa = PBXGroup;
 			children = (
+				9A6523701ED09B2E00C3BA8D /* BidirectionalBinding.swift */,
 				9ADE4A7B1DA44A9E005C2AC8 /* CocoaAction.swift */,
 				9A2E425D1DAA6737006D909F /* CocoaTarget.swift */,
 				CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */,
@@ -908,6 +918,7 @@
 				538DCB771DCA5E3200332880 /* Shared */,
 				9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */,
 				9A7990CD1F1085D8001493A3 /* BindingTargetSpec.swift */,
+				9AF77A6E1EEAD94F008D1F3A /* BidirectionalBindingSpec.swift */,
 				CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */,
 				9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* DynamicPropertySpec.swift */,
@@ -1396,6 +1407,7 @@
 				9AA0BD921DDE29F800531FCF /* NSObject+ObjCRuntime.swift in Sources */,
 				9A1D061A1D93EA0100ACF44C /* UIProgressView.swift in Sources */,
 				9AA0BD7F1DDE03DE00531FCF /* ObjC+Runtime.swift in Sources */,
+				9A6523741ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */,
 				9A2E42611DAA6737006D909F /* CocoaTarget.swift in Sources */,
 				9A9037521ED61C6300345D62 /* ReactiveSwift+Lifetime.swift in Sources */,
 				9A1D06121D93EA0100ACF44C /* UIBarButtonItem.swift in Sources */,
@@ -1416,6 +1428,7 @@
 				7DFBED281CDB8DE300EE435B /* DynamicPropertySpec.swift in Sources */,
 				9A9DFEEB1DA7EFB60039EE1B /* AssociationSpec.swift in Sources */,
 				CD8401851CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */,
+				9AF77A711EEAD94F008D1F3A /* BidirectionalBindingSpec.swift in Sources */,
 				9A1E72BC1D4DE96500CC20C3 /* KeyValueObservingSpec.swift in Sources */,
 				9A1D06451D93EA7E00ACF44C /* UIImageViewSpec.swift in Sources */,
 				9A1D06551D93EA7E00ACF44C /* UITextViewSpec.swift in Sources */,
@@ -1478,6 +1491,7 @@
 				9ADE4A7E1DA44A9E005C2AC8 /* CocoaAction.swift in Sources */,
 				9AA0BD831DDE03F500531FCF /* ObjC+RuntimeSubclassing.swift in Sources */,
 				CD0C45E01CC9A288009F5BF0 /* DynamicProperty.swift in Sources */,
+				9A6523731ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */,
 				9AA0BD911DDE29F800531FCF /* NSObject+ObjCRuntime.swift in Sources */,
 				9AF0EA771D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */,
 				9A9037511ED61C6300345D62 /* ReactiveSwift+Lifetime.swift in Sources */,
@@ -1492,6 +1506,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A6523711ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */,
 				4ABEFE2B1DCFD0030066A8C2 /* NSTableView.swift in Sources */,
 				CD0C45DE1CC9A288009F5BF0 /* DynamicProperty.swift in Sources */,
 				4ABEFE301DCFD0530066A8C2 /* NSCollectionView.swift in Sources */,
@@ -1547,6 +1562,7 @@
 				D9558AB91DFF86C0003254E1 /* NSPopUpButtonSpec.swift in Sources */,
 				BFA6B94D1A7604D400C846D1 /* SignalProducerNimbleMatchers.swift in Sources */,
 				9A24A8451DE142A400987AF9 /* SwizzlingSpec.swift in Sources */,
+				9AF77A6F1EEAD94F008D1F3A /* BidirectionalBindingSpec.swift in Sources */,
 				9A6AAA2B1DB8F85C0013AAEA /* ReusableComponentsSpec.swift in Sources */,
 				CD8401831CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */,
 				9A9DFEE91DA7EFB60039EE1B /* AssociationSpec.swift in Sources */,
@@ -1584,6 +1600,7 @@
 				53AC46CC1DD6F97400C799E1 /* UISlider.swift in Sources */,
 				9AA0BD821DDE03F500531FCF /* ObjC+RuntimeSubclassing.swift in Sources */,
 				9A1D060F1D93EA0000ACF44C /* UIView.swift in Sources */,
+				9A6523721ED09B2E00C3BA8D /* BidirectionalBinding.swift in Sources */,
 				9A1D06051D93EA0000ACF44C /* UIDatePicker.swift in Sources */,
 				9A1D05E11D93E99100ACF44C /* NSObject+Association.swift in Sources */,
 				9A1D06041D93EA0000ACF44C /* UIControl.swift in Sources */,
@@ -1658,6 +1675,7 @@
 				4ABEFE211DCFCF090066A8C2 /* UITableViewSpec.swift in Sources */,
 				9A1D06401D93EA7E00ACF44C /* UIControlSpec.swift in Sources */,
 				9A7990CF1F1085D8001493A3 /* BindingTargetSpec.swift in Sources */,
+				9AF77A701EEAD94F008D1F3A /* BidirectionalBindingSpec.swift in Sources */,
 				9A1D06481D93EA7E00ACF44C /* UIProgressViewSpec.swift in Sources */,
 				CD8401841CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */,
 				A9EB3D291E94F3D3002A9BCC /* UITabBarItemSpec.swift in Sources */,

--- a/ReactiveCocoa/BidirectionalBinding.swift
+++ b/ReactiveCocoa/BidirectionalBinding.swift
@@ -1,0 +1,370 @@
+import ReactiveSwift
+import Result
+
+infix operator <~>: BindingPrecedence
+
+// `ValueBindable` need not conform to `BindingSource`, since the expected public
+// APIs for observing user interactions are still the signals named with plural nouns.
+
+public struct ValueBindable<Owner: AnyObject, Value>: ActionBindableProtocol, BindingTargetProvider {
+	fileprivate weak var owner: Owner?
+	fileprivate let isEnabled: ReferenceWritableKeyPath<Owner, Bool>
+	fileprivate let value: ReferenceWritableKeyPath<Owner, Value>
+	fileprivate let values: (Owner) -> Signal<Value, NoError>
+	fileprivate let actionDidBind: ((Owner, ActionStates, CompositeDisposable) -> Void)?
+
+	public var bindingTarget: BindingTarget<Value> {
+		let lifetime = owner.map(lifetime(of:)) ?? .empty
+		return BindingTarget(on: UIScheduler(), lifetime: lifetime) { value in
+			self.owner?[keyPath: self.value] = value
+		}
+	}
+
+	public var actionBindable: ActionBindable<Owner, Value> {
+		return ActionBindable(owner: owner, isEnabled: isEnabled, values: values, actionDidBind: actionDidBind)
+	}
+
+	public init(
+		owner: Owner?,
+		isEnabled: ReferenceWritableKeyPath<Owner, Bool>,
+		value: ReferenceWritableKeyPath<Owner, Value>,
+		values: @escaping (Owner) -> Signal<Value, NoError>,
+		actionDidBind: ((Owner, ActionStates, CompositeDisposable) -> Void)? = nil
+	) {
+		self.owner = owner
+		self.isEnabled = isEnabled
+		self.value = value
+		self.values = values
+		self.actionDidBind = actionDidBind
+	}
+}
+
+public struct ActionBindable<Owner: AnyObject, Value>: ActionBindableProtocol {
+	fileprivate weak var owner: Owner?
+	fileprivate let isEnabled: ReferenceWritableKeyPath<Owner, Bool>
+	fileprivate let values: (Owner) -> Signal<Value, NoError>
+	fileprivate let actionDidBind: ((Owner, ActionStates, CompositeDisposable) -> Void)?
+
+	public var actionBindable: ActionBindable<Owner, Value> {
+		return self
+	}
+
+	public init(
+		owner: Owner?,
+		isEnabled: ReferenceWritableKeyPath<Owner, Bool>,
+		values: @escaping (Owner) -> Signal<Value, NoError>,
+		actionDidBind: ((Owner, ActionStates, CompositeDisposable) -> Void)? = nil
+	) {
+		self.owner = owner
+		self.isEnabled = isEnabled
+		self.values = values
+		self.actionDidBind = actionDidBind
+	}
+}
+
+public protocol ActionBindableProtocol {
+	associatedtype Owner: AnyObject
+	associatedtype Value
+
+	var actionBindable: ActionBindable<Owner, Value> { get }
+}
+
+public struct ActionStates {
+	let isExecuting: SignalProducer<Bool, NoError>
+
+	fileprivate init<Input, Output, Error>(scheduler: UIScheduler, action: Action<Input, Output, Error>) {
+		isExecuting = action.isExecuting.producer.observe(on: scheduler)
+	}
+}
+
+// MARK: Transformation.
+extension ActionBindableProtocol {
+	fileprivate func mapOutput<U>(_ transform: @escaping (Value) -> U) -> ActionBindable<Owner, U> {
+		let bindable = actionBindable
+		return ActionBindable(owner: bindable.owner,
+		                      isEnabled: bindable.isEnabled,
+		                      values: { bindable.values($0).map(transform) },
+		                      actionDidBind: bindable.actionDidBind)
+	}
+}
+
+// MARK: Binding implementation.
+
+extension ValueBindable {
+	fileprivate func bind<P: ComposableMutablePropertyProtocol>(to property: P) -> Disposable? where P.Value == Value {
+		return owner.flatMap { owner in
+			return property.withValue { current in
+				let disposable = CompositeDisposable()
+				let serialDisposable = SerialDisposable()
+				let scheduler = UIScheduler()
+				var isReplacing = false
+
+				owner[keyPath: self.value] = current
+
+				disposable += property.signal
+					.observe { event in
+						serialDisposable.inner = scheduler.schedule {
+							guard !isReplacing else { return }
+
+							switch event {
+							case let .value(value):
+								self.owner?[keyPath: self.value] = value
+							case .completed:
+								disposable.dispose()
+							case .interrupted, .failed:
+								fatalError("Unexpected event.")
+							}
+						}
+					}
+
+				// UI control always takes precedence over changes from the background
+				// thread for now.
+				//
+				// We also take advantage of the fact that `Property` is synchronous to
+				// use a boolean flag as a simple & efficient feedback loop breaker.
+
+				disposable += values(owner)
+					.observeValues { [weak property] value in
+						guard let property = property else { return }
+
+						isReplacing = true
+						property.value = value
+						serialDisposable.inner = nil
+						isReplacing = false
+					}
+
+				property.lifetime += disposable
+				ReactiveCocoa.lifetime(of: owner) += disposable
+
+				return AnyDisposable(disposable.dispose)
+			}
+		}
+	}
+}
+
+extension ActionBindableProtocol {
+	fileprivate func bind<Output, Error>(to action: Action<Value, Output, Error>) -> Disposable? {
+		let bindable = actionBindable
+		return bindable.owner.flatMap { control in
+			let disposable = CompositeDisposable()
+			let scheduler = UIScheduler()
+
+			disposable += bindable.values(control).observeValues { [weak action] value in
+				action?.apply(value).start()
+			}
+
+			disposable += action.isEnabled.producer
+				.observe(on: scheduler)
+				.startWithValues { isEnabled in
+					bindable.owner?[keyPath: bindable.isEnabled] = isEnabled
+			}
+
+
+			action.lifetime += disposable
+			ReactiveCocoa.lifetime(of: control) += disposable
+
+			bindable.actionDidBind?(control, ActionStates(scheduler: scheduler, action: action), disposable)
+
+			return AnyDisposable(disposable.dispose)
+		}
+	}
+}
+
+// MARK: Value bindings
+
+extension ComposableMutablePropertyProtocol {
+	/// Create a value binding between `bindable` and `property`.
+	///
+	/// The binding would use the current value of `property` as the initial value. It
+	/// would prefer changes initiated on the main queue by `bindable`.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// heaterSwitch.reactive.isOn <~> viewModel.isHeaterTurnedOn
+	/// viewModel.isHeaterTurnedOn <~> heaterSwitch.reactive.isOn
+	/// ```
+	///
+	/// - parameters:
+	///   - property: The property to bind with.
+	///   - bindable: The value bindable to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the value binding.
+	@discardableResult
+	public static func <~> <Owner>(property: Self, bindable: ValueBindable<Owner, Value>) -> Disposable? {
+		return bindable <~> property
+	}
+}
+
+extension ValueBindable {
+	/// Create a value binding between `bindable` and `property`.
+	/// 
+	/// The binding would use the current value of `property` as the initial value. It 
+	/// would prefer changes initiated on the main queue by `bindable`.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// heaterSwitch.reactive.isOn <~> viewModel.isHeaterTurnedOn
+	/// viewModel.isHeaterTurnedOn <~> heaterSwitch.reactive.isOn
+	/// ```
+	///
+	/// - parameters:
+	///   - bindable: The value bindable to bind with.
+	///   - property: The property to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the value binding.
+	@discardableResult
+	public static func <~> <P: ComposableMutablePropertyProtocol>(bindable: ValueBindable, property: P) -> Disposable? where P.Value == Value {
+		return bindable.bind(to: property)
+	}
+}
+
+
+// MARK: Action bindings
+
+extension Action {
+	/// Create an action binding between `bindable` and `action`.
+	///
+	/// The availability of the `bindable` is bound to the availability of `action`, and
+	/// any value initiated by the `bindable` would be turned into an execution attempt of
+	/// `action`. Errors of the `Action` are ignored by the binding.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// confirmButton.reactive.pressed <~> viewModel.submit
+	/// viewModel.submit <~> confirmButton.reactive.pressed
+	/// ```
+	///
+	/// - parameters:
+	///   - bindable: The value bindable to bind with.
+	///   - action: The `Action` to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the action binding.
+	@discardableResult
+	public static func <~><Bindable>(action: Action, bindable: Bindable) -> Disposable? where Bindable: ActionBindableProtocol, Bindable.Value == Input {
+		return bindable <~> action
+	}
+}
+
+extension Action where Input == () {
+	/// Create an action binding between `bindable` and `action`.
+	///
+	/// The availability of the `bindable` is bound to the availability of `action`, and
+	/// any value initiated by the `bindable` would be turned into an execution attempt of
+	/// `action`. Errors of the `Action` are ignored by the binding.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// confirmButton.reactive.pressed <~> viewModel.submit
+	/// viewModel.submit <~> confirmButton.reactive.pressed
+	/// ```
+	///
+	/// - parameters:
+	///   - bindable: The value bindable to bind with.
+	///   - action: The `Action` to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the action binding.
+	@discardableResult
+	public static func <~> <Bindable>(action: Action, bindable: Bindable) -> Disposable? where Bindable: ActionBindableProtocol {
+		return bindable <~> action
+	}
+
+	/// Create an action binding between `bindable` and `action`.
+	///
+	/// The availability of the `bindable` is bound to the availability of `action`, and
+	/// any value initiated by the `bindable` would be turned into an execution attempt of
+	/// `action`. Errors of the `Action` are ignored by the binding.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// confirmButton.reactive.pressed <~> viewModel.submit
+	/// viewModel.submit <~> confirmButton.reactive.pressed
+	/// ```
+	///
+	/// - parameters:
+	///   - bindable: The value bindable to bind with.
+	///   - action: The `Action` to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the action binding.
+	@discardableResult
+	public static func <~> <Bindable>(action: Action, bindable: Bindable) -> Disposable? where Bindable: ActionBindableProtocol, Bindable.Value == () {
+		return bindable <~> action
+	}
+}
+
+extension ActionBindableProtocol {
+	/// Create an action binding between `bindable` and `action`.
+	///
+	/// The availability of the `bindable` is bound to the availability of `action`, and
+	/// any value initiated by the `bindable` would be turned into an execution attempt of
+	/// `action`. Errors of the `Action` are ignored by the binding.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// confirmButton.reactive.pressed <~> viewModel.submit
+	/// viewModel.submit <~> confirmButton.reactive.pressed
+	/// ```
+	///
+	/// - parameters:
+	///   - bindable: The value bindable to bind with.
+	///   - action: The `Action` to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the action binding.
+	@discardableResult
+	public static func <~> <Output, Error>(bindable: Self, action: Action<Value, Output, Error>) -> Disposable? {
+		return bindable.bind(to: action)
+	}
+
+	/// Create an action binding between `bindable` and `action`.
+	///
+	/// The availability of the `bindable` is bound to the availability of `action`, and
+	/// any value initiated by the `bindable` would be turned into an execution attempt of
+	/// `action`. Errors of the `Action` are ignored by the binding.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// confirmButton.reactive.pressed <~> viewModel.submit
+	/// viewModel.submit <~> confirmButton.reactive.pressed
+	/// ```
+	///
+	/// - parameters:
+	///   - bindable: The value bindable to bind with.
+	///   - action: The `Action` to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the action binding.
+	@discardableResult
+	public static func <~> <Output, Error>(bindable: Self, action: Action<(), Output, Error>) -> Disposable? {
+		return bindable.mapOutput { _ in } <~> action
+	}
+}
+
+extension ActionBindableProtocol where Value == () {
+	/// Create an action binding between `bindable` and `action`.
+	///
+	/// The availability of the `bindable` is bound to the availability of `action`, and
+	/// any value initiated by the `bindable` would be turned into an execution attempt of
+	/// `action`. Errors of the `Action` are ignored by the binding.
+	///
+	/// ## Example
+	/// ```
+	/// // Both are equivalent.
+	/// confirmButton.reactive.pressed <~> viewModel.submit
+	/// viewModel.submit <~> confirmButton.reactive.pressed
+	/// ```
+	///
+	/// - parameters:
+	///   - bindable: The value bindable to bind with.
+	///   - action: The `Action` to bind with.
+	///
+	/// - returns: A `Disposable` that can be used to tear down the action binding.
+	@discardableResult
+	public static func <~> <Output, Error>(bindable: Self, action: Action<(), Output, Error>) -> Disposable? {
+		return bindable.bind(to: action)
+	}
+}

--- a/ReactiveCocoa/Deprecations+Removals.swift
+++ b/ReactiveCocoa/Deprecations+Removals.swift
@@ -1,5 +1,20 @@
 import ReactiveSwift
 import enum Result.NoError
+#if os(iOS)
+import UIKit
+#endif
+
+#if os(iOS)
+extension Reactive where Base: UISwitch {
+	@available(*, unavailable, message:"Use `<~>` on `isOn` instead. For example: `action <~> acceptanceSwitch.reactive.isOn`")
+	public var toggled: Any { fatalError() }
+}
+
+extension Reactive where Base: UIRefreshControl {
+	@available(*, unavailable, message:"Use `<~>` on `isRefreshing` instead. For example: `action <~> refreshControl.reactive.isRefreshing`")
+	public var toggled: Any { fatalError() }
+}
+#endif
 
 extension Action {
 	@available(*, unavailable, message:"Use the `CocoaAction` initializers instead.")

--- a/ReactiveCocoa/UIKit/UIButton.swift
+++ b/ReactiveCocoa/UIKit/UIButton.swift
@@ -1,30 +1,22 @@
 import ReactiveSwift
 import UIKit
 
-extension Reactive where Base: UIButton {
-	/// The action to be triggered when the button is pressed. It also controls
-	/// the enabled state of the button.
-	public var pressed: CocoaAction<Base>? {
-		get {
-			return associatedAction.withValue { info in
-				return info.flatMap { info in
-					return info.controlEvents == pressEvent ? info.action : nil
-				}
-			}
-		}
-
-		nonmutating set {
-			setAction(newValue, for: pressEvent)
-		}
-	}
-
-    private var pressEvent: UIControlEvents {
+extension UIButton: ReactiveControlConfigurable {
+	public static var defaultControlEvents: UIControlEvents {
 		if #available(iOS 9.0, tvOS 9.0, *) {
 			return .primaryActionTriggered
 		} else {
 			return .touchUpInside
 		}
-    }
+	}
+}
+
+extension Reactive where Base: UIButton {
+	/// The action to be triggered when the button is pressed. It also controls
+	/// the enabled state of the button.
+	public var pressed: ActionBindable<Base, Void> {
+        return makeActionBindable(for: Base.defaultControlEvents, { _ in })
+	}
 
 	/// Sets the title of the button for its normal state.
 	public var title: BindingTarget<String> {

--- a/ReactiveCocoa/UIKit/UILabel.swift
+++ b/ReactiveCocoa/UIKit/UILabel.swift
@@ -13,7 +13,14 @@ extension Reactive where Base: UILabel {
 	}
 
 	/// Sets the color of the text of the label.
-	public var textColor: BindingTarget<UIColor> {
-		return makeBindingTarget { $0.textColor = $1 }
+	public var textColor: BindingTarget<UIColor?> {
+		return self[\._textColor]
+	}
+}
+
+private extension UILabel {
+	var _textColor: UIColor? {
+		get { return textColor }
+		set { textColor = newValue }
 	}
 }

--- a/ReactiveCocoa/UIKit/UISegmentedControl.swift
+++ b/ReactiveCocoa/UIKit/UISegmentedControl.swift
@@ -2,14 +2,20 @@ import ReactiveSwift
 import enum Result.NoError
 import UIKit
 
+extension UISegmentedControl: ReactiveControlConfigurable {
+	public static var defaultControlEvents: UIControlEvents {
+		return [.valueChanged]
+	}
+}
+
 extension Reactive where Base: UISegmentedControl {
 	/// Changes the selected segment of the segmented control.
-	public var selectedSegmentIndex: BindingTarget<Int> {
-		return makeBindingTarget { $0.selectedSegmentIndex = $1 }
+	public var selectedSegmentIndex: ValueBindable<Base, Int> {
+		return self[\.selectedSegmentIndex]
 	}
 
 	/// A signal of indexes of selections emitted by the segmented control.
 	public var selectedSegmentIndexes: Signal<Int, NoError> {
-		return mapControlEvents(.valueChanged) { $0.selectedSegmentIndex }
+		return map(\.selectedSegmentIndex)
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -2,10 +2,25 @@ import ReactiveSwift
 import enum Result.NoError
 import UIKit
 
+extension UITextField: ReactiveContinuousControlConfigurable {
+	public static var defaultControlEvents: UIControlEvents {
+		return [.editingDidEnd, .editingDidEndOnExit]
+	}
+
+	public static var defaultContinuousControlEvents: UIControlEvents {
+		return .allEditingEvents
+	}
+}
+
 extension Reactive where Base: UITextField {
 	/// Sets the text of the text field.
-	public var text: BindingTarget<String?> {
-		return makeBindingTarget { $0.text = $1 }
+	public var text: ValueBindable<Base, String?> {
+		return self[\.text]
+	}
+
+	/// Sets the text of the text field.
+	public var continuousText: ValueBindable<Base, String?> {
+		return self[continuous: \.text]
 	}
 
 	/// A signal of text values emitted by the text field upon end of editing.
@@ -13,23 +28,28 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
-		return mapControlEvents([.editingDidEnd, .editingDidEndOnExit]) { $0.text }
+		return map(\.text)
 	}
 
 	/// A signal of text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {
-		return mapControlEvents(.allEditingEvents) { $0.text }
+		return continuousMap(\.text)
 	}
-	
+
 	/// Sets the attributed text of the text field.
-	public var attributedText: BindingTarget<NSAttributedString?> {
-		return makeBindingTarget { $0.attributedText = $1 }
+	public var attributedText: ValueBindable<Base, NSAttributedString?> {
+		return self[\.attributedText]
+	}
+
+	/// Sets the attributed text of the text field.
+	public var continuousAttributedText: ValueBindable<Base, NSAttributedString?> {
+		return self[continuous: \.attributedText]
 	}
 	
 	/// Sets the textColor of the text field.
-	public var textColor: BindingTarget<UIColor> {
+	public var textColor: BindingTarget<UIColor?> {
 		return makeBindingTarget { $0.textColor = $1 }
 	}
 	
@@ -38,14 +58,14 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe attributed text values that change on all editing events,
 	///   see `continuousAttributedTextValues`.
 	public var attributedTextValues: Signal<NSAttributedString?, NoError> {
-		return mapControlEvents([.editingDidEnd, .editingDidEndOnExit]) { $0.attributedText }
+		return map(\.attributedText)
 	}
 	
 	/// A signal of attributed text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
 	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
-		return mapControlEvents(.allEditingEvents) { $0.attributedText }
+		return continuousMap(\.attributedText)
 	}
 
 	/// Sets the secure text entry attribute on the text field.

--- a/ReactiveCocoa/UIKit/UIView.swift
+++ b/ReactiveCocoa/UIKit/UIView.swift
@@ -18,7 +18,7 @@ extension Reactive where Base: UIView {
 	}
 
 	/// Sets the background color of the view.
-	public var backgroundColor: BindingTarget<UIColor> {
+	public var backgroundColor: BindingTarget<UIColor?> {
 		return makeBindingTarget { $0.backgroundColor = $1 }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
@@ -2,14 +2,20 @@ import ReactiveSwift
 import enum Result.NoError
 import UIKit
 
+extension UIDatePicker: ReactiveControlConfigurable {
+	public static var defaultControlEvents: UIControlEvents {
+		return .valueChanged
+	}
+}
+
 extension Reactive where Base: UIDatePicker {
 	/// Sets the date of the date picker.
-	public var date: BindingTarget<Date> {
-		return makeBindingTarget { $0.date = $1 }
+	public var date: ValueBindable<Base, Date> {
+		return self[\.date]
 	}
 
 	/// A signal of dates emitted by the date picker.
 	public var dates: Signal<Date, NoError> {
-		return mapControlEvents(.valueChanged) { $0.date }
+		return map(\.date)
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIRefreshControl.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIRefreshControl.swift
@@ -2,31 +2,29 @@ import ReactiveSwift
 import enum Result.NoError
 import UIKit
 
+private extension UIRefreshControl {
+    var _isRefreshing: Bool {
+        get { return isRefreshing }
+        set {
+            if newValue {
+                beginRefreshing()
+            } else {
+                endRefreshing()
+            }
+        }
+    }
+}
+
 extension Reactive where Base: UIRefreshControl {
 	/// Sets whether the refresh control should be refreshing.
-	public var isRefreshing: BindingTarget<Bool> {
-		return makeBindingTarget { $1 ? $0.beginRefreshing() : $0.endRefreshing() }
+	public var isRefreshing: ValueBindable<Base, Bool> {
+		return makeValueBindable(value: \._isRefreshing,
+		                         values: { $0.reactive.controlEvents(.valueChanged).map { $0.isRefreshing } },
+		                         actionDidBind: { $2 += $0.reactive.isRefreshing <~ $1.isExecuting })
 	}
 
 	/// Sets the attributed title of the refresh control.
 	public var attributedTitle: BindingTarget<NSAttributedString?> {
 		return makeBindingTarget { $0.attributedTitle = $1 }
-	}
-
-	/// The action to be triggered when the refresh control is refreshed. It
-	/// also controls the enabled and refreshing states of the refresh control.
-	public var refresh: CocoaAction<Base>? {
-		get {
-			return associatedAction.withValue { info in
-				return info.flatMap { info in
-					return info.controlEvents == .valueChanged ? info.action : nil
-				}
-			}
-		}
-
-		nonmutating set {
-			let disposable = newValue.flatMap { isRefreshing <~ $0.isExecuting }
-			setAction(newValue, for: .valueChanged, disposable: disposable)
-		}
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISlider.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISlider.swift
@@ -2,11 +2,17 @@ import UIKit
 import ReactiveSwift
 import enum Result.NoError
 
+extension UISlider: ReactiveControlConfigurable {
+	public static var defaultControlEvents: UIControlEvents {
+		return .valueChanged
+	}
+}
+
 extension Reactive where Base: UISlider {
 
 	/// Sets slider's value.
-	public var value: BindingTarget<Float> {
-		return makeBindingTarget { $0.value = $1 }
+	public var value: ValueBindable<Base, Float> {
+		return self[\.value]
 	}
 
 	/// Sets slider's minimum value.
@@ -25,6 +31,6 @@ extension Reactive where Base: UISlider {
 	/// - note: If slider's `isContinuous` property is `false` then values are
 	///         sent only when user releases the slider.
 	public var values: Signal<Float, NoError> {
-		return mapControlEvents(.valueChanged) { $0.value }
+		return map(\.value)
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIStepper.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIStepper.swift
@@ -2,11 +2,17 @@ import UIKit
 import ReactiveSwift
 import enum Result.NoError
 
+extension UIStepper: ReactiveControlConfigurable {
+	public static var defaultControlEvents: UIControlEvents {
+		return .valueChanged
+	}
+}
+
 extension Reactive where Base: UIStepper {
 
 	/// Sets the stepper's value.
-	public var value: BindingTarget<Double> {
-		return makeBindingTarget { $0.value = $1 }
+	public var value: ValueBindable<Base, Double> {
+        return self[\.value]
 	}
 
 	/// Sets stepper's minimum value.
@@ -22,6 +28,6 @@ extension Reactive where Base: UIStepper {
 	/// A signal of double values emitted by the stepper upon each user's
 	/// interaction.
 	public var values: Signal<Double, NoError> {
-		return mapControlEvents(.valueChanged) { $0.value }
+		return map(\.value)
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISwitch.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISwitch.swift
@@ -2,29 +2,20 @@ import ReactiveSwift
 import enum Result.NoError
 import UIKit
 
-extension Reactive where Base: UISwitch {
-	/// The action to be triggered when the switch is changed. It also controls
-	/// the enabled state of the switch
-	public var toggled: CocoaAction<Base>? {
-		get {
-			return associatedAction.withValue { info in
-				return info.flatMap { info in
-					return info.controlEvents == .valueChanged ? info.action : nil
-				}
-			}
-		}
-
-		nonmutating set {
-			setAction(newValue, for: .valueChanged)
-		}
+extension UISwitch: ReactiveControlConfigurable {
+	public static var defaultControlEvents: UIControlEvents {
+		return .valueChanged
 	}
+}
+
+extension Reactive where Base: UISwitch {
 	/// Sets the on-off state of the switch.
-	public var isOn: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isOn = $1 }
+	public var isOn: ValueBindable<Base, Bool> {
+		return self[\.isOn]
 	}
 
 	/// A signal of on-off states in `Bool` emitted by the switch.
 	public var isOnValues: Signal<Bool, NoError> {
-		return mapControlEvents(.valueChanged) { $0.isOn }
+		return map(\.isOn)
 	}
 }

--- a/ReactiveCocoaTests/BidirectionalBindingSpec.swift
+++ b/ReactiveCocoaTests/BidirectionalBindingSpec.swift
@@ -1,0 +1,226 @@
+import Nimble
+import Quick
+import ReactiveSwift
+import ReactiveCocoa
+import Result
+
+private final class MockControl<Value> {
+	var isEnabled = true
+	var value: Value
+
+	var actionBindable: ActionBindable<MockControl, Value> {
+		return ActionBindable(owner: self,
+		                     isEnabled: \.isEnabled,
+		                     values: { $0.signal })
+	}
+
+	var valueBindable: ValueBindable<MockControl, Value> {
+		return ValueBindable(owner: self,
+		                     isEnabled: \.isEnabled,
+		                     value: \.value,
+		                     values: { $0.signal })
+	}
+
+	let (signal, observer) = Signal<Value, NoError>.pipe()
+
+	init(_ initial: Value) {
+		value = initial
+	}
+
+	func emulateUserInput(_ input: Value) {
+		value = input
+		observer.send(value: input)
+	}
+}
+
+enum TestValue: Equatable {
+    case undefined
+    case initial
+    case subsequent
+    case final
+}
+
+class BidirectionalBindingSpec: QuickSpec {
+	override func spec() {
+		func itShouldTrackAvailabilityOfTheBoundAction<Bindable: ActionBindableProtocol>(
+			_ control: MockControl<TestValue>,
+			_ bindable: Bindable
+		) where Bindable.Value == TestValue {
+			let (pipe, observer) = Signal<Never, NoError>.pipe()
+
+			let action = Action<TestValue, Never, NoError> { _ in
+				return SignalProducer(pipe)
+			}
+
+			control.isEnabled = false
+			expect(action.isEnabled.value) == true
+
+			action <~> bindable
+			expect(action.isEnabled.value) == true
+			expect(control.isEnabled) == true
+
+			action.apply(.initial).start()
+			expect(action.isEnabled.value) == false
+			expect(control.isEnabled) == false
+
+			observer.sendCompleted()
+			expect(action.isEnabled.value) == true
+			expect(control.isEnabled) == true
+		}
+
+		func itShouldStartTheActionForEveryUserInput<Bindable: ActionBindableProtocol>(
+			_ control: MockControl<TestValue>,
+			_ bindable: Bindable
+		) where Bindable.Value == TestValue {
+			let (pipe, observer) = Signal<(), NoError>.pipe()
+			var values: [TestValue] = []
+
+			let action = Action<TestValue, Never, NoError> { input in
+				return SignalProducer
+					.never
+					.take(until: pipe)
+					.on(started: { values.append(input) })
+			}
+
+			var disabledActionCount = 0
+			action.disabledErrors.observeValues { disabledActionCount += 1 }
+
+			action <~> bindable
+
+			control.emulateUserInput(.undefined)
+			expect(values) == [.undefined]
+			expect(disabledActionCount) == 0
+
+			control.emulateUserInput(.initial)
+			expect(values) == [.undefined]
+			observer.send(value: ())
+			expect(disabledActionCount) == 1
+
+			control.emulateUserInput(.subsequent)
+			expect(values) == [.undefined, .subsequent]
+			observer.send(value: ())
+			expect(disabledActionCount) == 1
+
+			control.emulateUserInput(.final)
+			expect(values) == [.undefined, .subsequent, .final]
+			observer.send(value: ())
+			expect(disabledActionCount) == 1
+		}
+
+		describe("ActionBindable") {
+			var actionBindable: ActionBindable<MockControl<TestValue>, TestValue>!
+			var control: MockControl<TestValue>!
+
+			beforeEach {
+				control = MockControl(.undefined)
+				actionBindable = control.actionBindable
+			}
+
+			afterEach {
+				weak var weakControl = control
+				control = nil
+
+				expect(weakControl).to(beNil())
+			}
+
+			it("should track the availability of the bound action") {
+				itShouldTrackAvailabilityOfTheBoundAction(control, actionBindable)
+			}
+
+			it("should start the action for every user input") {
+				itShouldStartTheActionForEveryUserInput(control, actionBindable)
+			}
+		}
+
+		describe("ValueBindable") {
+            var source: MutableProperty<TestValue>!
+			var valueBindable: ValueBindable<MockControl<TestValue>, TestValue>!
+			var control: MockControl<TestValue>!
+
+			beforeEach {
+                control = MockControl(.undefined)
+				valueBindable = control.valueBindable
+                source = MutableProperty(.initial)
+			}
+
+			afterEach {
+				weak var weakControl = control
+				control = nil
+
+				expect(weakControl).to(beNil())
+			}
+
+            it("should initialize the control") {
+                expect(control?.value) == .undefined
+
+                source <~> valueBindable
+                expect(control?.value) == .initial
+                expect(source?.value) == .initial
+            }
+
+            it("should immediately propagate mutations from the source") {
+                source <~> valueBindable
+                expect(control?.value) == .initial
+                expect(source?.value) == .initial
+
+                source.value = .subsequent
+                expect(control?.value) == .subsequent
+                expect(source?.value) == .subsequent
+
+                source.value = .final
+                expect(control?.value) == .final
+                expect(source?.value) == .final
+            }
+
+            it("should immediately propagate user inputs from the control") {
+                source <~> valueBindable
+                expect(control?.value) == .initial
+                expect(source?.value) == .initial
+
+                control.emulateUserInput(.subsequent)
+                expect(control?.value) == .subsequent
+                expect(source?.value) == .subsequent
+
+                control.emulateUserInput(.final)
+                expect(control?.value) == .final
+                expect(source?.value) == .final
+            }
+
+            it("should immediately propagate user input from the control, and then propagate mutations from the source") {
+                source <~> valueBindable
+                expect(control?.value) == .initial
+                expect(source?.value) == .initial
+
+                control.emulateUserInput(.subsequent)
+                expect(control?.value) == .subsequent
+                expect(source?.value) == .subsequent
+
+                source.value = .final
+                expect(control?.value) == .final
+                expect(source?.value) == .final
+            }
+
+            it("should immediately propagate mutations from the source, and then propagate user input from the control") {
+                source <~> valueBindable
+                expect(control?.value) == .initial
+                expect(source?.value) == .initial
+
+                source.value = .subsequent
+                expect(control?.value) == .subsequent
+                expect(source?.value) == .subsequent
+
+                control.emulateUserInput(.final)
+                expect(control?.value) == .final
+                expect(source?.value) == .final
+            }
+
+			it("should track the availability of the bound action") {
+				itShouldTrackAvailabilityOfTheBoundAction(control, valueBindable)
+			}
+
+			it("should start the action for every user input") {
+				itShouldStartTheActionForEveryUserInput(control, valueBindable)
+			}
+		}
+	}
+}

--- a/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
@@ -22,7 +22,7 @@ class UIBarButtonItemSpec: QuickSpec {
 
 		it("should not be retained with the presence of a `pressed` action") {
 			let action = Action<(),(),NoError> { SignalProducer(value: ()) }
-			barButtonItem.reactive.pressed = CocoaAction(action)
+			barButtonItem.reactive.pressed <~> action
 		}
 
 		it("should accept changes from bindings to its enabling state") {

--- a/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
@@ -51,7 +51,7 @@ class UIButtonSpec: QuickSpec {
 
 			pressed <~ SignalProducer(action.values)
 
-			button.reactive.pressed = CocoaAction(action)
+			button.reactive.pressed <~> action
 			expect(pressed.value) == false
 
 			button.sendActions(for: event)

--- a/ReactiveCocoaTests/UIKit/UIDatePickerSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIDatePickerSpec.swift
@@ -25,7 +25,7 @@ class UIDatePickerSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its date value") {
-			picker.reactive.date.action(date)
+			picker.reactive.date <~ SignalProducer(value: date)
 			expect(picker.date) == date
 		}
 

--- a/ReactiveCocoaTests/UIKit/UIRefreshControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIRefreshControlSpec.swift
@@ -57,7 +57,7 @@ class UIRefreshControlSpec: QuickSpec {
 
 			refreshed <~ SignalProducer(action.values)
 
-			refreshControl.reactive.refresh = CocoaAction(action)
+			refreshControl.reactive.isRefreshing <~> action
 			expect(refreshed.value) == false
 
 			refreshControl.sendActions(for: .valueChanged)
@@ -72,10 +72,14 @@ class UIRefreshControlSpec: QuickSpec {
 				SignalProducer(value: true).delay(1, on: QueueScheduler.main)
 			}
 
-			refreshControl.reactive.refresh = CocoaAction(action)
+			refreshControl.reactive.isRefreshing <~> action
 			expect(refreshControl.isRefreshing) == false
+			expect(action.isEnabled.value) == true
+			expect(action.isExecuting.value) == false
 
 			refreshControl.sendActions(for: .valueChanged)
+			expect(action.isEnabled.value) == false
+			expect(action.isExecuting.value) == true
 			expect(refreshControl.isRefreshing) == true
 
 			expect(refreshControl.isRefreshing).toEventually(equal(false), timeout: 2)

--- a/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
@@ -54,8 +54,8 @@ class UISwitchSpec: QuickSpec {
 			}
 			isOn <~ SignalProducer(action.values)
 			
-			toggle.reactive.toggled = CocoaAction(action) { return $0.isOn }
-			
+			toggle.reactive.isOn <~> action
+
 			expect(isOn.value) == false
 			
 			toggle.isOn = true


### PR DESCRIPTION
Introducing a new `<~>` bidirectional binding operator. This replaces the assignment-based `CocoaAction` action binding API, and is extended to support two-way bindings with properties.

A set of the existing control `BindingTarget`s are upgraded to be `ActionBindable` and `ValueBindable`. Both still support unidirectional bindings via `<~`.

- [x] Skeleton and API mock
- [x] Implementation
- [x] Test coverage

## Action bindings
### Before
```swift
switch.reactive.toggled = CocoaAction(viewModel.toggle) { $0.isOn }
button.reactive.pressed = CocoaAction(viewModel.submit)
refreshControl.reactive.refresh = CocoaAction(viewModel.refresh)
```

### After
```swift
switch.reactive.isOn <~> viewModel.toggle
button.reactive.pressed <~> viewModel.submit
refreshControl.reactive.isRefreshing <~> viewModel.refresh
```

## Property bindings
### Before
```swift
usernameField.text = viewModel.username.value
viewModel.username <~ usernameField.reactive.textValues
```

### After
```swift
viewModel.username <~> usernameField.reactive.text
```