### PR TITLE
 Make CocoaTarget to public 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # master
 *Please put new entries at the top.
 
-1. Add `showsCancelButton`, `textDidBeginEditing` and `textDidEndEditing` extensions to `UISearchBar` (#3566)
+1. Add `showsCancelButton`, `textDidBeginEditing` and `textDidEndEditing` extensions to `UISearchBar` (#3565)
 1. `NotificationCenter.reactive.keyboard(_:)` for system keyboard notification by the event types. (#3566, kudos to @ra1028)
 1. `CocoaTarget` now public (#3572, kudos to @ra1028)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 *Please put new entries at the top.
 
 1. Add `showsCancelButton`, `textDidBeginEditing` and `textDidEndEditing` extensions to `UISearchBar` (#3566)
-
 1. `NotificationCenter.reactive.keyboard(_:)` for system keyboard notification by the event types. (#3566, kudos to @ra1028)
+1. `CocoaTarget` now public (#3572, kudos to @ra1028)
 
 # 7.1.0
 # 7.1.0-rc.2

--- a/ReactiveCocoa/CocoaTarget.swift
+++ b/ReactiveCocoa/CocoaTarget.swift
@@ -16,7 +16,7 @@ public final class CocoaTarget<Value>: NSObject {
 
 	private var state: State
 
-	public init(_ observer: Signal<Value, NoError>.Observer, transform: @escaping (Any?) -> Value) {
+	public init(_ observer: Signal<Value, NoError>.Observer, _ transform: @escaping (Any?) -> Value) {
 		self.observer = observer
 		self.transform = transform
 		self.state = .idle
@@ -57,6 +57,6 @@ public final class CocoaTarget<Value>: NSObject {
 
 extension CocoaTarget where Value == Void {
 	public convenience init(_ observer: Signal<(), NoError>.Observer) {
-		self.init(observer, transform: { _ in })
+		self.init(observer) { _ in }
 	}
 }

--- a/ReactiveCocoa/CocoaTarget.swift
+++ b/ReactiveCocoa/CocoaTarget.swift
@@ -3,21 +3,24 @@ import ReactiveSwift
 import enum Result.NoError
 
 /// A target that accepts action messages.
-internal final class CocoaTarget<Value>: NSObject {
+public final class CocoaTarget<Value>: NSObject {
 	private enum State {
 		case idle
 		case sending(queue: [Value])
 	}
+
+	public let selector: Selector
 
 	private let observer: Signal<Value, NoError>.Observer
 	private let transform: (Any?) -> Value
 
 	private var state: State
 
-	internal init(_ observer: Signal<Value, NoError>.Observer, transform: @escaping (Any?) -> Value) {
+	public init(_ observer: Signal<Value, NoError>.Observer, transform: @escaping (Any?) -> Value) {
 		self.observer = observer
 		self.transform = transform
 		self.state = .idle
+		selector = #selector(invoke(_:))
 	}
 
 	/// Broadcast the action message to all observers.
@@ -29,7 +32,7 @@ internal final class CocoaTarget<Value>: NSObject {
 	///
 	/// - parameters:
 	///   - sender: The object which sends the action message.
-	@objc internal func invoke(_ sender: Any?) {
+	@objc private func invoke(_ sender: Any?) {
 		switch state {
 		case .idle:
 			state = .sending(queue: [])
@@ -53,7 +56,7 @@ internal final class CocoaTarget<Value>: NSObject {
 }
 
 extension CocoaTarget where Value == Void {
-	internal convenience init(_ observer: Signal<(), NoError>.Observer) {
+	public convenience init(_ observer: Signal<(), NoError>.Observer) {
 		self.init(observer, transform: { _ in })
 	}
 }

--- a/ReactiveCocoa/UIKit/UIControl.swift
+++ b/ReactiveCocoa/UIKit/UIControl.swift
@@ -75,7 +75,7 @@ extension Reactive where Base: UIControl {
 		return Signal { observer, signalLifetime in
 			let receiver = CocoaTarget(observer) { transform($0 as! Base) }
 			base.addTarget(receiver,
-			               action: #selector(receiver.invoke),
+			               action: receiver.selector,
 			               for: controlEvents)
 
 			let disposable = lifetime.ended.observeCompleted(observer.sendCompleted)
@@ -84,7 +84,7 @@ extension Reactive where Base: UIControl {
 				disposable?.dispose()
 
 				base?.removeTarget(receiver,
-				                   action: #selector(receiver.invoke),
+				                   action: receiver.selector,
 				                   for: controlEvents)
 			}
 		}

--- a/ReactiveCocoa/UIKit/UIGestureRecognizer.swift
+++ b/ReactiveCocoa/UIKit/UIGestureRecognizer.swift
@@ -11,13 +11,13 @@ extension Reactive where Base: UIGestureRecognizer {
 			let receiver = CocoaTarget<Base>(observer) { gestureRecognizer in
 				return gestureRecognizer as! Base
 			}
-			base.addTarget(receiver, action: #selector(receiver.invoke))
+			base.addTarget(receiver, action: receiver.selector)
 			
 			let disposable = lifetime.ended.observeCompleted(observer.sendCompleted)
 			
 			signalLifetime.observeEnded { [weak base] in
 				disposable?.dispose()
-				base?.removeTarget(receiver, action: #selector(receiver.invoke))
+				base?.removeTarget(receiver, action: receiver.selector)
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation
I need this when introduce extended operators in my app.
e.g
```swift
public extension Reactive where Base: CADisplayLink {
    static func link(to runloop: RunLoop, forMode mode: RunLoopMode, framesPerSecond: Int = 60) -> SignalProducer<CADisplayLink, NoError> {
        return .init { observer, lifetime in
            let target = CocoaTarget(observer)
            var displayLink: CADisplayLink? = .init(target: target, selector: target.selector)
            displayLink?.preferredFramesPerSecond = framesPerSecond
            displayLink?.add(to: runloop, forMode: mode)
            
            lifetime.observeEnded {
                displayLink?.invalidate()
                displayLink = nil
            }
        }
    }
}
```

#### Checklist
- [x] Updated CHANGELOG.md.
