### PR TITLE
RFC: Use Sourcery to generate BindingTargets for UIKit

### DIFF
--- a/.sourcery.yml
+++ b/.sourcery.yml
@@ -1,0 +1,6 @@
+sources:
+  - ReactiveCocoa/UIKit
+templates:
+  - SourceryTemplates/
+output:
+  ReactiveCocoa/UIKit

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		004FD0071E26CDB300A03A82 /* NSButtonSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004FD0061E26CDB300A03A82 /* NSButtonSpec.swift */; };
 		006518761E26865800C3139A /* NSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006518751E26865800C3139A /* NSButton.swift */; };
+		21384489205563C4006C6648 /* BindingTarget.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21384488205563C4006C6648 /* BindingTarget.generated.swift */; };
 		3B30EE8C1E7BE529007CC8EF /* DeprecationsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B30EE8B1E7BE529007CC8EF /* DeprecationsSpec.swift */; };
 		3B30EE8D1E7BE529007CC8EF /* DeprecationsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B30EE8B1E7BE529007CC8EF /* DeprecationsSpec.swift */; };
 		3B30EE8E1E7BE529007CC8EF /* DeprecationsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B30EE8B1E7BE529007CC8EF /* DeprecationsSpec.swift */; };
@@ -394,6 +395,7 @@
 /* Begin PBXFileReference section */
 		004FD0061E26CDB300A03A82 /* NSButtonSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSButtonSpec.swift; sourceTree = "<group>"; };
 		006518751E26865800C3139A /* NSButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSButton.swift; sourceTree = "<group>"; };
+		21384488205563C4006C6648 /* BindingTarget.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindingTarget.generated.swift; sourceTree = "<group>"; };
 		3B30EE8B1E7BE529007CC8EF /* DeprecationsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationsSpec.swift; sourceTree = "<group>"; };
 		3BCAAC791DEE19BC00B30335 /* UIRefreshControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIRefreshControl.swift; sourceTree = "<group>"; };
 		3BCAAC7B1DEE1A2300B30335 /* UIRefreshControlSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIRefreshControlSpec.swift; sourceTree = "<group>"; };
@@ -718,6 +720,7 @@
 		9A1D05EB1D93E9F100ACF44C /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				21384488205563C4006C6648 /* BindingTarget.generated.swift */,
 				CD91E3D41DDAC67700FA70D0 /* iOS */,
 				9A6AAA221DB8F51C0013AAEA /* ReusableComponents.swift */,
 				9A1D05EC1D93E9F100ACF44C /* UIActivityIndicatorView.swift */,
@@ -1595,6 +1598,7 @@
 				9A1D06011D93EA0000ACF44C /* UIBarItem.swift in Sources */,
 				A9EB3D811E955602002A9BCC /* UIFeedbackGenerator.swift in Sources */,
 				9A1D060D1D93EA0000ACF44C /* UITextField.swift in Sources */,
+				21384489205563C4006C6648 /* BindingTarget.generated.swift in Sources */,
 				9A9037501ED61C6300345D62 /* ReactiveSwift+Lifetime.swift in Sources */,
 				9AB15C7B1E26CD9A00997378 /* Deprecations+Removals.swift in Sources */,
 				A9EB3D831E955602002A9BCC /* UINotification​Feedback​Generator.swift in Sources */,

