### PR TITLE
Introduce `mapControlEvents`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # master
 *Please put new entries at the top.
 
-1. Resigning first responder when reacting to a `UITextField` signal no longer deadlocks. (#3453)
+1. Resigning first responder when reacting to a `UITextField` signal no longer deadlocks. (#3453, #3472)
 
 1. New operator: `take(duringLifetimeOf:)`. (#3466, kudos to @andersio)
    It is available on `Signal` and `SignalProducer`, and supports both Objective-C and native Swift objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # master
 *Please put new entries at the top.
 
+1. Introduce `mapControlEvents(_:_:)` which is set to replace `controlEvents(_:_:)` in most cases. (#3472)
+
+   You should use `mapControlEvents` in general unless the state of the control — e.g. `text`, `state` — is **not** concerned. In other words, you should avoid using `map` on a control event signal to extract the state from the control.
+
 1. Resigning first responder when reacting to a `UITextField` signal no longer deadlocks. (#3453, #3472)
 
 1. New operator: `take(duringLifetimeOf:)`. (#3466, kudos to @andersio)

--- a/ReactiveCocoa/UIKit/UIControl.swift
+++ b/ReactiveCocoa/UIKit/UIControl.swift
@@ -44,11 +44,23 @@ extension Reactive where Base: UIControl {
 	/// - parameters:
 	///   - controlEvents: The control event mask.
 	///
-	/// - returns: A signal that sends the control each time the control event 
-	///            occurs.
+	/// - returns: A signal that sends the control each time the control event occurs.
 	public func controlEvents(_ controlEvents: UIControlEvents) -> Signal<Base, NoError> {
+		return mapControlEvents(controlEvents, { $0 })
+	}
+
+	/// Create a signal which sends a `value` event for each of the specified
+	/// control events.
+	///
+	/// - parameters:
+	///   - controlEvents: The control event mask.
+	///   - transform: A transform to reduce `Base`.
+	///
+	/// - returns: A signal that sends the reduced value from the control each time the
+	///            control event occurs.
+	public func mapControlEvents<Value>(_ controlEvents: UIControlEvents, _ transform: @escaping (Base) -> Value) -> Signal<Value, NoError> {
 		return Signal { observer in
-			let receiver = CocoaTarget(observer) { $0 as! Base }
+			let receiver = CocoaTarget(observer) { transform($0 as! Base) }
 			base.addTarget(receiver,
 			               action: #selector(receiver.invoke),
 			               for: controlEvents)

--- a/ReactiveCocoa/UIKit/UIControl.swift
+++ b/ReactiveCocoa/UIKit/UIControl.swift
@@ -41,6 +41,9 @@ extension Reactive where Base: UIControl {
 	/// Create a signal which sends a `value` event for each of the specified
 	/// control events.
 	///
+	/// - note: If you mean to observe the **value** of `self` with regard to a particular
+	///         control event, `mapControlEvents(_:_:)` should be used instead.
+	///
 	/// - parameters:
 	///   - controlEvents: The control event mask.
 	///
@@ -51,6 +54,16 @@ extension Reactive where Base: UIControl {
 
 	/// Create a signal which sends a `value` event for each of the specified
 	/// control events.
+	///
+	/// - important: You should use `mapControlEvents` in general unless the state of
+	///              the control — e.g. `text`, `state` — is not concerned. In other
+	///              words, you should avoid using `map` on a control event signal to
+	///              extract the state from the control.
+	///
+	/// - note: For observations that could potentially manipulate the first responder
+	///         status of `base`, `mapControlEvents(_:_:)` is made aware of the potential
+	///         recursion induced by UIKit and would collect the values for the control
+	///         events accordingly using the given transform.
 	///
 	/// - parameters:
 	///   - controlEvents: The control event mask.

--- a/ReactiveCocoa/UIKit/UISegmentedControl.swift
+++ b/ReactiveCocoa/UIKit/UISegmentedControl.swift
@@ -10,6 +10,6 @@ extension Reactive where Base: UISegmentedControl {
 
 	/// A signal of indexes of selections emitted by the segmented control.
 	public var selectedSegmentIndexes: Signal<Int, NoError> {
-		return controlEvents(.valueChanged).map { $0.selectedSegmentIndex }
+		return mapControlEvents(.valueChanged) { $0.selectedSegmentIndex }
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -13,14 +13,14 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
-		return controlEvents(.editingDidEnd).map { $0.text }
+		return mapControlEvents(.editingDidEnd) { $0.text }
 	}
 
 	/// A signal of text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {
-		return controlEvents(.allEditingEvents).map { $0.text }
+		return mapControlEvents(.allEditingEvents) { $0.text }
 	}
 	
 	/// Sets the attributed text of the text field.
@@ -38,14 +38,14 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe attributed text values that change on all editing events,
 	///   see `continuousAttributedTextValues`.
 	public var attributedTextValues: Signal<NSAttributedString?, NoError> {
-		return controlEvents(.editingDidEnd).map { $0.attributedText }
+		return mapControlEvents(.editingDidEnd) { $0.attributedText }
 	}
 	
 	/// A signal of attributed text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
 	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
-		return controlEvents(.allEditingEvents).map { $0.attributedText }
+		return mapControlEvents(.allEditingEvents) { $0.attributedText }
 	}
 
 	/// Sets the secure text entry attribute on the text field.

--- a/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
@@ -10,6 +10,6 @@ extension Reactive where Base: UIDatePicker {
 
 	/// A signal of dates emitted by the date picker.
 	public var dates: Signal<Date, NoError> {
-		return controlEvents(.valueChanged).map { $0.date }
+		return mapControlEvents(.valueChanged) { $0.date }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISlider.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISlider.swift
@@ -25,6 +25,6 @@ extension Reactive where Base: UISlider {
 	/// - note: If slider's `isContinuous` property is `false` then values are
 	///         sent only when user releases the slider.
 	public var values: Signal<Float, NoError> {
-		return controlEvents(.valueChanged).map { $0.value }
+		return mapControlEvents(.valueChanged) { $0.value }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIStepper.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIStepper.swift
@@ -22,6 +22,6 @@ extension Reactive where Base: UIStepper {
 	/// A signal of double values emitted by the stepper upon each user's
 	/// interaction.
 	public var values: Signal<Double, NoError> {
-		return controlEvents(.valueChanged).map { $0.value }
+		return mapControlEvents(.valueChanged) { $0.value }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISwitch.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISwitch.swift
@@ -25,6 +25,6 @@ extension Reactive where Base: UISwitch {
 
 	/// A signal of on-off states in `Bool` emitted by the switch.
 	public var isOnValues: Signal<Bool, NoError> {
-		return controlEvents(.valueChanged).map { $0.isOn }
+		return mapControlEvents(.valueChanged) { $0.isOn }
 	}
 }

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -141,6 +141,7 @@ class UITextFieldSpec: QuickSpec {
 
 					if text == "2" {
 						textField.resignFirstResponder()
+						textField.text = "3"
 					}
 				}
 				expect(values) == []


### PR DESCRIPTION
With reentrance support in #3453, mapping control events should be done via `CocoaTarget` so that the actual value —  rather than the control reference itself — is cached when a control event is sent recursively.

[The test case has been updated to reveal the issue.](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/3472/commits/46430da32aba3da605c829f4619ea4dbacf56072#diff-14b588001e801f83b72681a6117e4f75R144) When running the test case on `master`:
```swift
error: -[ReactiveCocoaTests.UITextFieldSpec should_not_deadlock_when_the_text_field_is_asked_to_resign_first_responder_by_any_of_its_observers]
expected to equal <[1, 2, 2]>, got <[1, 2, 3]>
```

`CocoaTarget` should have cached the value when the event is sent. But due to the current implementation of convenience signals, `CocoaTarget` captures the reference instead, and the correct value is overwritten by a subsequent mutation before `CocoaTarget` dequeues the reference and pipes it to `map`.

The transform can be replaced by smart key path in Swift 4.

TODO:
- [x] Test case
- [x] Changelog