### PR TITLE
Interception Acceleration and improve KVO interoperability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# master
+*Please put new entries at the top.*
+
+1. Intercepting a selector that has been swizzled by KVO beforehand no longer causes concurrent invocations of the selector to exhibit undefined behavior. (#3467, kudos to @andersio)
+
+1. Improved method interception performance for a limited set of method signatures. (#3467)
+
 # 5.0
 
 ### Table of Contents

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -129,6 +129,10 @@
 		9A24A8451DE142A400987AF9 /* SwizzlingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A24A8431DE1429600987AF9 /* SwizzlingSpec.swift */; };
 		9A24A8461DE142A500987AF9 /* SwizzlingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A24A8431DE1429600987AF9 /* SwizzlingSpec.swift */; };
 		9A24A8471DE142A600987AF9 /* SwizzlingSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A24A8431DE1429600987AF9 /* SwizzlingSpec.swift */; };
+		9A2517AA1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2517A91ED9A831008C13EC /* NSObject+InterceptionThunks.swift */; };
+		9A2517AB1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2517A91ED9A831008C13EC /* NSObject+InterceptionThunks.swift */; };
+		9A2517AC1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2517A91ED9A831008C13EC /* NSObject+InterceptionThunks.swift */; };
+		9A2517AD1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2517A91ED9A831008C13EC /* NSObject+InterceptionThunks.swift */; };
 		9A2E425E1DAA6737006D909F /* CocoaTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2E425D1DAA6737006D909F /* CocoaTarget.swift */; };
 		9A2E425F1DAA6737006D909F /* CocoaTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2E425D1DAA6737006D909F /* CocoaTarget.swift */; };
 		9A2E42601DAA6737006D909F /* CocoaTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2E425D1DAA6737006D909F /* CocoaTarget.swift */; };
@@ -413,6 +417,7 @@
 		9A1D06751D9415FB00ACF44C /* ObjCRuntimeAliases.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCRuntimeAliases.h; sourceTree = "<group>"; };
 		9A1E72B91D4DE96500CC20C3 /* KeyValueObservingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueObservingSpec.swift; sourceTree = "<group>"; };
 		9A24A8431DE1429600987AF9 /* SwizzlingSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwizzlingSpec.swift; sourceTree = "<group>"; };
+		9A2517A91ED9A831008C13EC /* NSObject+InterceptionThunks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+InterceptionThunks.swift"; sourceTree = "<group>"; };
 		9A2E425D1DAA6737006D909F /* CocoaTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaTarget.swift; sourceTree = "<group>"; };
 		9A54A2101DDF5B4D001739B3 /* InterceptingPerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterceptingPerformanceTests.swift; sourceTree = "<group>"; };
 		9A54A21A1DE00D09001739B3 /* ObjC+Selector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ObjC+Selector.swift"; sourceTree = "<group>"; };
@@ -786,6 +791,7 @@
 				9ADE4A901DA6EA40005C2AC8 /* NSObject+ReactiveExtensionsProvider.swift */,
 				9AD0F0691D48BA4800ADFAB7 /* NSObject+KeyValueObserving.swift */,
 				9A1D065A1D93EC6E00ACF44C /* NSObject+Intercepting.swift */,
+				9A2517A91ED9A831008C13EC /* NSObject+InterceptionThunks.swift */,
 				4A0E10FE1D2A92720065D310 /* NSObject+Lifetime.swift */,
 				9AF0EA741D9A7FF700F27DDF /* NSObject+BindingTarget.swift */,
 				9A1D05DF1D93E99100ACF44C /* NSObject+Association.swift */,
@@ -1235,6 +1241,7 @@
 				419139491DB910570043C9D1 /* UIGestureRecognizer.swift in Sources */,
 				9A1D06161D93EA0100ACF44C /* UIControl.swift in Sources */,
 				9A1D06141D93EA0100ACF44C /* UIButton.swift in Sources */,