--- a/ReactiveCocoa/UIKit/BindingTarget.generated.swift
+++ b/ReactiveCocoa/UIKit/BindingTarget.generated.swift
@@ -1,0 +1,634 @@
+// Generated using Sourcery 0.10.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import ReactiveSwift
+import UIKit
+
+
+extension Reactive where Base: UIBarItem {
+  /// Sets the isEnabled of the barItem
+  public var isEnabled: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isEnabled = $1 }
+  }
+
+  /// Sets the image of the barItem
+  public var image: BindingTarget<UIImage?> {
+    return makeBindingTarget { $0.image = $1 }
+  }
+
+  /// Sets the title of the barItem
+  public var title: BindingTarget<String?> {
+    return makeBindingTarget { $0.title = $1 }
+  }
+
+}
+
+extension Reactive where Base: UIControl {
+  /// Sets the isEnabled of the control
+  public var isEnabled: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isEnabled = $1 }
+  }
+
+  /// Sets the isSelected of the control
+  public var isSelected: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isSelected = $1 }
+  }
+
+  /// Sets the isHighlighted of the control
+  public var isHighlighted: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isHighlighted = $1 }
+  }
+
+  /// Sets the contentVerticalAlignment of the control
+  public var contentVerticalAlignment: BindingTarget<UIControlContentVerticalAlignment> {
+    return makeBindingTarget { $0.contentVerticalAlignment = $1 }
+  }
+
+  /// Sets the contentHorizontalAlignment of the control
+  public var contentHorizontalAlignment: BindingTarget<UIControlContentHorizontalAlignment> {
+    return makeBindingTarget { $0.contentHorizontalAlignment = $1 }
+  }
+
+}
+
+extension Reactive where Base: UIImageView {
+  /// Sets the image of the imageView
+  public var image: BindingTarget<UIImage?> {
+    return makeBindingTarget { $0.image = $1 }
+  }
+
+  /// Sets the highlightedImage of the imageView
+  public var highlightedImage: BindingTarget<UIImage?> {
+    return makeBindingTarget { $0.highlightedImage = $1 }
+  }
+
+}
+
+extension Reactive where Base: UILabel {
+  /// Sets the text of the label
+  public var text: BindingTarget<String?> {
+    return makeBindingTarget { $0.text = $1 }
+  }
+
+  /// Sets the attributedText of the label
+  public var attributedText: BindingTarget<NSAttributedString?> {
+    return makeBindingTarget { $0.attributedText = $1 }
+  }
+
+  /// Sets the font of the label
+  public var font: BindingTarget<UIFont> {
+    return makeBindingTarget { $0.font = $1 }
+  }
+
+  /// Sets the textColor of the label
+  public var textColor: BindingTarget<UIColor> {
+    return makeBindingTarget { $0.textColor = $1 }
+  }
+
+  /// Sets the textAlignment of the label
+  public var textAlignment: BindingTarget<NSTextAlignment> {
+    return makeBindingTarget { $0.textAlignment = $1 }
+  }
+
+  /// Sets the lineBreakMode of the label
+  public var lineBreakMode: BindingTarget<NSLineBreakMode> {
+    return makeBindingTarget { $0.lineBreakMode = $1 }
+  }
+
+  /// Sets the isEnabled of the label
+  public var isEnabled: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isEnabled = $1 }
+  }
+
+  /// Sets the adjustsFontSizeToFitWidth of the label
+  public var adjustsFontSizeToFitWidth: BindingTarget<Bool> {
+    return makeBindingTarget { $0.adjustsFontSizeToFitWidth = $1 }
+  }
+
+  /// Sets the allowsDefaultTighteningForTruncation of the label
+  @available(iOS 9, *)
+  public var allowsDefaultTighteningForTruncation: BindingTarget<Bool> {
+    return makeBindingTarget { $0.allowsDefaultTighteningForTruncation = $1 }
+  }
+
+  /// Sets the baselineAdjustment of the label
+  public var baselineAdjustment: BindingTarget<UIBaselineAdjustment> {
+    return makeBindingTarget { $0.baselineAdjustment = $1 }
+  }
+
+  /// Sets the minimumScaleFactor of the label
+  public var minimumScaleFactor: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.minimumScaleFactor = $1 }
+  }
+
+  /// Sets the numberOfLines of the label
+  public var numberOfLines: BindingTarget<Int> {
+    return makeBindingTarget { $0.numberOfLines = $1 }
+  }
+
+  /// Sets the highlightedTextColor of the label
+  public var highlightedTextColor: BindingTarget<UIColor>? {
+    return makeBindingTarget { $0.highlightedTextColor = $1 }
+  }
+
+  /// Sets the isHighlighted of the label
+  public var isHighlighted: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isHighlighted = $1 }
+  }
+
+  /// Sets the shadowColor of the label
+  public var shadowColor: BindingTarget<UIColor>? {
+    return makeBindingTarget { $0.shadowColor = $1 }
+  }
+
+  /// Sets the shadowOffset of the label
+  public var shadowOffset: BindingTarget<CGSize> {
+    return makeBindingTarget { $0.shadowOffset = $1 }
+  }
+
+  /// Sets the preferredMaxLayoutWidth of the label
+  public var preferredMaxLayoutWidth: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.preferredMaxLayoutWidth = $1 }
+  }
+
+  /// Sets the isUserInteractionEnabled of the label
+  public var isUserInteractionEnabled: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isUserInteractionEnabled = $1 }
+  }
+
+}
+
+extension Reactive where Base: UINavigationItem {
+  /// Sets the title of the navigationItem
+  public var title: BindingTarget<String?> {
+    return makeBindingTarget { $0.title = $1 }
+  }
+
+}
+
+extension Reactive where Base: UIProgressView {
+  /// Sets the progress of the progressView
+  public var progress: BindingTarget<Float> {
+    return makeBindingTarget { $0.progress = $1 }
+  }
+
+  /// Sets the observedProgress of the progressView
+  @available(iOS 9, *)
+  public var observedProgress: BindingTarget<Progress?> {
+    return makeBindingTarget { $0.observedProgress = $1 }
+  }
+
+  /// Sets the progressViewStyle of the progressView
+  public var progressViewStyle: BindingTarget<UIProgressViewStyle> {
+    return makeBindingTarget { $0.progressViewStyle = $1 }
+  }
+
+  /// Sets the progressTintColor of the progressView
+  public var progressTintColor: BindingTarget<UIColor?> {
+    return makeBindingTarget { $0.progressTintColor = $1 }
+  }
+
+  /// Sets the progressImage of the progressView
+  public var progressImage: BindingTarget<UIImage?> {
+    return makeBindingTarget { $0.progressImage = $1 }
+  }
+
+  /// Sets the trackTintColor of the progressView
+  public var trackTintColor: BindingTarget<UIColor?> {
+    return makeBindingTarget { $0.trackTintColor = $1 }
+  }
+
+  /// Sets the trackImage of the progressView
+  public var trackImage: BindingTarget<UIImage?> {
+    return makeBindingTarget { $0.trackImage = $1 }
+  }
+
+}
+
+extension Reactive where Base: UIScrollView {
+  /// Sets the contentInset of the scrollView
+  public var contentInset: BindingTarget<UIEdgeInsets> {
+    return makeBindingTarget { $0.contentInset = $1 }
+  }
+
+  /// Sets the scrollIndicatorInsets of the scrollView
+  public var scrollIndicatorInsets: BindingTarget<UIEdgeInsets> {
+    return makeBindingTarget { $0.scrollIndicatorInsets = $1 }
+  }
+
+  /// Sets the isScrollEnabled of the scrollView
+  public var isScrollEnabled: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isScrollEnabled = $1 }
+  }
+
+  /// Sets the zoomScale of the scrollView
+  public var zoomScale: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.zoomScale = $1 }
+  }
+
+  /// Sets the minimumZoomScale of the scrollView
+  public var minimumZoomScale: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.minimumZoomScale = $1 }
+  }
+
+  /// Sets the maximumZoomScale of the scrollView
+  public var maximumZoomScale: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.maximumZoomScale = $1 }
+  }
+
+}
+
+extension Reactive where Base: UISegmentedControl {
+  /// Sets the selectedSegmentIndex of the segmentedControl
+  public var selectedSegmentIndex: BindingTarget<Int> {
+    return makeBindingTarget { $0.selectedSegmentIndex = $1 }
+  }
+
+}
+
+extension Reactive where Base: UITabBarItem {
+  /// Sets the badgeValue of the tabBarItem
+  public var badgeValue: BindingTarget<String?> {
+    return makeBindingTarget { $0.badgeValue = $1 }
+  }
+
+}
+
+extension Reactive where Base: UITextField {
+  /// Sets the text of the textField
+  public var text: BindingTarget<String?> {
+    return makeBindingTarget { $0.text = $1 }
+  }
+
+  /// Sets the attributedText of the textField
+  public var attributedText: BindingTarget<NSAttributedString?> {
+    return makeBindingTarget { $0.attributedText = $1 }
+  }
+
+  /// Sets the placeholder of the textField
+  public var placeholder: BindingTarget<String?> {
+    return makeBindingTarget { $0.placeholder = $1 }
+  }
+
+  /// Sets the attributedPlaceholder of the textField
+  public var attributedPlaceholder: BindingTarget<NSAttributedString?> {
+    return makeBindingTarget { $0.attributedPlaceholder = $1 }
+  }
+
+  /// Sets the defaultTextAttributes of the textField
+  public var defaultTextAttributes: BindingTarget<[String : Any]> {
+    return makeBindingTarget { $0.defaultTextAttributes = $1 }
+  }
+
+  /// Sets the font of the textField
+  public var font: BindingTarget<UIFont?> {
+    return makeBindingTarget { $0.font = $1 }
+  }
+
+  /// Sets the textColor of the textField
+  public var textColor: BindingTarget<UIColor> {
+    return makeBindingTarget { $0.textColor = $1 }
+  }
+
+  /// Sets the textAlignment of the textField
+  public var textAlignment: BindingTarget<NSTextAlignment> {
+    return makeBindingTarget { $0.textAlignment = $1 }
+  }
+
+  /// Sets the typingAttributes of the textField
+  public var typingAttributes: BindingTarget<[String : Any]?> {
+    return makeBindingTarget { $0.typingAttributes = $1 }
+  }
+
+  /// Sets the adjustsFontSizeToFitWidth of the textField
+  public var adjustsFontSizeToFitWidth: BindingTarget<Bool> {
+    return makeBindingTarget { $0.adjustsFontSizeToFitWidth = $1 }
+  }
+
+  /// Sets the minimumFontSize of the textField
+  public var minimumFontSize: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.minimumFontSize = $1 }
+  }
+
+  /// Sets the clearsOnBeginEditing of the textField
+  public var clearsOnBeginEditing: BindingTarget<Bool> {
+    return makeBindingTarget { $0.clearsOnBeginEditing = $1 }
+  }
+
+  /// Sets the clearsOnInsertion of the textField
+  public var clearsOnInsertion: BindingTarget<Bool> {
+    return makeBindingTarget { $0.clearsOnInsertion = $1 }
+  }
+
+  /// Sets the allowsEditingTextAttributes of the textField
+  public var allowsEditingTextAttributes: BindingTarget<Bool> {
+    return makeBindingTarget { $0.allowsEditingTextAttributes = $1 }
+  }
+
+  /// Sets the borderStyle of the textField
+  public var borderStyle: BindingTarget<UITextBorderStyle> {
+    return makeBindingTarget { $0.borderStyle = $1 }
+  }
+
+  /// Sets the background of the textField
+  public var background: BindingTarget<UIImage?> {
+    return makeBindingTarget { $0.background = $1 }
+  }
+
+  /// Sets the disabledBackground of the textField
+  public var disabledBackground: BindingTarget<UIImage?> {
+    return makeBindingTarget { $0.disabledBackground = $1 }
+  }
+
+  /// Sets the clearButtonMode of the textField
+  public var clearButtonMode: BindingTarget<UITextFieldViewMode> {
+    return makeBindingTarget { $0.clearButtonMode = $1 }
+  }
+
+  /// Sets the leftView of the textField
+  public var leftView: BindingTarget<UIView?> {
+    return makeBindingTarget { $0.leftView = $1 }
+  }
+
+  /// Sets the leftViewMode of the textField
+  public var leftViewMode: BindingTarget<UITextFieldViewMode> {
+    return makeBindingTarget { $0.leftViewMode = $1 }
+  }
+
+  /// Sets the rightView of the textField
+  public var rightView: BindingTarget<UIView?> {
+    return makeBindingTarget { $0.rightView = $1 }
+  }
+
+  /// Sets the rightViewMode of the textField
+  public var rightViewMode: BindingTarget<UITextFieldViewMode> {
+    return makeBindingTarget { $0.rightViewMode = $1 }
+  }
+
+  /// Sets the inputView of the textField
+  public var inputView: BindingTarget<UIView?> {
+    return makeBindingTarget { $0.inputView = $1 }
+  }
+
+  /// Sets the inputAccessoryView of the textField
+  public var inputAccessoryView: BindingTarget<UIView?> {
+    return makeBindingTarget { $0.inputAccessoryView = $1 }
+  }
+
+  /// Sets the isSecureTextEntry of the textField
+  public var isSecureTextEntry: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isSecureTextEntry = $1 }
+  }
+
+}
+
+extension Reactive where Base: UITextView {
+  /// Sets the text of the textView
+  public var text: BindingTarget<String?> {
+    return makeBindingTarget { $0.text = $1 }
+  }
+
+  /// Sets the attributedText of the textView
+  public var attributedText: BindingTarget<NSAttributedString?> {
+    return makeBindingTarget { $0.attributedText = $1 }
+  }
+
+  /// Sets the font of the textView
+  public var font: BindingTarget<UIFont?> {
+    return makeBindingTarget { $0.font = $1 }
+  }
+
+  /// Sets the textColor of the textView
+  public var textColor: BindingTarget<UIColor?> {
+    return makeBindingTarget { $0.textColor = $1 }
+  }
+
+  /// Sets the isEditable of the textView
+  public var isEditable: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isEditable = $1 }
+  }
+
+  /// Sets the allowsEditingTextAttributes of the textView
+  public var allowsEditingTextAttributes: BindingTarget<Bool> {
+    return makeBindingTarget { $0.allowsEditingTextAttributes = $1 }
+  }
+
+  /// Sets the dataDetectorTypes of the textView
+  public var dataDetectorTypes: BindingTarget<UIDataDetectorTypes> {
+    return makeBindingTarget { $0.dataDetectorTypes = $1 }
+  }
+
+  /// Sets the textAlignment of the textView
+  public var textAlignment: BindingTarget<NSTextAlignment> {
+    return makeBindingTarget { $0.textAlignment = $1 }
+  }
+
+  /// Sets the typingAttributes of the textView
+  public var typingAttributes: BindingTarget<[String : Any]> {
+    return makeBindingTarget { $0.typingAttributes = $1 }
+  }
+
+  /// Sets the linkTextAttributes of the textView
+  public var linkTextAttributes: BindingTarget<[String : Any]> {
+    return makeBindingTarget { $0.linkTextAttributes = $1 }
+  }
+
+  /// Sets the textContainerInset of the textView
+  public var textContainerInset: BindingTarget<UIEdgeInsets> {
+    return makeBindingTarget { $0.textContainerInset = $1 }
+  }
+
+  /// Sets the selectedRange of the textView
+  public var selectedRange: BindingTarget<NSRange> {
+    return makeBindingTarget { $0.selectedRange = $1 }
+  }
+
+  /// Sets the clearsOnInsertion of the textView
+  public var clearsOnInsertion: BindingTarget<Bool> {
+    return makeBindingTarget { $0.clearsOnInsertion = $1 }
+  }
+
+  /// Sets the isSelectable of the textView
+  public var isSelectable: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isSelectable = $1 }
+  }
+
+  /// Sets the inputView of the textView
+  public var inputView: BindingTarget<UIView?> {
+    return makeBindingTarget { $0.inputView = $1 }
+  }
+
+  /// Sets the inputAccessoryView of the textView
+  public var inputAccessoryView: BindingTarget<UIView?> {
+    return makeBindingTarget { $0.inputAccessoryView = $1 }
+  }
+
+}
+
+extension Reactive where Base: UIView {
+  /// Sets the backgroundColor of the view
+  public var backgroundColor: BindingTarget<UIColor> {
+    return makeBindingTarget { $0.backgroundColor = $1 }
+  }
+
+  /// Sets the isHidden of the view
+  public var isHidden: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isHidden = $1 }
+  }
+
+  /// Sets the alpha of the view
+  public var alpha: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.alpha = $1 }
+  }
+
+  /// Sets the isOpaque of the view
+  public var isOpaque: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isOpaque = $1 }
+  }
+
+  /// Sets the tintColor of the view
+  public var tintColor: BindingTarget<UIColor> {
+    return makeBindingTarget { $0.tintColor = $1 }
+  }
+
+  /// Sets the tintAdjustmentMode of the view
+  public var tintAdjustmentMode: BindingTarget<UIViewTintAdjustmentMode> {
+    return makeBindingTarget { $0.tintAdjustmentMode = $1 }
+  }
+
+  /// Sets the clipsToBounds of the view
+  public var clipsToBounds: BindingTarget<Bool> {
+    return makeBindingTarget { $0.clipsToBounds = $1 }
+  }
+
+  /// Sets the clearsContextBeforeDrawing of the view
+  public var clearsContextBeforeDrawing: BindingTarget<Bool> {
+    return makeBindingTarget { $0.clearsContextBeforeDrawing = $1 }
+  }
+
+  /// Sets the mask of the view
+  public var mask: BindingTarget<UIView?> {
+    return makeBindingTarget { $0.mask = $1 }
+  }
+
+  /// Sets the isUserInteractionEnabled of the view
+  public var isUserInteractionEnabled: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isUserInteractionEnabled = $1 }
+  }
+
+  /// Sets the isMultipleTouchEnabled of the view
+  public var isMultipleTouchEnabled: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isMultipleTouchEnabled = $1 }
+  }
+
+  /// Sets the isExclusiveTouch of the view
+  public var isExclusiveTouch: BindingTarget<Bool> {
+    return makeBindingTarget { $0.isExclusiveTouch = $1 }
+  }
+
+  /// Sets the frame of the view
+  public var frame: BindingTarget<CGRect> {
+    return makeBindingTarget { $0.frame = $1 }
+  }
+
+  /// Sets the bounds of the view
+  public var bounds: BindingTarget<CGRect> {
+    return makeBindingTarget { $0.bounds = $1 }
+  }
+
+  /// Sets the center of the view
+  public var center: BindingTarget<CGPoint> {
+    return makeBindingTarget { $0.center = $1 }
+  }
+
+  /// Sets the transform of the view
+  public var transform: BindingTarget<CGAffineTransform> {
+    return makeBindingTarget { $0.transform = $1 }
+  }
+
+  /// Sets the directionalLayoutMargins of the view
+  @available(iOS 11, *)
+  public var directionalLayoutMargins: BindingTarget<NSDirectionalEdgeInsets> {
+    return makeBindingTarget { $0.directionalLayoutMargins = $1 }
+  }
+
+  /// Sets the layoutMargins of the view
+  public var layoutMargins: BindingTarget<UIEdgeInsets> {
+    return makeBindingTarget { $0.layoutMargins = $1 }
+  }
+
+  /// Sets the preservesSuperviewLayoutMargins of the view
+  public var preservesSuperviewLayoutMargins: BindingTarget<Bool> {
+    return makeBindingTarget { $0.preservesSuperviewLayoutMargins = $1 }
+  }
+
+  /// Sets the insetsLayoutMarginsFromSafeArea of the view
+  @available(iOS 11, *)
+  public var insetsLayoutMarginsFromSafeArea: BindingTarget<Bool> {
+    return makeBindingTarget { $0.insetsLayoutMarginsFromSafeArea = $1 }
+  }
+
+  /// Sets the contentMode of the view
+  public var contentMode: BindingTarget<UIViewContentMode> {
+    return makeBindingTarget { $0.contentMode = $1 }
+  }
+
+  /// Sets the autoresizesSubviews of the view
+  public var autoresizesSubviews: BindingTarget<Bool> {
+    return makeBindingTarget { $0.autoresizesSubviews = $1 }
+  }
+
+  /// Sets the autoresizingMask of the view
+  public var autoresizingMask: BindingTarget<UIViewAutoresizing> {
+    return makeBindingTarget { $0.autoresizingMask = $1 }
+  }
+
+  /// Sets the translatesAutoresizingMaskIntoConstraints of the view
+  public var translatesAutoresizingMaskIntoConstraints: BindingTarget<Bool> {
+    return makeBindingTarget { $0.translatesAutoresizingMaskIntoConstraints = $1 }
+  }
+
+  /// Sets the semanticContentAttribute of the view
+  @available(iOS 9, *)
+  public var semanticContentAttribute: BindingTarget<UISemanticContentAttribute> {
+    return makeBindingTarget { $0.semanticContentAttribute = $1 }
+  }
+
+  /// Sets the interactions of the view
+  @available(iOS 11, *)
+  public var interactions: BindingTarget<[UIInteraction]> {
+    return makeBindingTarget { $0.interactions = $1 }
+  }
+
+  /// Sets the contentScaleFactor of the view
+  public var contentScaleFactor: BindingTarget<CGFloat> {
+    return makeBindingTarget { $0.contentScaleFactor = $1 }
+  }
+
+  /// Sets the gestureRecognizers of the view
+  public var gestureRecognizers: BindingTarget<[UIGestureRecognizer]?> {
+    return makeBindingTarget { $0.gestureRecognizers = $1 }
+  }
+
+  /// Sets the motionEffects of the view
+  public var motionEffects: BindingTarget<[UIMotionEffect]> {
+    return makeBindingTarget { $0.motionEffects = $1 }
+  }
+
+  /// Sets the restorationIdentifier of the view
+  public var restorationIdentifier: BindingTarget<String?> {
+    return makeBindingTarget { $0.restorationIdentifier = $1 }
+  }
+
+  /// Sets the tag of the view
+  public var tag: BindingTarget<Int> {
+    return makeBindingTarget { $0.tag = $1 }
+  }
+
+  /// Sets the accessibilityIgnoresInvertColors of the view
+  @available(iOS 11, *)
+  public var accessibilityIgnoresInvertColors: BindingTarget<Bool> {
+    return makeBindingTarget { $0.accessibilityIgnoresInvertColors = $1 }
+  }
+
+}

