### PR TITLE
Fix bad productName values

### DIFF
--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -977,7 +977,7 @@
 			dependencies = (
 			);
 			name = "ReactiveCocoa-tvOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveCocoa-tvOS";
 			productReference = 57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -1014,7 +1014,7 @@
 			dependencies = (
 			);
 			name = "ReactiveCocoa-watchOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveCocoa-watchOS";
 			productReference = A9B315541B3940610001CB9C /* ReactiveCocoa.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -1032,7 +1032,7 @@
 			dependencies = (
 			);
 			name = "ReactiveCocoa-macOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveCocoa-macOS";
 			productReference = D04725EA19E49ED7006002AA /* ReactiveCocoa.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -1050,7 +1050,7 @@
 				D04725F819E49ED7006002AA /* PBXTargetDependency */,
 			);
 			name = "ReactiveCocoa-macOSTests";
-			productName = ReactiveCocoaTests;
+			productName = "ReactiveCocoa-macOSTests";
 			productReference = D04725F519E49ED7006002AA /* ReactiveCocoaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -1068,7 +1068,7 @@
 			dependencies = (
 			);
 			name = "ReactiveCocoa-iOS";
-			productName = ReactiveCocoa;
+			productName = "ReactiveCocoa-iOS";
 			productReference = D047260C19E49F82006002AA /* ReactiveCocoa.framework */;
 			productType = "com.apple.product-type.framework";
 		};
@@ -1087,7 +1087,7 @@
 				D047261919E49F82006002AA /* PBXTargetDependency */,
 			);
 			name = "ReactiveCocoa-iOSTests";
-			productName = ReactiveCocoaTests;
+			productName = "ReactiveCocoa-iOSTests";
 			productReference = D047261619E49F82006002AA /* ReactiveCocoaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};


### PR DESCRIPTION
This (should be) a very minimally invasive PR. 

**The background:**

In general, Xcode appears to behave very badly when using workspaces and its "Find Implicit Dependencies" feature in the scheme editor. Many folks throw up their hands and resort to manual dependency specifications.

Well I think that its terrible behavior can be attributed to a bug in Xcode that causes it to not update the `productName` value in the `.pbxproj` file when a target is renamed. This happens very commonly when creating a framework project, then duplicating the framework targets with suffixes for other platforms.

For some folks, this patch may improve their build experience in Xcode quite a bit—especially for follks like me with very large workspaces that involve a lot of subprojects.

Sorry it took so long to write this one up after making the branch—I hadn't verified that the fix actually worked until I hit the issue again today, and fixing the `productName` value resolved my dependency issue. I'll try and cook up a Radar for this now that I know the steps.