+				9A2517AD1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */,
 				9A1D065E1D93EC6E00ACF44C /* NSObject+Intercepting.swift in Sources */,
 				9AA0BD8D1DDE153A00531FCF /* ObjC+Constants.swift in Sources */,
 				9AF0EA781D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */,
@@ -1301,6 +1308,7 @@
 			files = (
 				9A2E42601DAA6737006D909F /* CocoaTarget.swift in Sources */,
 				9A74884A1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */,
+				9A2517AC1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */,
 				9A9DFEE51DA7B5500039EE1B /* NSObject+Intercepting.swift in Sources */,
 				9A54A21D1DE00D09001739B3 /* ObjC+Selector.swift in Sources */,
 				9AB15C7C1E26CD9A00997378 /* Deprecations+Removals.swift in Sources */,
@@ -1356,6 +1364,7 @@
 				53A6BED21DD4BCA90016C058 /* MKMapView.swift in Sources */,
 				9A1D065B1D93EC6E00ACF44C /* NSObject+Intercepting.swift in Sources */,
 				4A0E10FF1D2A92720065D310 /* NSObject+Lifetime.swift in Sources */,
+				9A2517AA1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */,
 				9AA0BD811DDE03F500531FCF /* ObjC+RuntimeSubclassing.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1418,6 +1427,7 @@
 				9A1D06051D93EA0000ACF44C /* UIDatePicker.swift in Sources */,
 				9A1D05E11D93E99100ACF44C /* NSObject+Association.swift in Sources */,
 				9A1D06041D93EA0000ACF44C /* UIControl.swift in Sources */,
+				9A2517AB1ED9A831008C13EC /* NSObject+InterceptionThunks.swift in Sources */,
 				9A1D06021D93EA0000ACF44C /* UIButton.swift in Sources */,
 				9AA0BD901DDE29F800531FCF /* NSObject+ObjCRuntime.swift in Sources */,
 				A9EB3D821E955602002A9BCC /* UIImpact​Feedback​Generator.swift in Sources */,

--- a/ReactiveCocoa/NSObject+InterceptionThunks.swift
+++ b/ReactiveCocoa/NSObject+InterceptionThunks.swift
@@ -1,0 +1,413 @@
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+// Naming convention: makeThunk[First Argument Type][Second Argument Type]...
+
+private var interceptorGenerators: [String: (ThunkConfiguration) -> Any] = {
+	var configurations: [String: (ThunkConfiguration) -> Any] = [
+		// Setters of automatic KVO compliant properties, and void-returning
+		// single-argument ObjC methods.
+		"v@:c": makeThunkInt8,
+		"v@:i": makeThunkCInt,
+		"v@:s": makeThunkInt16,
+		"v@:l": makeThunkInt32,
+		"v@:q": makeThunkInt64,
+		"v@:C": makeThunkUInt8,
+		"v@:I": makeThunkCUnsignedInt,
+		"v@:S": makeThunkUInt16,
+		"v@:L": makeThunkUInt32,
+		"v@:Q": makeThunkUInt64,
+		"v@:B": makeThunkBool,
+		"v@:@": makeThunkAnyObject,
+		"v@:f": makeThunkFloat,
+		"v@:d": makeThunkDouble]
+
+	#if arch(i386) || arch(arm)
+		configurations["v@:{CGRect={CGPoint=ff}{CGSize=ff}}"] = makeThunkCGRect
+		configurations["v@:{CGPoint=ff}"] = makeThunkCGPoint
+		configurations["v@:{CGSize=ff}"] = makeThunkCGSize
+		configurations["v@:{NSRange=LL}"] = makeThunkNSRange
+	#else
+		configurations["v@:{CGRect={CGPoint=dd}{CGSize=dd}}"] = makeThunkCGRect
+		configurations["v@:{CGPoint=dd}"] = makeThunkCGPoint
+		configurations["v@:{CGSize=dd}"] = makeThunkCGSize
+		configurations["v@:{NSRange=QQ}"] = makeThunkNSRange
+	#endif
+
+	return configurations
+}()
+
+internal func getInterceptor(for typeEncoding: UnsafePointer<CChar>) -> ((ThunkConfiguration) -> Any)? {
+	func clean(_ typeEncoding: UnsafePointer<Int8>) -> String {
+		return String(String(cString: typeEncoding)
+			.characters.filter { !"0123456789".characters.contains($0) })
+	}
+
+	return interceptorGenerators[clean(typeEncoding)]
+}
+
+internal struct ThunkConfiguration {
+	fileprivate let stateKey: AssociationKey<InterceptingState?>
+	fileprivate let selector: Selector
+	fileprivate let methodSignature: AnyObject
+	fileprivate let originalImplementation: IMP?
+	fileprivate let perceivedClass: AnyClass
+
+	init(stateKey: AssociationKey<InterceptingState?>, selector: Selector, methodSignature: AnyObject, originalImplementation: IMP?, perceivedClass: AnyClass) {
+		self.stateKey = stateKey
+		self.selector = selector
+		self.methodSignature = methodSignature
+		self.originalImplementation = originalImplementation
+		self.perceivedClass = perceivedClass
+	}
+
+	fileprivate func getImplementation() -> IMP? {
+		let impl = originalImplementation ?? class_getMethodImplementation(perceivedClass, selector)
+		return impl.flatMap { $0 != _rac_objc_msgForward ? $0 : nil }
+	}
+
+	fileprivate func forward(_ object: Unmanaged<AnyObject>, noConcreteImpl: Bool, pack: (ObjCInvocation) -> Void) {
+		let invocation = NSInvocation.invocation(withMethodSignature: methodSignature)
+		invocation.target = object
+		invocation.setSelector(selector)
+		pack(invocation)
+
+		if noConcreteImpl {
+			typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, AnyObject) -> Void
+			let impl = class_getMethodImplementation(perceivedClass, ObjCSelector.forwardInvocation)
+			let superImplementation = unsafeBitCast(impl, to: CImplementation.self)
+			superImplementation(object, ObjCSelector.forwardInvocation, invocation)
+		}
+
+		if let state = Associations(object.takeUnretainedValue()).value(forKey: stateKey) {
+			state.observer.send(value: invocation)
+		}
+	}
+}
+
+private func makeThunkBool(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, Bool) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, Bool) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkInt8(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, Int8) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, Int8) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkDouble(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, Double) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, Double) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkFloat(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, Float) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, Float) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkCInt(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, CInt) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, CInt) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkInt64(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, Int64) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, Int64) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkInt32(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, Int32) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, Int32) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkAnyObject(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, AnyObject) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, AnyObject) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkCGPoint(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, CGPoint) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, CGPoint) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkNSRange(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, NSRange) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, NSRange) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkCGRect(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, CGRect) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, CGRect) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkInt16(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, Int16) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, Int16) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkCGSize(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, CGSize) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, CGSize) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkUInt8(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, UInt8) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, UInt8) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkCUnsignedInt(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, CUnsignedInt) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, CUnsignedInt) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkUInt64(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, UInt64) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, UInt64) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkUInt32(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, UInt32) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, UInt32) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}
+
+private func makeThunkUInt16(config: ThunkConfiguration) -> (@convention(block) (Unmanaged<AnyObject>, UInt16) -> Void) {
+	return { object, value in
+		typealias CImplementation = @convention(c) (Unmanaged<AnyObject>, Selector, UInt16) -> Void
+		var noConcreteImpl = false
+
+		if let impl = config.getImplementation() {
+			unsafeBitCast(impl, to: CImplementation.self)(object, config.selector, value)
+		} else {
+			noConcreteImpl = true
+		}
+
+		config.forward(object, noConcreteImpl: noConcreteImpl) { invocation in
+			var value = value
+			invocation.setArgument(&value, at: 2)
+		}
+	}
+}