--- a/ReactiveCocoa/UIKit/UIBarItem.swift
+++ b/ReactiveCocoa/UIKit/UIBarItem.swift
@@ -1,19 +1,8 @@
 import ReactiveSwift
 import UIKit
 
-extension Reactive where Base: UIBarItem {
-	/// Sets whether the bar item is enabled.
-	public var isEnabled: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isEnabled = $1 }
-	}
-
-	/// Sets image of bar item.
-	public var image: BindingTarget<UIImage?> {
-		return makeBindingTarget { $0.image = $1 }
-	}
-
-	/// Sets the title of bar item.
-	public var title: BindingTarget<String?> {
-		return makeBindingTarget { $0.title = $1 }
-	}
+protocol ReactiveUIBarItem {
+	var isEnabled: BindingTarget<Bool> { get }
+	var image: BindingTarget<UIImage?> { get }
+	var title: BindingTarget<String?> { get }
 }

--- a/ReactiveCocoa/UIKit/UIControl.swift
+++ b/ReactiveCocoa/UIKit/UIControl.swift
@@ -2,6 +2,14 @@ import ReactiveSwift
 import UIKit
 import enum Result.NoError
 
+protocol ReactiveUIControl {
+	var isEnabled: BindingTarget<Bool> { get }
+	var isSelected: BindingTarget<Bool> { get }
+	var isHighlighted: BindingTarget<Bool> { get }
+	var contentVerticalAlignment: BindingTarget<UIControlContentVerticalAlignment> { get }
+	var contentHorizontalAlignment: BindingTarget<UIControlContentHorizontalAlignment> { get }
+}
+
 extension Reactive where Base: UIControl {
 	/// The current associated action of `self`, with its registered event mask
 	/// and its disposable.
@@ -93,20 +101,5 @@ extension Reactive where Base: UIControl {
 	@available(*, unavailable, renamed: "controlEvents(_:)")
 	public func trigger(for controlEvents: UIControlEvents) -> Signal<(), NoError> {
 		fatalError()
-	}
-
-	/// Sets whether the control is enabled.
-	public var isEnabled: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isEnabled = $1 }
-	}
-
-	/// Sets whether the control is selected.
-	public var isSelected: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isSelected = $1 }
-	}
-
-	/// Sets whether the control is highlighted.
-	public var isHighlighted: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isHighlighted = $1 }
 	}
 }

