### PR TITLE
Implement Property + SmartKeyPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # master
 *Please put new entries at the top.
 
-1. Added `tintColor` binding target to `UIView`. (#3542)
+1. Added `tintColor` binding target to `UIView`. (#3542, kudos to @iv-mexx)
+1. Smart Key Paths for `Property`. (#3546, kudos to @iv-mexx)
+	
+	Example: 
+	```swift
+	let title = Property(object: viewController, keyPath: \UIViewController.title)
+	```
+
 
 # 7.0.0
 1. Update ReactiveSwift to 3.0.

--- a/ReactiveCocoaTests/KVOKVCExtensionSpec.swift
+++ b/ReactiveCocoaTests/KVOKVCExtensionSpec.swift
@@ -14,7 +14,164 @@ private let finalOtherPropertyValue = "FinalOtherValue"
 
 class KVOKVCExtensionSpec: QuickSpec {
 	override func spec() {
-		describe("Property(object:keyPath:)") {
+		describe("Property(object:keyPath:<KeyPath>)") {
+			var object: ObservableObject!
+			var property: Property<Int>!
+			
+			beforeEach {
+				object = ObservableObject()
+				expect(object.rac_value) == 0
+				
+				property = Property<Int>(object: object, keyPath: \ObservableObject.rac_value)
+			}
+			
+			afterEach {
+				object = nil
+			}
+			
+			it("should read the underlying object") {
+				expect(property.value) == 0
+				
+				object.rac_value = 1
+				expect(property.value) == 1
+			}
+			
+			it("should yield a producer that sends the current value and then the changes for the key path of the underlying object") {
+				var values: [Int] = []
+				property.producer.startWithValues { value in
+					values.append(value)
+				}
+				
+				expect(values) == [ 0 ]
+				
+				object.rac_value = 1
+				expect(values) == [ 0, 1 ]
+				
+				object.rac_value = 2
+				expect(values) == [ 0, 1, 2 ]
+			}
+			
+			it("should yield a producer that sends the current value and then the changes for the key path of the underlying object, even if the value actually remains unchanged") {
+				var values: [Int] = []
+				property.producer.startWithValues { value in
+					values.append(value)
+				}
+				
+				expect(values) == [ 0 ]
+				
+				object.rac_value = 0
+				expect(values) == [ 0, 0 ]
+				
+				object.rac_value = 0
+				expect(values) == [ 0, 0, 0 ]
+			}
+			
+			it("should yield a signal that emits subsequent values for the key path of the underlying object") {
+				var values: [Int] = []
+				property.signal.observeValues { value in
+					values.append(value)
+				}
+				
+				expect(values) == []
+				
+				object.rac_value = 1
+				expect(values) == [ 1 ]
+				
+				object.rac_value = 2
+				expect(values) == [ 1, 2 ]
+			}
+			
+			it("should yield a signal that emits subsequent values for the key path of the underlying object, even if the value actually remains unchanged") {
+				var values: [Int] = []
+				property.signal.observeValues { value in
+					values.append(value)
+				}
+				
+				expect(values) == []
+				
+				object.rac_value = 0
+				expect(values) == [ 0 ]
+				
+				object.rac_value = 0
+				expect(values) == [ 0, 0 ]
+			}
+			
+			it("should have a completed producer when the underlying object deallocates") {
+				var completed = false
+				
+				property = {
+					// Use a closure so this object has a shorter lifetime.
+					let object = ObservableObject()
+					let property = Property<Int>(object: object, keyPath: \ObservableObject.rac_value)
+					
+					property.producer.startWithCompleted {
+						completed = true
+					}
+					
+					expect(completed) == false
+					expect(property.value) == 0
+					return property
+				}()
+				
+				expect(completed).toEventually(beTruthy())
+			}
+			
+			it("should have a completed signal when the underlying object deallocates") {
+				var completed = false
+				
+				property = {
+					// Use a closure so this object has a shorter lifetime.
+					let object = ObservableObject()
+					let property = Property<Int>(object: object, keyPath: \ObservableObject.rac_value)
+					
+					property.signal.observeCompleted {
+						completed = true
+					}
+					
+					expect(completed) == false
+					expect(property.value).notTo(beNil())
+					return property
+				}()
+				
+				expect(completed).toEventually(beTruthy())
+			}
+			
+			it("should not be retained by its underlying object"){
+				weak var weakProperty: Property<Int>? = property
+				
+				property = nil
+				expect(weakProperty).to(beNil())
+			}
+			
+			it("should be accessible even if the underlying object has deinitialized") {
+				object.rac_value = .max
+				object = nil
+				
+				expect(property.value) == Int.max
+				
+				var latestValue: Int?
+				property.producer.startWithValues { latestValue = $0 }
+				expect(latestValue) == .max
+				
+				var isInterrupted = false
+				property.signal.observeInterrupted { isInterrupted = true }
+				expect(isInterrupted) == true
+			}
+			
+//			it("should support un-bridged reference types") {
+//				let dynamicProperty = DynamicProperty<UnbridgedObject>(object: object, keyPath: \ObservableObject.rac_reference)
+//				dynamicProperty.value = UnbridgedObject("foo")
+//				expect(object.rac_reference.value) == "foo"
+//			}
+//			
+//			it("should support un-bridged value types") {
+//				let dynamicProperty = DynamicProperty<UnbridgedValue>(object: object, keyPath: \ObservableObject.rac_unbridged)
+//				dynamicProperty.value = .changed
+//				expect(object.rac_unbridged as? UnbridgedValue) == UnbridgedValue.changed
+//			}
+		}
+		
+		describe("Property(object:keyPath:<String>)") {
 			var object: ObservableObject!
 			var property: Property<Int>!
 


### PR DESCRIPTION
#### Checklist
- [x] Updated CHANGELOG.md.

In #440, Smart Key Path support was added for `BindingTarget`, but it was not yet possible to use Smart Key Paths as `BindingSource`. 

This PR now adds 
* `NSObject.reactive.producer(for:keyPath:)` with `KeyPath`
* `NSObject.reactive.signal(for:keyPath:)` with `KeyPath`
* `Property(object:keyPath:)` with `KeyPath`

I've left the "old" methods with the same signature (only `String` instead of `KeyPath` for `keyPath`) alone - should we replace them? (I would say "Yes").

Also, I've not yet touched `DynamicProperty` because it would be either necessary to create a whole new class that uses `KeyPath` instead of `String`, or to change the existing one, and I again wanted to ask it we should keep the Version that takes `String` or replace it.