### PR TITLE
Reactive key path subscript.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # master
 *Please put new entries at the top.
 
+1. Subscripting `reactive` with a key path now yields a corresponding `BindingTarget` under Swift 3.2+. (#3489, kudos to @andersio)
+
+   Example:
+   ```swift
+   label.reactive[\.text] <~ viewModel.title
+   ```
+
 # 6.0.0-rc.2
 1. `NSObject` reactive extensions now work in generic environments that are limited to `NSObjectProtocol`. (#3484, kudos to @nickdomenicali)
 

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -157,6 +157,9 @@
 		9A7488491E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
 		9A74884A1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
 		9A74884B1E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
+		9A7990CE1F1085D8001493A3 /* BindingTargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7990CD1F1085D8001493A3 /* BindingTargetSpec.swift */; };
+		9A7990CF1F1085D8001493A3 /* BindingTargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7990CD1F1085D8001493A3 /* BindingTargetSpec.swift */; };
+		9A7990D01F1085D8001493A3 /* BindingTargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7990CD1F1085D8001493A3 /* BindingTargetSpec.swift */; };
 		9A892D8F1E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */; };
 		9A892D901E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */; };
 		9A892D911E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */; };
@@ -426,6 +429,7 @@
 		9A6AAA271DB8F7EB0013AAEA /* ReusableComponentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponentsSpec.swift; sourceTree = "<group>"; };
 		9A6AAA291DB8F7F10013AAEA /* ReusableComponentsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableComponentsSpec.swift; sourceTree = "<group>"; };
 		9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxy.swift; sourceTree = "<group>"; };
+		9A7990CD1F1085D8001493A3 /* BindingTargetSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindingTargetSpec.swift; sourceTree = "<group>"; };
 		9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxySpec.swift; sourceTree = "<group>"; };
 		9A90374E1ED61C6300345D62 /* ReactiveSwift+Lifetime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReactiveSwift+Lifetime.swift"; sourceTree = "<group>"; };
 		9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationSpec.swift; sourceTree = "<group>"; };
@@ -831,6 +835,7 @@
 				9A1D06231D93EA7E00ACF44C /* UIKit */,
 				538DCB771DCA5E3200332880 /* Shared */,
 				9A9DFEE81DA7EFB60039EE1B /* AssociationSpec.swift */,
+				9A7990CD1F1085D8001493A3 /* BindingTargetSpec.swift */,
 				CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */,
 				9A892D8E1E8D19BE00EA35F3 /* DelegateProxySpec.swift */,
 				D0A2260D1A72F16D00D33B74 /* DynamicPropertySpec.swift */,
@@ -1277,6 +1282,7 @@
 				9A1E72BC1D4DE96500CC20C3 /* KeyValueObservingSpec.swift in Sources */,
 				9A1D06451D93EA7E00ACF44C /* UIImageViewSpec.swift in Sources */,
 				9A1D06551D93EA7E00ACF44C /* UITextViewSpec.swift in Sources */,
+				9A7990D01F1085D8001493A3 /* BindingTargetSpec.swift in Sources */,
 				9A1D063B1D93EA7E00ACF44C /* UIButtonSpec.swift in Sources */,
 				9A24A8471DE142A600987AF9 /* SwizzlingSpec.swift in Sources */,
 				9A1D064B1D93EA7E00ACF44C /* UISegmentedControlSpec.swift in Sources */,
@@ -1386,6 +1392,7 @@
 				B696FB811A7640C00075236D /* TestError.swift in Sources */,
 				9A892D8F1E8D19BE00EA35F3 /* DelegateProxySpec.swift in Sources */,
 				004FD0071E26CDB300A03A82 /* NSButtonSpec.swift in Sources */,
+				9A7990CE1F1085D8001493A3 /* BindingTargetSpec.swift in Sources */,
 				D9558AB91DFF86C0003254E1 /* NSPopUpButtonSpec.swift in Sources */,
 				BFA6B94D1A7604D400C846D1 /* SignalProducerNimbleMatchers.swift in Sources */,
 				9A24A8451DE142A400987AF9 /* SwizzlingSpec.swift in Sources */,
