### PR TITLE
Added cancelButtonClicked signal to UISearchBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please put new entries at the top.
 
+1. Added `cancelButtonClicked` signal to `UISearchBar`.
 1. Subscripting `reactive` with a key path now yields a corresponding `BindingTarget` under Swift 3.2+. (#3489, kudos to @andersio)
 
    Example:

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -48,7 +48,6 @@ extension Reactive where Base: UISearchBar {
 	/// A void signal emitted by the search bar upon any click on the cancel button
 	public var cancelButtonClicked: Signal<Void, NoError> {
 		return proxy.intercept(#selector(UISearchBarDelegate.searchBarCancelButtonClicked))
-			.map { () -> Void in }
 	}
 	
 }

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -10,6 +10,10 @@ private class SearchBarDelegateProxy: DelegateProxy<UISearchBarDelegate>, UISear
 	@objc func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
 		forwardee?.searchBar?(searchBar, textDidChange: searchText)
 	}
+	
+	@objc func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+		forwardee?.searchBarCancelButtonClicked?(searchBar)
+	}
 }
 
 extension Reactive where Base: UISearchBar {
@@ -39,6 +43,12 @@ extension Reactive where Base: UISearchBar {
 	public var continuousTextValues: Signal<String?, NoError> {
 		return proxy.intercept(#selector(UISearchBarDelegate.searchBar(_:textDidChange:)))
 			.map { [unowned base] in base.text }
+	}
+	
+	/// A void signal emitted by the search bar upon any click on the cancel button
+	public var cancelButtonClicked: Signal<Void, NoError> {
+		return proxy.intercept(#selector(UISearchBarDelegate.searchBarCancelButtonClicked))
+			.map { () -> Void in }
 	}
 	
 }

--- a/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
@@ -105,6 +105,18 @@ class UISearchBarSpec: QuickSpec {
 			searchBar.delegate!.searchBarSearchButtonClicked!(searchBar)
 			expect(receiver.searchButtonClickedCounter) == 1
 		}
+		
+		it("should pass through the unintercepted calls") {
+			searchBar.reactive.continuousTextValues.observe { _ in }
+			
+			let receiver = SearchBarDelegateReceiver()
+			searchBar.delegate = receiver
+			expect(receiver.searchBarCancelButtonClickedCounter) == 0
+			
+			searchBar.delegate!.searchBarCancelButtonClicked!(searchBar)
+			expect(receiver.searchBarCancelButtonClickedCounter) == 1
+		}
+		
 	}
 }
 
@@ -112,6 +124,7 @@ class SearchBarDelegateReceiver: NSObject, UISearchBarDelegate {
 	var textDidChangeCounter = 0
 	var textDidEndEditingCounter = 0
 	var searchButtonClickedCounter = 0
+	var searchBarCancelButtonClickedCounter = 0
 
 	func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
 		searchButtonClickedCounter += 1
@@ -123,5 +136,9 @@ class SearchBarDelegateReceiver: NSObject, UISearchBarDelegate {
 
 	func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
 		textDidEndEditingCounter += 1
+	}
+	
+	func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+		searchBarCancelButtonClickedCounter += 1
 	}
 }


### PR DESCRIPTION
Since there is a signal for UISearchBar.continuousTextValues which can be binded to a filter, I think there should be a signal for the cancel button so such filter can be cancelled.

This is my first contribution so I hope my request follows the way you work.

#### Checklist
- [X] Updated CHANGELOG.md.