--- a/ReactiveCocoa/ObjC+Messages.swift
+++ b/ReactiveCocoa/ObjC+Messages.swift
@@ -18,6 +18,8 @@ internal let NSMethodSignature: AnyClass = NSClassFromString("NSMethodSignature"
 
 // Methods of `NSInvocation`.
 @objc internal protocol ObjCInvocation {
+	var target: Any? { get set }
+
 	@objc(setSelector:)
 	func setSelector(_ selector: Selector)
 
@@ -30,7 +32,10 @@ internal let NSMethodSignature: AnyClass = NSClassFromString("NSMethodSignature"
 	func invoke()
 
 	@objc(invocationWithMethodSignature:)
-	static func invocation(withMethodSignature signature: AnyObject) -> AnyObject
+	static func invocation(withMethodSignature signature: AnyObject) -> ObjCInvocation
+
+	@objc(setArgument:atIndex:)
+	func setArgument(_ pointer: UnsafeRawPointer, at index: Int)
 }
 
 // Methods of `NSMethodSignature`.

--- a/ReactiveCocoa/ObjC+Selector.swift
+++ b/ReactiveCocoa/ObjC+Selector.swift
@@ -10,13 +10,6 @@ extension Selector {
 		return prefixing("rac0_")
 	}
 
-	/// An alias of `self`, used in method interception specifically for
-	/// preserving (if found) an immediate implementation of `self` in the
-	/// runtime subclass.
-	internal var interopAlias: Selector {
-		return prefixing("rac1_")
-	}
-
 	/// An alias of `self`, used for delegate proxies.
 	internal var delegateProxyAlias: Selector {
 		return prefixing("rac2_")


### PR DESCRIPTION
Preceded by #3362, *Bypass the message forwarding for common method signatures*.

This PR resurrects #3362 from the void to replace the current IMP swapping trick used for an KVO interoperating scenario #3302.

### To-do
- [ ] Written Spec for Swizzling Interoperability.
- [ ] Wait for DelegateProxy revamp (#3467).

### The Problem
As mentioned in https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3302#issuecomment-269062819:
> Limited interoperability with isa-swizzling in general: RAC would not subclass any external runtime subclass.
>
> If a selector is being implemented or overriden in the runtime subclass, and subsequently swizzled by RAC, concurrent invocation of the selector would lead to undefined behaviour.

TL;DR: It isn't safe to observe a key path, and then swizzle the setter with RAC.

This is due to [the said IMP swapping trick](https://github.com/ReactiveCocoa/ReactiveCocoa/blob/master/ReactiveCocoa/NSObject%2BIntercepting.swift#L181), which causes the actual implementation of the selector indeterministic when it is invoked concurrently.

Note that this applies to only automatic KVO. Manual KVO doesn't use isa-swizzling, so it won't mess with RAC at all.

### The Solution
We want to guarantee that **for all automatic KVO notification compliant key paths** using RAC interception on top of KVO does not lead to undefined behaviour.

To achieve this, RAC would provide concrete implementations for a defined set of setter signatures, so that we have the compile-time information to invoke the KVO implementation directly, instead of swapping implementations and invoking through `NSInvocation`.

IOW for [all the types supported by automatic KVO](https://www.mikeash.com/pyblog/friday-qa-2009-01-23.html), we would have a concrete setter generator for it. The signature of the generator would be:
```swift
// `Any` should hold a `@convention(block) (Unmanaged<AnyObject>, U...) -> Void
(InterceptorInfo) -> Any
```

⚠️ For cases that do not fit in the defined set, we would now **trap** by default and support them case by case, since isa swizzling framework is rather rare. ⚠️

### Bonus
Message forwarding is expensive. Concrete implementations cut the overhead.

### Future Work
We may extend the set of generators beyond types supported by automatic KVO. For example, #3362 suggested to cover all commonly used signatures in delegates.