### PR TITLE
Replace NSObject with NSObjectProtocol in extensions

### DIFF
--- a/ReactiveCocoa/NSObject+Association.swift
+++ b/ReactiveCocoa/NSObject+Association.swift
@@ -48,7 +48,7 @@ internal struct Associations<Base: AnyObject> {
 	}
 }
 
-extension Reactive where Base: NSObject {
+extension Reactive where Base: NSObjectProtocol {
 	/// Retrieve the associated value for the specified key. If the value does not
 	/// exist, `initial` would be called and the returned value would be
 	/// associated subsequently.
@@ -72,8 +72,8 @@ extension Reactive where Base: NSObject {
 	}
 }
 
-extension NSObject {
-	@nonobjc internal var associations: Associations<NSObject> {
+extension NSObjectProtocol {
+	@nonobjc internal var associations: Associations<Self> {
 		return Associations(self)
 	}
 }

--- a/ReactiveCocoa/NSObject+BindingTarget.swift
+++ b/ReactiveCocoa/NSObject+BindingTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ReactiveSwift
 
-extension Reactive where Base: NSObject {
+extension Reactive where Base: NSObjectProtocol {
 	/// Creates a binding target which uses the lifetime of the object, and 
 	/// weakly references the object so that the supplied `action` is triggered 
 	/// only if the object has not deinitialized.

--- a/ReactiveCocoa/NSObject+Lifetime.swift
+++ b/ReactiveCocoa/NSObject+Lifetime.swift
@@ -31,7 +31,7 @@ internal func lifetime(of object: AnyObject) -> Lifetime {
 	}
 }
 
-extension Reactive where Base: NSObject {
+extension Reactive where Base: NSObjectProtocol {
 	/// Returns a lifetime that ends when the object is deallocated.
 	@nonobjc public var lifetime: Lifetime {
 		return base.synchronized {

--- a/ReactiveCocoa/NSObject+Synchronizing.swift
+++ b/ReactiveCocoa/NSObject+Synchronizing.swift
@@ -1,5 +1,5 @@
-extension NSObject {
-	@nonobjc internal final func synchronized<Result>(execute: () throws -> Result) rethrows -> Result {
+extension NSObjectProtocol {
+	internal final func synchronized<Result>(execute: () throws -> Result) rethrows -> Result {
 		objc_sync_enter(self)
 		defer { objc_sync_exit(self) }
 		return try execute()


### PR DESCRIPTION
I did this after wanting to grab the lifetime from a protocol that conforms to `NSObjectProtocol` and couldn't.

There are a couple other `NSObject` extensions this doesn't include but that's mostly because I'm new to this code base and didn't want to mess anything up without first getting feedback.