### PR TITLE
UITextField text signal now reacts to `editingDidEndOnExit`.

### DIFF
--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -13,7 +13,7 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
 	public var textValues: Signal<String?, NoError> {
-		return controlEvents(.editingDidEnd).map { $0.text }
+		return controlEvents([.editingDidEnd, .editingDidEndOnExit]).map { $0.text }
 	}
 
 	/// A signal of text values emitted by the text field upon any changes.
@@ -38,7 +38,7 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe attributed text values that change on all editing events,
 	///   see `continuousAttributedTextValues`.
 	public var attributedTextValues: Signal<NSAttributedString?, NoError> {
-		return controlEvents(.editingDidEnd).map { $0.attributedText }
+		return controlEvents([.editingDidEnd, .editingDidEndOnExit]).map { $0.attributedText }
 	}
 	
 	/// A signal of attributed text values emitted by the text field upon any changes.

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -40,6 +40,18 @@ class UITextFieldSpec: QuickSpec {
 			expect(latestValue) == textField.text
 		}
 
+		it("should emit user initiated changes to its text value when the editing ends as a reuslt of the return key being pressed") {
+			textField.text = "Test"
+
+			var latestValue: String?
+			textField.reactive.textValues.observeValues { text in
+				latestValue = text
+			}
+
+			textField.sendActions(for: .editingDidEndOnExit)
+			expect(latestValue) == textField.text
+		}
+
 		it("should emit user initiated changes to its text value continuously") {
 			var latestValue: String?
 			textField.reactive.continuousTextValues.observeValues { text in
@@ -81,7 +93,19 @@ class UITextFieldSpec: QuickSpec {
 			textField.sendActions(for: .editingDidEnd)
 			expect(latestValue) == textField.attributedText
 		}
-		
+
+		it("should emit user initiated changes to its attributed text value when the editing ends as a reuslt of the return key being pressed") {
+			textField.attributedText = NSAttributedString(string: "Test")
+
+			var latestValue: NSAttributedString?
+			textField.reactive.attributedTextValues.observeValues { attributedText in
+				latestValue = attributedText
+			}
+
+			textField.sendActions(for: .editingDidEndOnExit)
+			expect(latestValue) == textField.attributedText
+		}
+
 		it("should emit user initiated changes to its attributed text value continuously") {
 			var latestValue: NSAttributedString?
 			textField.reactive.continuousAttributedTextValues.observeValues { attributedText in


### PR DESCRIPTION
Fixes #3465.