--- a/ReactiveCocoa/UIKit/UIImageView.swift
+++ b/ReactiveCocoa/UIKit/UIImageView.swift
@@ -1,14 +1,9 @@
 import ReactiveSwift
 import UIKit
 
-extension Reactive where Base: UIImageView {
-	/// Sets the image of the image view.
-	public var image: BindingTarget<UIImage?> {
-		return makeBindingTarget { $0.image = $1 }
-	}
-
-	/// Sets the image of the image view for its highlighted state.
-	public var highlightedImage: BindingTarget<UIImage?> {
-		return makeBindingTarget { $0.highlightedImage = $1 }
-	}
+protocol ReactiveUIImageView {
+	var image: BindingTarget<UIImage?> { get }
+	var highlightedImage: BindingTarget<UIImage?> { get }
 }
+
+

--- a/ReactiveCocoa/UIKit/UILabel.swift
+++ b/ReactiveCocoa/UIKit/UILabel.swift
@@ -1,19 +1,30 @@
 import ReactiveSwift
 import UIKit
 
-extension Reactive where Base: UILabel {
-	/// Sets the text of the label.
-	public var text: BindingTarget<String?> {
-		return makeBindingTarget { $0.text = $1 }
-	}
-
-	/// Sets the attributed text of the label.
-	public var attributedText: BindingTarget<NSAttributedString?> {
-		return makeBindingTarget { $0.attributedText = $1 }
-	}
-
-	/// Sets the color of the text of the label.
-	public var textColor: BindingTarget<UIColor> {
-		return makeBindingTarget { $0.textColor = $1 }
-	}
+protocol ReactiveUILabel {
+	// Accessing the Text Attributes
+	var text: BindingTarget<String?> { get }
+	var attributedText: BindingTarget<NSAttributedString?> { get }
+	var font: BindingTarget<UIFont> { get }
+	var textColor: BindingTarget<UIColor> { get }
+	var textAlignment: BindingTarget<NSTextAlignment> { get }
+	var lineBreakMode: BindingTarget<NSLineBreakMode> { get }
+	var isEnabled: BindingTarget<Bool> { get }
+	// Sizing the Label's Text
+	var adjustsFontSizeToFitWidth: BindingTarget<Bool> { get }
+	@available(iOS 9, *)
+	var allowsDefaultTighteningForTruncation: BindingTarget<Bool> { get }
+	var baselineAdjustment: BindingTarget<UIBaselineAdjustment> { get }
+	var minimumScaleFactor: BindingTarget<CGFloat> { get }
+	var numberOfLines: BindingTarget<Int> { get }
+	// Managing Highlight Values
+	var highlightedTextColor: BindingTarget<UIColor>? { get }
+	var isHighlighted: BindingTarget<Bool> { get }
+	// Drawing a Shadow
+	var shadowColor: BindingTarget<UIColor>? { get }
+	var shadowOffset: BindingTarget<CGSize> { get }
+	// Getting Layout Constraints
+	var preferredMaxLayoutWidth: BindingTarget<CGFloat> { get }
+	// Setting and getting Attributes
+	var isUserInteractionEnabled: BindingTarget<Bool> { get }
 }

--- a/ReactiveCocoa/UIKit/UINavigationItem.swift
+++ b/ReactiveCocoa/UIKit/UINavigationItem.swift
@@ -1,12 +1,11 @@
 import ReactiveSwift
 import UIKit
 
+protocol ReactiveUINavigationItem {
+	var title: BindingTarget<String?> { get }
+}
+
 extension Reactive where Base: UINavigationItem {
-	/// Sets the title of the navigation item.
-	public var title: BindingTarget<String?> {
-		return makeBindingTarget { $0.title = $1 }
-	}
-	
 	#if os(iOS)
 		/// Sets the prompt of the navigation item.
 		public var prompt: BindingTarget<String?> {

--- a/ReactiveCocoa/UIKit/UIProgressView.swift
+++ b/ReactiveCocoa/UIKit/UIProgressView.swift
@@ -1,9 +1,15 @@
 import ReactiveSwift
 import UIKit
 
-extension Reactive where Base: UIProgressView {
-	/// Sets the relative progress to be reflected by the progress view.
-	public var progress: BindingTarget<Float> {
-		return makeBindingTarget { $0.progress = $1 }
-	}
+protocol ReactiveUIProgressView {
+	// Managing the Progress Bar
+	var progress: BindingTarget<Float> { get}
+	@available(iOS 9, *)
+	var observedProgress: BindingTarget<Progress?> { get}
+	// Configuring the Progress Bar
+	var progressViewStyle: BindingTarget<UIProgressViewStyle> { get}
+	var progressTintColor: BindingTarget<UIColor?> { get}
+	var progressImage: BindingTarget<UIImage?> { get}
+	var trackTintColor: BindingTarget<UIColor?> { get}
+	var trackImage: BindingTarget<UIImage?> { get}
 }

--- a/ReactiveCocoa/UIKit/UIScrollView.swift
+++ b/ReactiveCocoa/UIKit/UIScrollView.swift
@@ -1,36 +1,17 @@
 import ReactiveSwift
 import UIKit
 
+protocol ReactiveUIScrollView {
+	var contentInset: BindingTarget<UIEdgeInsets> { get }
+	var scrollIndicatorInsets: BindingTarget<UIEdgeInsets> { get }
+	var isScrollEnabled: BindingTarget<Bool> { get }
+	var zoomScale: BindingTarget<CGFloat> { get }
+	var minimumZoomScale: BindingTarget<CGFloat> { get }
+	var maximumZoomScale: BindingTarget<CGFloat> { get }
+}
+
 extension Reactive where Base: UIScrollView {
-	/// Sets the content inset of the scroll view.
-	public var contentInset: BindingTarget<UIEdgeInsets> {
-		return makeBindingTarget { $0.contentInset = $1 }
-	}
 
-	/// Sets the scroll indicator insets of the scroll view.
-	public var scrollIndicatorInsets: BindingTarget<UIEdgeInsets> {
-		return makeBindingTarget { $0.scrollIndicatorInsets = $1 }
-	}
-
-	/// Sets whether scrolling the scroll view is enabled.
-	public var isScrollEnabled: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isScrollEnabled = $1 }
-	}
-
-	/// Sets the zoom scale of the scroll view.
-	public var zoomScale: BindingTarget<CGFloat> {
-		return makeBindingTarget { $0.zoomScale = $1 }
-	}
-
-	/// Sets the minimum zoom scale of the scroll view.
-	public var minimumZoomScale: BindingTarget<CGFloat> {
-		return makeBindingTarget { $0.minimumZoomScale = $1 }
-	}
-
-	/// Sets the maximum zoom scale of the scroll view.
-	public var maximumZoomScale: BindingTarget<CGFloat> {
-		return makeBindingTarget { $0.maximumZoomScale = $1 }
-	}
 	
 	#if os(iOS)
 	/// Sets whether the scroll view scrolls to the top when the menu is tapped.

--- a/ReactiveCocoa/UIKit/UISegmentedControl.swift
+++ b/ReactiveCocoa/UIKit/UISegmentedControl.swift
@@ -2,12 +2,11 @@ import ReactiveSwift
 import enum Result.NoError
 import UIKit
 
-extension Reactive where Base: UISegmentedControl {
-	/// Changes the selected segment of the segmented control.
-	public var selectedSegmentIndex: BindingTarget<Int> {
-		return makeBindingTarget { $0.selectedSegmentIndex = $1 }
-	}
+protocol ReactiveUISegmentedControl {
+	var selectedSegmentIndex: BindingTarget<Int> { get }
+}
 
+extension Reactive where Base: UISegmentedControl {
 	/// A signal of indexes of selections emitted by the segmented control.
 	public var selectedSegmentIndexes: Signal<Int, NoError> {
 		return mapControlEvents(.valueChanged) { $0.selectedSegmentIndex }

--- a/ReactiveCocoa/UIKit/UITabBarItem.swift
+++ b/ReactiveCocoa/UIKit/UITabBarItem.swift
@@ -1,14 +1,13 @@
 import ReactiveSwift
 import UIKit
 
+protocol ReactiveUITabBarItem {
+	var badgeValue: BindingTarget<String?> { get }
+}
+
 extension Reactive where Base: UITabBarItem {
-	/// Sets the badge value of the tab bar item.
-	public var badgeValue: BindingTarget<String?> {
-		return makeBindingTarget { $0.badgeValue = $1 }
-	}
-	
-	
 	/// Sets the badge color of the tab bar item.
+	// Sourcery currently does not capture all @available attributes, see https://github.com/krzysztofzablocki/Sourcery/issues/540
 	@available(iOS 10, *)
 	@available(tvOS 10, *)
 	public var badgeColor: BindingTarget<UIColor?> {

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -2,12 +2,42 @@ import ReactiveSwift
 import enum Result.NoError
 import UIKit
 
-extension Reactive where Base: UITextField {
-	/// Sets the text of the text field.
-	public var text: BindingTarget<String?> {
-		return makeBindingTarget { $0.text = $1 }
-	}
+protocol ReactiveUITextField {
+	// Accessing the Text Attributes
+	var text: BindingTarget<String?> {get }
+	var attributedText: BindingTarget<NSAttributedString?> {get }
+	var placeholder: BindingTarget<String?> {get }
+	var attributedPlaceholder: BindingTarget<NSAttributedString?> { get }
+	var defaultTextAttributes: BindingTarget<[String : Any]> { get }
+	var font: BindingTarget<UIFont?> { get }
+	var textColor: BindingTarget<UIColor> {get }
+	var textAlignment: BindingTarget<NSTextAlignment> { get }
+	var typingAttributes: BindingTarget<[String : Any]?> { get }
+	//  Sizing the Text Field's Text
+	var adjustsFontSizeToFitWidth: BindingTarget<Bool> { get }
+	var minimumFontSize: BindingTarget<CGFloat> { get }
+	// Managing the Editing Behavior
+	var clearsOnBeginEditing: BindingTarget<Bool> { get }
+	var clearsOnInsertion: BindingTarget<Bool> { get }
+	var allowsEditingTextAttributes: BindingTarget<Bool> { get }
+	// Setting the View's Background Appearence
+	var borderStyle: BindingTarget<UITextBorderStyle> { get }
+	var background: BindingTarget<UIImage?> { get }
+	var disabledBackground: BindingTarget<UIImage?> { get }
+	// Managing Overlay Views
+	var clearButtonMode: BindingTarget<UITextFieldViewMode> { get }
+	var leftView: BindingTarget<UIView?> { get }
+	var leftViewMode: BindingTarget<UITextFieldViewMode> { get }
+	var rightView: BindingTarget<UIView?> { get }
+	var rightViewMode: BindingTarget<UITextFieldViewMode> { get }
+	// Replacing System Input View
+	var inputView: BindingTarget<UIView?> { get }
+	var inputAccessoryView: BindingTarget<UIView?> { get }
+	
+	var isSecureTextEntry: BindingTarget<Bool> { get }
+}
 
+extension Reactive where Base: UITextField {
 	/// A signal of text values emitted by the text field upon end of editing.
 	///
 	/// - note: To observe text values that change on all editing events,
@@ -23,21 +53,6 @@ extension Reactive where Base: UITextField {
 		return mapControlEvents(.allEditingEvents) { $0.text }
 	}
 	
-	/// Sets the attributed text of the text field.
-	public var attributedText: BindingTarget<NSAttributedString?> {
-		return makeBindingTarget { $0.attributedText = $1 }
-	}
-
-	/// Sets the placeholder text of the text field.
-	public var placeholder: BindingTarget<String?> {
-		return makeBindingTarget { $0.placeholder = $1 }
-	}
-	
-	/// Sets the textColor of the text field.
-	public var textColor: BindingTarget<UIColor> {
-		return makeBindingTarget { $0.textColor = $1 }
-	}
-	
 	/// A signal of attributed text values emitted by the text field upon end of editing.
 	///
 	/// - note: To observe attributed text values that change on all editing events,
@@ -51,10 +66,5 @@ extension Reactive where Base: UITextField {
 	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
 	public var continuousAttributedTextValues: Signal<NSAttributedString?, NoError> {
 		return mapControlEvents(.allEditingEvents) { $0.attributedText }
-	}
-
-	/// Sets the secure text entry attribute on the text field.
-	public var isSecureTextEntry: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isSecureTextEntry = $1 }
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -8,16 +8,33 @@ private class TextViewDelegateProxy: DelegateProxy<UITextViewDelegate>, UITextVi
 	}
 }
 
+protocol ReactiveUITextView {
+	// Configuring the Text Attributes
+	var text: BindingTarget<String?> { get }
+	var attributedText: BindingTarget<NSAttributedString?> { get }
+	var font: BindingTarget<UIFont?> { get }
+	var textColor: BindingTarget<UIColor?> { get }
+	var isEditable: BindingTarget<Bool> { get }
+	var allowsEditingTextAttributes: BindingTarget<Bool> { get }
+	var dataDetectorTypes: BindingTarget<UIDataDetectorTypes> { get }
+	var textAlignment: BindingTarget<NSTextAlignment> { get }
+	var typingAttributes: BindingTarget<[String : Any]> { get }
+	var linkTextAttributes: BindingTarget<[String : Any]> { get }
+	var textContainerInset: BindingTarget<UIEdgeInsets> { get }
+	// Working with the Selection
+	var selectedRange: BindingTarget<NSRange> { get }
+	var clearsOnInsertion: BindingTarget<Bool> { get }
+	var isSelectable: BindingTarget<Bool> { get }
+	// Replacing the System Input View
+	var inputView: BindingTarget<UIView?> { get }
+	var inputAccessoryView: BindingTarget<UIView?> { get }
+}
+
 extension Reactive where Base: UITextView {
 	private var proxy: TextViewDelegateProxy {
 		return .proxy(for: base,
 		              setter: #selector(setter: base.delegate),
 		              getter: #selector(getter: base.delegate))
-	}
-
-	/// Sets the text of the text view.
-	public var text: BindingTarget<String?> {
-		return makeBindingTarget { $0.text = $1 }
 	}
 
 	private func textValues(forName name: NSNotification.Name) -> Signal<String?, NoError> {
@@ -41,11 +58,6 @@ extension Reactive where Base: UITextView {
 	/// - note: To observe text values only when editing ends, see `textValues`.
 	public var continuousTextValues: Signal<String?, NoError> {
 		return textValues(forName: .UITextViewTextDidChange)
-	}
-	
-	/// Sets the attributed text of the text view.
-	public var attributedText: BindingTarget<NSAttributedString?> {
-		return makeBindingTarget { $0.attributedText = $1 }
 	}
 	
 	private func attributedTextValues(forName name: NSNotification.Name) -> Signal<NSAttributedString?, NoError> {

--- a/ReactiveCocoa/UIKit/UIView.swift
+++ b/ReactiveCocoa/UIKit/UIView.swift
@@ -1,29 +1,59 @@
 import ReactiveSwift
 import UIKit
 
-extension Reactive where Base: UIView {
-	/// Sets the alpha value of the view.
-	public var alpha: BindingTarget<CGFloat> {
-		return makeBindingTarget { $0.alpha = $1 }
-	}
 
-	/// Sets whether the view is hidden.
-	public var isHidden: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isHidden = $1 }
-	}
-
-	/// Sets whether the view accepts user interactions.
-	public var isUserInteractionEnabled: BindingTarget<Bool> {
-		return makeBindingTarget { $0.isUserInteractionEnabled = $1 }
-	}
-
-	/// Sets the background color of the view.
-	public var backgroundColor: BindingTarget<UIColor> {
-		return makeBindingTarget { $0.backgroundColor = $1 }
-	}
-	
-	/// Sets the tintColor of the view
-	public var tintColor: BindingTarget<UIColor> {
-		return makeBindingTarget { $0.tintColor = $1 }
-	}
+protocol ReactiveUIView {
+	// Configuring a View's Visual Appearence
+	var backgroundColor: BindingTarget<UIColor> { get }
+	var isHidden: BindingTarget<Bool> { get }
+	var alpha: BindingTarget<CGFloat> { get }
+	var isOpaque: BindingTarget<Bool> { get }
+	var tintColor: BindingTarget<UIColor> { get }
+	var tintAdjustmentMode: BindingTarget<UIViewTintAdjustmentMode> { get }
+	var clipsToBounds: BindingTarget<Bool> { get }
+	var clearsContextBeforeDrawing: BindingTarget<Bool> { get }
+	var mask: BindingTarget<UIView?> { get }
+	// Configuring the Event-Related Behaviour
+	var isUserInteractionEnabled: BindingTarget<Bool> { get }
+	var isMultipleTouchEnabled: BindingTarget<Bool> { get }
+	var isExclusiveTouch: BindingTarget<Bool> { get }
+	// Configuring the Bounds and Frame Rectangles
+	var frame: BindingTarget<CGRect> { get }
+	var bounds: BindingTarget<CGRect> { get }
+	var center: BindingTarget<CGPoint> { get }
+	var transform: BindingTarget<CGAffineTransform> { get }
+	// Configuring Content Margins
+	@available(iOS 11, *)
+	var directionalLayoutMargins: BindingTarget<NSDirectionalEdgeInsets> { get }
+	var layoutMargins: BindingTarget<UIEdgeInsets> { get }
+	var preservesSuperviewLayoutMargins: BindingTarget<Bool> { get }
+	// Getting the Save Area
+	@available(iOS 11, *)
+	var insetsLayoutMarginsFromSafeArea: BindingTarget<Bool> { get }
+	// Configuring the Resizing Behavior
+	var contentMode: BindingTarget<UIViewContentMode> { get }
+	var autoresizesSubviews: BindingTarget<Bool> { get }
+	var autoresizingMask: BindingTarget<UIViewAutoresizing> { get }
+	// Laying out Subviews
+	var translatesAutoresizingMaskIntoConstraints: BindingTarget<Bool> { get }
+	// Managing the User Interface Direction
+	@available(iOS 9, *)
+	var semanticContentAttribute: BindingTarget<UISemanticContentAttribute> { get }
+	// Supporting Drag and Drop Interactions
+	@available(iOS 11, *)
+	var interactions: BindingTarget<[UIInteraction]> { get }
+	// Drawing and Updating the View
+	var contentScaleFactor: BindingTarget<CGFloat> { get }
+	// Managing Gesture Recognizers
+	var gestureRecognizers: BindingTarget<[UIGestureRecognizer]?> { get }
+	// Using Motion Effects
+	var motionEffects: BindingTarget<[UIMotionEffect]> { get }
+	// Preserving and Restoring State
+	var restorationIdentifier: BindingTarget<String?> { get }
+	// Identifying the View at Runtime
+	var tag: BindingTarget<Int> { get }
+	// Modyfing the Accessibility Behavior
+	@available(iOS 11, *)
+	var accessibilityIgnoresInvertColors: BindingTarget<Bool> { get }
 }
+

--- a/SourceryTemplates/BindingTarget.stencil
+++ b/SourceryTemplates/BindingTarget.stencil
@@ -1,0 +1,18 @@
+import ReactiveSwift
+import UIKit
+
+{% for protocol in types.protocols %}
+{% if protocol.name|hasPrefix:"ReactiveUI" %}
+
+extension Reactive where Base: {{ protocol.name|replace:"Reactive",""}} {
+{% for variable in protocol.variables %}
+  /// Sets the {{variable.name}} of the {{ protocol.name|replace:"ReactiveUI",""|lowerFirstLetter}}
+  {{ variable.attributes.available}}
+  public var {{variable.name}}: {{variable.typeName}} {
+    return makeBindingTarget { $0.{{variable.name}} = $1 }
+  }
+
+{% endfor %}
+}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
#### Checklist
- [ ] Updated CHANGELOG.md.

_This is not yet completed but I wanted to put this up for discussion before continuing._

The code for providing UI Bindings (I'm talking mainly about `BindingTarget` right now) is always the same and has to be copy&pasted for each new attributed to be added. 

Also, currently they are not complete. Every now and the I find myself in need of a less common used attribute thats still missing. E.g. right now I was about to add `borderStyle` to `UITextfield` and `accessoryType` to `UITableViewCell`.

So I played around a bit with [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to see how it would work to generate the Boilerplate for these Bindings automatically.

*Note:* I did not yet integrate Sourcery in the Build Process or anything, I've just installed it via homebrew and ran it in the root directory of Reactive Cocoa. Currently there's a .sourcery.yml Configuration file with very basic configuration.

## Code Generation

I've only looked at `BindingTarget` right now, and I've ignored some special cases. Adding special cases manually is not a problem, just do the same as before.

The Template is setup to look for Protocols named `ReactiveUI<Foo>` and for all variables declared in the Protocol.

It will then generate an Extension: 

```swift
extension Reactive where Base: <Foo> {
  var <VariableName>: <VariableType> { 
    makeBindingTarget { $0.<VariableName> = $1 }
  }
}
```

This is an actual example how the Protocol has to be defined:

```swift
protocol ReactiveUINavigationItem {
  var title: BindingTarget<String?> { get }
}
```

## Generate other Bindings

I have not yet looked into the other kinds of bindings and if/how they can be generated as well

## Still to figure out

The current Source Files are linked to varying targets (macOS, iOS, watchOS, tvOS). I think it will thus be necessary to run Sourcery once for each platform and always include only the Source Files that apply to that platform.

Right now I've ignored this and only converted some UIKit Extensions without regard to the platform