### PR TITLE
More useful system keyboard event notification observing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please put new entries at the top.
 
+1. `NotificationCenter.reactive.keyboard(_:)` for system keyboard notification by the event types. (#3566, kudos to @ra1028)
+
 # 7.1.0
 # 7.1.0-rc.2
 1. Fix an issue preventing ReactiveCocoa from being built with the Swift 3.2 language mode. (#3556)

--- a/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
@@ -80,12 +80,7 @@ extension Reactive where Base: NotificationCenter {
 	/// - returns: A `Signal` that emits the context of system keyboard events.
 	public func keyboard(_ first: KeyboardEvent, _ tail: KeyboardEvent...) -> Signal<KeyboardChangeContext, NoError> {
 		let events = [first] + tail
-		return .merge(
-			events.map { event in
-				notifications(forName: event.notificationName)
-					.map { notification in KeyboardChangeContext(userInfo: notification.userInfo!, event: event) }
-			}
-		)
+		return .merge(events.map(_keyboard))
 	}
 	
 	/// Create a `Signal` that notifies whenever the system keyboard announces an
@@ -94,6 +89,11 @@ extension Reactive where Base: NotificationCenter {
 	/// - returns: A `Signal` that emits the context of every change in the
 	///            system keyboard's frame.
 	public var keyboardChange: Signal<KeyboardChangeContext, NoError> {
-		return keyboard(.willChangeFrame)
+		return _keyboard(.willChangeFrame)
+	}
+	
+	private func _keyboard(_ event: KeyboardEvent) -> Signal<KeyboardChangeContext, NoError> {
+		return notifications(forName: event.notificationName)
+			.map { notification in KeyboardChangeContext(userInfo: notification.userInfo!, event: event) }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
@@ -12,7 +12,7 @@ public enum KeyboardEvent {
 	case didChangeFrame
 	
 	/// The name of the notification to observe system keyboard events.
-	var notificationName: Notification.Name {
+	fileprivate var notificationName: Notification.Name {
 		switch self {
 		case .willShow:
 			return .UIKeyboardWillShow

--- a/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
@@ -78,7 +78,8 @@ extension Reactive where Base: NotificationCenter {
 	/// Create a `Signal` that notifies whenever the system keyboard announces specified events.
 	///
 	/// - returns: A `Signal` that emits the context of system keyboard events.
-	public func keyboard(_ events: KeyboardEvent...) -> Signal<KeyboardChangeContext, NoError> {
+	public func keyboard(_ first: KeyboardEvent, _ tail: KeyboardEvent...) -> Signal<KeyboardChangeContext, NoError> {
+		let events = [first] + tail
 		return .merge(
 			events.map { event in
 				notifications(forName: event.notificationName)

--- a/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
@@ -75,12 +75,28 @@ public struct KeyboardChangeContext {
 }
 
 extension Reactive where Base: NotificationCenter {
+	/// Create a `Signal` that notifies whenever the system keyboard announce specified event.
+	///
+	/// - parameters:
+	///   - event:  The type of system keyboard event to observe.
+	///
+	/// - returns: A `Signal` that emits the context of system keyboard event.
+	public func keyboard(_ event: KeyboardEvent) -> Signal<KeyboardChangeContext, NoError> {
+		return notifications(forName: event.notificationName)
+			.map { notification in KeyboardChangeContext(userInfo: notification.userInfo!, event: event) }
+	}
+	
 	/// Create a `Signal` that notifies whenever the system keyboard announces specified events.
 	///
+	/// - parameters:
+	///   - first: First type of system keyboard event to observe.
+	///   - second: Second type of system keyboard event to observe.
+	///   - tail: Rest of the types of system keyboard events to observe.
+	///
 	/// - returns: A `Signal` that emits the context of system keyboard events.
-	public func keyboard(_ first: KeyboardEvent, _ tail: KeyboardEvent...) -> Signal<KeyboardChangeContext, NoError> {
-		let events = [first] + tail
-		return .merge(events.map(_keyboard))
+	public func keyboard(_ first: KeyboardEvent, _ second: KeyboardEvent, _ tail: KeyboardEvent...) -> Signal<KeyboardChangeContext, NoError> {
+		let events = [first, second] + tail
+		return .merge(events.map(keyboard))
 	}
 	
 	/// Create a `Signal` that notifies whenever the system keyboard announces an
@@ -89,11 +105,6 @@ extension Reactive where Base: NotificationCenter {
 	/// - returns: A `Signal` that emits the context of every change in the
 	///            system keyboard's frame.
 	public var keyboardChange: Signal<KeyboardChangeContext, NoError> {
-		return _keyboard(.willChangeFrame)
-	}
-	
-	private func _keyboard(_ event: KeyboardEvent) -> Signal<KeyboardChangeContext, NoError> {
-		return notifications(forName: event.notificationName)
-			.map { notification in KeyboardChangeContext(userInfo: notification.userInfo!, event: event) }
+		return keyboard(.willChangeFrame)
 	}
 }

--- a/ReactiveCocoaTests/UIKit/UIKeyboardSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIKeyboardSpec.swift
@@ -6,6 +6,116 @@ import Nimble
 
 class UIKeyboardSpec: QuickSpec {
 	override func spec() {
+		describe("NotificationCenter.reactive.keyboard(_:)") {
+			it("should emit a `value` event when the notification is posted") {
+				var context: KeyboardChangeContext?
+				
+				let testCenter = NotificationCenter()
+				
+				testCenter.reactive.keyboard(.willShow, .didShow, .willHide, .didHide, .willChangeFrame, .didChangeFrame)
+					.observeValues { context = $0 }
+				
+				func makeDummyInfo(beginFrameHeight: CGFloat) -> [AnyHashable: Any] {
+					var dummyInfo: [AnyHashable: Any] = [
+						UIKeyboardFrameBeginUserInfoKey: CGRect(x: 10, y: 10, width: 10, height: beginFrameHeight),
+						UIKeyboardFrameEndUserInfoKey: CGRect(x: 20, y: 20, width: 20, height: 20),
+						UIKeyboardAnimationDurationUserInfoKey: 1.0,
+						UIKeyboardAnimationCurveUserInfoKey: NSNumber(value: UIViewAnimationCurve.easeInOut.rawValue)
+					]
+					if #available(*, iOS 9.0) {
+						dummyInfo[UIKeyboardIsLocalUserInfoKey] = NSNumber(value: true)
+					}
+					return dummyInfo
+				}
+				
+				testCenter.post(name: .UIKeyboardWillShow,
+				                object: nil,
+				                userInfo: makeDummyInfo(beginFrameHeight: 10))
+				
+				expect(context).toNot(beNil())
+				
+				expect(context?.event) == .willShow
+				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 10)
+				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
+				expect(context?.animationCurve) == .easeInOut
+				expect(context?.animationDuration) == 1.0
+				
+				if #available(*, iOS 9.0) {
+					expect(context?.isLocal) == true
+				}
+				
+				testCenter.post(name: .UIKeyboardDidShow,
+				                object: nil,
+				                userInfo: makeDummyInfo(beginFrameHeight: 20))
+				
+				expect(context?.event) == .didShow
+				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 20)
+				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
+				expect(context?.animationCurve) == .easeInOut
+				expect(context?.animationDuration) == 1.0
+				
+				if #available(*, iOS 9.0) {
+					expect(context?.isLocal) == true
+				}
+				
+				testCenter.post(name: .UIKeyboardWillHide,
+				                object: nil,
+				                userInfo: makeDummyInfo(beginFrameHeight: 30))
+				
+				expect(context?.event) == .willHide
+				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 30)
+				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
+				expect(context?.animationCurve) == .easeInOut
+				expect(context?.animationDuration) == 1.0
+				
+				if #available(*, iOS 9.0) {
+					expect(context?.isLocal) == true
+				}
+				
+				testCenter.post(name: .UIKeyboardDidHide,
+				                object: nil,
+				                userInfo: makeDummyInfo(beginFrameHeight: 40))
+				
+				expect(context?.event) == .didHide
+				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 40)
+				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
+				expect(context?.animationCurve) == .easeInOut
+				expect(context?.animationDuration) == 1.0
+				
+				if #available(*, iOS 9.0) {
+					expect(context?.isLocal) == true
+				}
+				
+				testCenter.post(name: .UIKeyboardWillChangeFrame,
+				                object: nil,
+				                userInfo: makeDummyInfo(beginFrameHeight: 50))
+				
+				expect(context?.event) == .willChangeFrame
+				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 50)
+				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
+				expect(context?.animationCurve) == .easeInOut
+				expect(context?.animationDuration) == 1.0
+				
+				if #available(*, iOS 9.0) {
+					expect(context?.isLocal) == true
+				}
+				
+				testCenter.post(name: .UIKeyboardDidChangeFrame,
+				                object: nil,
+				                userInfo: makeDummyInfo(beginFrameHeight: 60))
+				
+				expect(context?.event) == .didChangeFrame
+				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 60)
+				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
+				expect(context?.animationCurve) == .easeInOut
+				expect(context?.animationDuration) == 1.0
+				
+				if #available(*, iOS 9.0) {
+					expect(context?.isLocal) == true
+				}
+			}
+		}
+		
 		describe("NotificationCenter.reactive.keyboardChange") {
 			it("should emit a `value` event when the notification is posted") {
 				var context: KeyboardChangeContext?
@@ -31,7 +141,8 @@ class UIKeyboardSpec: QuickSpec {
 				                userInfo: dummyInfo)
 
 				expect(context).toNot(beNil())
-
+				
+				expect(context?.event) == .willChangeFrame
 				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 10)
 				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
 				expect(context?.animationCurve) == .easeInOut

--- a/ReactiveCocoaTests/UIKit/UIKeyboardSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIKeyboardSpec.swift
@@ -6,7 +6,45 @@ import Nimble
 
 class UIKeyboardSpec: QuickSpec {
 	override func spec() {
-		describe("NotificationCenter.reactive.keyboard(_:)") {
+		describe("NotificationCenter.reactive.keyboard(_;)") {
+			it("should emit a `value` event when the notification is posted") {
+				var context: KeyboardChangeContext?
+				
+				let testCenter = NotificationCenter()
+				
+				testCenter.reactive.keyboard(.willShow)
+					.observeValues { context = $0 }
+				
+				var dummyInfo: [AnyHashable: Any] = [
+					UIKeyboardFrameBeginUserInfoKey: CGRect(x: 10, y: 10, width: 10, height: 10),
+					UIKeyboardFrameEndUserInfoKey: CGRect(x: 20, y: 20, width: 20, height: 20),
+					UIKeyboardAnimationDurationUserInfoKey: 1.0,
+					UIKeyboardAnimationCurveUserInfoKey: NSNumber(value: UIViewAnimationCurve.easeInOut.rawValue)
+				]
+				
+				if #available(*, iOS 9.0) {
+					dummyInfo[UIKeyboardIsLocalUserInfoKey] = NSNumber(value: true)
+				}
+				
+				testCenter.post(name: .UIKeyboardWillShow,
+				                object: nil,
+				                userInfo: dummyInfo)
+				
+				expect(context).toNot(beNil())
+				
+				expect(context?.event) == .willShow
+				expect(context?.beginFrame) == CGRect(x: 10, y: 10, width: 10, height: 10)
+				expect(context?.endFrame) == CGRect(x: 20, y: 20, width: 20, height: 20)
+				expect(context?.animationCurve) == .easeInOut
+				expect(context?.animationDuration) == 1.0
+				
+				if #available(*, iOS 9.0) {
+					expect(context?.isLocal) == true
+				}
+			}
+		}
+		
+		describe("NotificationCenter.reactive.keyboard(_:_:_;)") {
 			it("should emit a `value` event when the notification is posted") {
 				var context: KeyboardChangeContext?
 				


### PR DESCRIPTION
This proposal has no breaking changes.

I've wanted to observe the keyboard changes by the event types. like below.

```swift
NotificationCenter.default.reactive.keyboard(.willShow, .willHide)
    .take(duringLifetimeOf: self)
    .observeValues { [unowned self] context in
        //  Do something...

        if context.event == .willShow {
            self.tableView.scrollToNearestSelectedRow(at: .none, animated: true)
        }
}
```

To be honest, I wanted to implement as follows, but it has breaking changes.
What do you think of this?

```swift
public enum KeyboardEvent {
    case .willShow
    ...

    struct Context {
        private let base: [AnyHashable: Any] ...
	public let event: KeyboardEvent ...
	public var beginFrame: CGRect ...
	public var endFrame: CGRect ...
    	public var animationCurve: UIViewAnimationCurve ...
    	public var animationDuration: Double ...
    	@available(iOS 9.0, *) ...
    	public var isLocal: Bool ...
    	fileprivate init(userInfo: [AnyHashable: Any], event: KeyboardEvent) ...
    }
}

extension Reactive where Base: NotificationCenter {
    public func keyboard(_ events: KeyboardEvent...) -> Signal<KeyboardEvent.Context, NoError> {
        return .merge(
            events.map { event in
                notifications(forName: event.notificationName)
                    .map { notification in KeyboardChangeContext(userInfo: notification.userInfo!, event: event) }
            }
        )
    }
}

extension Reactive where Base: NotificationCenter {
    @available(*, deprecated, message="Use .keyboard(.willChangeFrame) instead")
    public var keyboardChange: Signal<KeyboardEvent.Context, NoError> {
        return keyboard(.willChangeFrame)
    }
}
```

#### Checklist
- [x] Updated CHANGELOG.md.
