### PR TITLE
Add showsCancelButton, textDidBeginEditing and ...EndEditing to UISearchBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please put new entries at the top.
 
+1. Add `showsCancelButton`, `textDidBeginEditing` and `textDidEndEditing` extensions to `UISearchBar` (#3565)
+
 # 7.1.0
 # 7.1.0-rc.2
 1. Fix an issue preventing ReactiveCocoa from being built with the Swift 3.2 language mode. (#3556)

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -3,6 +3,10 @@ import enum Result.NoError
 import UIKit
 
 private class SearchBarDelegateProxy: DelegateProxy<UISearchBarDelegate>, UISearchBarDelegate {
+	@objc func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+		forwardee?.searchBarTextDidBeginEditing?(searchBar)
+	}
+
 	@objc func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
 		forwardee?.searchBarTextDidEndEditing?(searchBar)
 	}
@@ -90,5 +94,20 @@ extension Reactive where Base: UISearchBar {
 	/// A void signal emitted by the search bar upon any click on the bookmark button
 	public var resultsListButtonClicked: Signal<Void, NoError> {
 		return proxy.intercept(#selector(proxy.searchBarResultsListButtonClicked))
+	}
+
+	/// A void signal emitted by the search bar upon start of editing
+	public var textDidBeginEditing: Signal<Void, NoError> {
+		return proxy.intercept(#selector(proxy.searchBarTextDidBeginEditing))
+	}
+
+	/// A void signal emitted by the search bar upon end of editing
+	public var textDidEndEditing: Signal<Void, NoError> {
+		return proxy.intercept(#selector(proxy.searchBarTextDidEndEditing))
+	}
+
+	/// Shows and hides the cancel button of the search bar
+	public var showsCancelButton: BindingTarget<Bool> {
+		return makeBindingTarget { $0.showsCancelButton = $1 }
 	}
 }


### PR DESCRIPTION
I want to show/hide the cancel button of a UISearchBar when its focus changed, with mapping with some other app specific conditions.
With the missing `textDidBeginEditing` reactive extension, I can use ReactiveCocoa to bind all I need instead of using its delegate.

As UISearchBar is not a UITextField nor UIControl, other common extensions such as `mapControlEvents` cannot be used for that.

#### Checklist
- [x] Updated CHANGELOG.md.