@@ -1500,6 +1507,7 @@
 				9A6AAA2E1DB903A20013AAEA /* ReusableComponentsSpec.swift in Sources */,
 				4ABEFE211DCFCF090066A8C2 /* UITableViewSpec.swift in Sources */,
 				9A1D06401D93EA7E00ACF44C /* UIControlSpec.swift in Sources */,
+				9A7990CF1F1085D8001493A3 /* BindingTargetSpec.swift in Sources */,
 				9A1D06481D93EA7E00ACF44C /* UIProgressViewSpec.swift in Sources */,
 				CD8401841CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */,
 				A9EB3D291E94F3D3002A9BCC /* UITabBarItemSpec.swift in Sources */,

--- a/ReactiveCocoa/NSObject+BindingTarget.swift
+++ b/ReactiveCocoa/NSObject+BindingTarget.swift
@@ -21,3 +21,29 @@ extension Reactive where Base: NSObjectProtocol {
 		}
 	}
 }
+
+#if swift(>=3.2)
+extension Reactive where Base: AnyObject {
+	/// Creates a binding target that writes to the object with the given key path  on a
+	/// `UIScheduler`.
+	///
+	/// - parameters:
+	///   - keyPath: The key path to be written to.
+	///
+	/// - returns: A binding target.
+	public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>) -> BindingTarget<Value> {
+		return BindingTarget(on: UIScheduler(), lifetime: ReactiveCocoa.lifetime(of: base), object: base, keyPath: keyPath)
+	}
+
+	/// Creates a binding target that writes to the object with the given key path.
+	///
+	/// - parameters:
+	///   - keyPath: The key path to be written to.
+	///   - scheduler: The scheduler to perform the write on.
+	///
+	/// - returns: A binding target.
+	public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>, on scheduler: Scheduler) -> BindingTarget<Value> {
+		return BindingTarget(on: scheduler, lifetime: ReactiveCocoa.lifetime(of: base), object: base, keyPath: keyPath)
+	}
+}
+#endif

--- a/ReactiveCocoa/NSObject+Lifetime.swift
+++ b/ReactiveCocoa/NSObject+Lifetime.swift
@@ -31,7 +31,7 @@ internal func lifetime(of object: AnyObject) -> Lifetime {
 	}
 }
 
-extension Reactive where Base: NSObjectProtocol {
+extension Reactive where Base: AnyObject & NSObjectProtocol {
 	/// Returns a lifetime that ends when the object is deallocated.
 	@nonobjc public var lifetime: Lifetime {
 		return base.synchronized {

--- a/ReactiveCocoaTests/BindingTargetSpec.swift
+++ b/ReactiveCocoaTests/BindingTargetSpec.swift
@@ -1,0 +1,47 @@
+import ReactiveSwift
+import ReactiveCocoa
+import Result
+import Quick
+import Nimble
+
+private class Object: NSObject {
+	var value: Int = 0
+}
+
+class BindingTargetSpec: QuickSpec {
+	override func spec() {
+		#if swift(>=3.2)
+		describe("key path binding target") {
+			it("should update the value") {
+				let object = Object()
+				expect(object.value) == 0
+
+				let property = MutableProperty(1)
+				object.reactive[\.value] <~ property
+				expect(object.value) == 1
+
+				property.value = 2
+				expect(object.value) == 2
+			}
+
+			it("should update the value on the given scheduler") {
+				let scheduler = TestScheduler()
+
+				let object = Object()
+				let property = MutableProperty(1)
+				object.reactive[\.value, on: scheduler] <~ property
+				expect(object.value) == 0
+
+				scheduler.run()
+				expect(object.value) == 1
+
+				property.value = 2
+				expect(object.value) == 1
+
+				scheduler.run()
+				expect(object.value) == 2
+			}
+		}
+		#endif
+	}
+}


### PR DESCRIPTION
Basically `view.reactive[\.text] <~ producer`.

#### Checklist
- [x] Updated CHANGELOG.md.
