### PR TITLE
Make `Reactive#makeBindingTarget(…)` available on `AnyObject`, not just NSObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 1. Added `tintColor` binding target to `UIView`. (#3542)
 
+1. Made `makeBindingTarget` available on Reactive extensions on all objects, not just `NSObject`. (#3545)
+
 # 7.0.0
 1. Update ReactiveSwift to 3.0.
 

--- a/ReactiveCocoa/NSObject+BindingTarget.swift
+++ b/ReactiveCocoa/NSObject+BindingTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ReactiveSwift
 
-extension Reactive where Base: NSObjectProtocol {
+extension Reactive where Base: AnyObject {
 	/// Creates a binding target which uses the lifetime of the object, and 
 	/// weakly references the object so that the supplied `action` is triggered 
 	/// only if the object has not deinitialized.
@@ -14,7 +14,7 @@ extension Reactive where Base: NSObjectProtocol {
 	/// - returns: A binding target that holds no strong references to the 
 	///            object.
 	public func makeBindingTarget<U>(on scheduler: Scheduler = UIScheduler(), _ action: @escaping (Base, U) -> Void) -> BindingTarget<U> {
-		return BindingTarget(on: scheduler, lifetime: lifetime) { [weak base = self.base] value in
+		return BindingTarget(on: scheduler, lifetime: ReactiveCocoa.lifetime(of: base)) { [weak base = self.base] value in
 			if let base = base {
 				action(base, value)
 			}

--- a/ReactiveCocoaTests/BindingTargetSpec.swift
+++ b/ReactiveCocoaTests/BindingTargetSpec.swift
@@ -6,10 +6,111 @@ import Nimble
 
 private class Object: NSObject {
 	var value: Int = 0
+
+	func increment() {
+		value += 1
+	}
+}
+
+private class NativeObject: ReactiveExtensionsProvider {
+	var value: Int = 0
+
+	func increment() {
+		value += 1
+	}
 }
 
 class BindingTargetSpec: QuickSpec {
 	override func spec() {
+		describe("arbitrary binding target on Objective-C object") {
+			it("should call the action") {
+				let object = Object()
+				let target = object.reactive.makeBindingTarget { (object: Object, nothing: Void) -> Void in
+					object.increment()
+				}
+				expect(object.value) == 0
+
+				let (signal, observer) = Signal<(), NoError>.pipe()
+				target <~ signal
+				expect(object.value) == 0
+
+				observer.send(value: ())
+				expect(object.value) == 1
+
+				observer.send(value: ())
+				expect(object.value) == 2
+			}
+
+			it("should call the action on the given scheduler") {
+				let scheduler = TestScheduler()
+
+				let object = Object()
+				let target = object.reactive.makeBindingTarget(on: scheduler) { (object: Object, nothing: Void) -> Void in
+					object.increment()
+				}
+				expect(object.value) == 0
+
+				let (signal, observer) = Signal<(), NoError>.pipe()
+				target <~ signal
+				observer.send(value: ())
+				expect(object.value) == 0
+
+				scheduler.run()
+				expect(object.value) == 1
+
+				observer.send(value: ())
+				expect(object.value) == 1
+
+				scheduler.run()
+				expect(object.value) == 2
+			}
+		}
+
+		describe("arbitrary binding target on native object") {
+			it("should call the action") {
+				let object = NativeObject()
+				let target = object.reactive.makeBindingTarget { (object: NativeObject, nothing: Void) -> Void in
+					object.increment()
+				}
+				expect(object.value) == 0
+
+				let (signal, observer) = Signal<(), NoError>.pipe()
+				target <~ signal
+				expect(object.value) == 0
+
+				observer.send(value: ())
+				expect(object.value) == 1
+
+				observer.send(value: ())
+				expect(object.value) == 2
+			}
+
+			it("should call the action on the given scheduler") {
+				let scheduler = TestScheduler()
+
+				let object = NativeObject()
+				let target = object.reactive.makeBindingTarget(on: scheduler) { (object: NativeObject, nothing: Void) -> Void in
+					object.increment()
+				}
+				expect(object.value) == 0
+
+				let (signal, observer) = Signal<(), NoError>.pipe()
+				target <~ signal
+				observer.send(value: ())
+				expect(object.value) == 0
+
+				scheduler.run()
+				expect(object.value) == 1
+
+				observer.send(value: ())
+				expect(object.value) == 1
+
+				scheduler.run()
+				expect(object.value) == 2
+			}
+		}
+
+
 		#if swift(>=3.2)
 		describe("key path binding target") {
 			it("should update the value") {
@@ -39,6 +140,18 @@ class BindingTargetSpec: QuickSpec {
 				expect(object.value) == 1
 
 				scheduler.run()
+				expect(object.value) == 2
+			}
+
+			it("should work for native swift objects") {
+				let object = NativeObject()
+				expect(object.value) == 0
+
+				let property = MutableProperty(1)
+				object.reactive[\.value] <~ property
+				expect(object.value) == 1
+
+				property.value = 2
 				expect(object.value) == 2
 			}
 		}


### PR DESCRIPTION
I started out initially by adding a `Lifetime(of: AnyObject)`, but realized that my main use-case was creating binding targets for non-ObjC reactive extension providers. Since there's already an internal function for this, this less complex PR is what came out of it.

Perhaps it's worth adding a `var lifetime: Lifetime` here, too?

#### Checklist
- [x] Updated CHANGELOG.md.
