### PR TITLE
DynamicProperty of optional property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # master
 *Please put new entries at the top.
 
-1. Added `tintColor` binding target to `UIView`. (#3542)
+1. Added `tintColor` binding target to `UIView`. (#3542, kudos to @iv-mexx)
+1. Fixed `DynamicProperty` for optional properties. (#3548, kudos to @iv-mexx)
 
 # 7.0.0
 1. Update ReactiveSwift to 3.0.

--- a/ReactiveCocoa/DynamicProperty.swift
+++ b/ReactiveCocoa/DynamicProperty.swift
@@ -45,16 +45,42 @@ public final class DynamicProperty<Value>: MutablePropertyProtocol {
 		return cache.signal
 	}
 
-	/// Create a typed mutable view to the given key path of the given Objective-C object.	
+	internal init(object: NSObject, keyPath: String, cache: Property<Value>) {
+		self.object = object
+		self.keyPath = keyPath
+		self.cache = cache
+	}
+	
+	/// Create a typed mutable view to the given key path of the given Objective-C object.
 	/// The generic type `Value` can be any Swift type, and will be bridged to Objective-C
 	/// via `Any`.
 	///
 	/// - parameters:
 	///   - object: The Objective-C object to be observed.
 	///   - keyPath: The key path to observe.
-	public init(object: NSObject, keyPath: String) {
-		self.object = object
-		self.keyPath = keyPath
-		self.cache = Property(object: object, keyPath: keyPath)
+	public convenience init(object: NSObject, keyPath: String) {
+		self.init(object: object, keyPath: keyPath, cache: Property(object: object, keyPath: keyPath))
 	}
 }
+
+extension DynamicProperty where Value: OptionalProtocol {
+	
+	/// The current value of the property, as read and written using Key-Value
+	/// Coding.
+	public var value: Value {
+		get { return cache.value }
+		set { object?.setValue(newValue.optional, forKeyPath: keyPath) }
+	}
+	
+	/// Create a typed mutable view to the given key path of the given Objective-C object.
+	/// The generic type `Value` can be any Swift type, and will be bridged to Objective-C
+	/// via `Any`.
+	///
+	/// - parameters:
+	///   - object: The Objective-C object to be observed.
+	///   - keyPath: The key path to observe.
+	public convenience init(object: NSObject, keyPath: String) {
+		self.init(object: object, keyPath: keyPath, cache: Property(object: object, keyPath: keyPath))
+	}
+}
+


### PR DESCRIPTION
#### Checklist
- [x] Updated CHANGELOG.md.

Adds necessary overloads to `DynamicProperty` and `Property` to enable the usage with optional `Value`. 

Refs #3547.
