### PR TITLE
UIButton.reactive.pressed doesn't work on tvOS

### DIFF
--- a/ReactiveCocoa/UIKit/UIButton.swift
+++ b/ReactiveCocoa/UIKit/UIButton.swift
@@ -8,15 +8,23 @@ extension Reactive where Base: UIButton {
 		get {
 			return associatedAction.withValue { info in
 				return info.flatMap { info in
-					return info.controlEvents == .touchUpInside ? info.action : nil
+					return info.controlEvents == pressEvent ? info.action : nil
 				}
 			}
 		}
 
 		nonmutating set {
-			setAction(newValue, for: .touchUpInside)
+			setAction(newValue, for: pressEvent)
 		}
 	}
+
+    private var pressEvent: UIControlEvents {
+        #if os(tvOS)
+            return .primaryActionTriggered
+        #else
+            return .touchUpInside
+        #endif
+    }
 
 	/// Sets the title of the button for its normal state.
 	public var title: BindingTarget<String> {

--- a/ReactiveCocoa/UIKit/UIButton.swift
+++ b/ReactiveCocoa/UIKit/UIButton.swift
@@ -19,11 +19,11 @@ extension Reactive where Base: UIButton {
 	}
 
     private var pressEvent: UIControlEvents {
-        #if os(tvOS)
-            return .primaryActionTriggered
-        #else
-            return .touchUpInside
-        #endif
+		if #available(iOS 9.0, tvOS 9.0, *) {
+			return .primaryActionTriggered
+		} else {
+			return .touchUpInside
+		}
     }
 
 	/// Sets the title of the button for its normal state.

--- a/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
@@ -40,7 +40,7 @@ class UIButtonSpec: QuickSpec {
 			expect(button.title(for: .selected)) == ""
 		}
 
-		it("should execute the `pressed` action upon receiving a `touchUpInside` action message.") {
+		let pressedTest: (UIButton, UIControlEvents) -> Void = { button, event in
 			button.isEnabled = true
 			button.isUserInteractionEnabled = true
 
@@ -53,9 +53,21 @@ class UIButtonSpec: QuickSpec {
 
 			button.reactive.pressed = CocoaAction(action)
 			expect(pressed.value) == false
-			
-			button.sendActions(for: .touchUpInside)
+
+			button.sendActions(for: event)
+
 			expect(pressed.value) == true
+		}
+
+		if #available(iOS 9.0, tvOS 9.0, *) {
+			it("should execute the `pressed` action upon receiving a `primaryActionTriggered` action message.") {
+				pressedTest(button, .primaryActionTriggered)
+			}
+		} else {
+			it("should execute the `pressed` action upon receiving a `touchUpInside` action message.") {
+				pressedTest(button, .touchUpInside)
+			}
 		}
 	}
 }
+


### PR DESCRIPTION
The reason is that .touchUpInside event is used instead of .primaryActionTriggered