### PR TITLE
Append `objc` prefixes to all ObjC messaging placeholders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 *Please put new entries at the top.
 
+1. Fixed a compilation issue related to [SR-7299](https://bugs.swift.org/browse/SR-7299). (#3580)
+
 1. Improved the interoperability of method interception. (#3570, kudos to @andersio)
 
 1. Add `showsCancelButton`, `textDidBeginEditing` and `textDidEndEditing` extensions to `UISearchBar` (#3566)

--- a/ReactiveCocoa/NSObject+Intercepting.swift
+++ b/ReactiveCocoa/NSObject+Intercepting.swift
@@ -102,7 +102,7 @@ extension NSObject {
 				selectorCache.cache(selector)
 
 				if signatureCache[selector] == nil {
-					let signature = NSMethodSignature.signature(withObjCTypes: typeEncoding)
+					let signature = NSMethodSignature.objcSignature(withObjCTypes: typeEncoding)
 					signatureCache[selector] = signature
 				}
 
@@ -193,7 +193,7 @@ private func enableMessageForwarding(_ realClass: AnyClass, _ selectorCache: Sel
 					let interopImpl = class_getMethodImplementation(topLevelClass, interopAlias)!
 
 					let previousImpl = class_replaceMethod(topLevelClass, selector, interopImpl, typeEncoding)
-					invocation.invoke()
+					invocation.objcInvoke()
 
 					_ = class_replaceMethod(topLevelClass, selector, previousImpl ?? noImplementation, typeEncoding)
 				}
@@ -229,8 +229,8 @@ private func enableMessageForwarding(_ realClass: AnyClass, _ selectorCache: Sel
 				_ = class_replaceMethod(realClass, alias, impl, typeEncoding)
 			}
 
-			invocation.setSelector(alias)
-			invocation.invoke()
+			invocation.objcSetSelector(alias)
+			invocation.objcInvoke()
 
 			return
 		}
@@ -396,14 +396,14 @@ private func checkTypeEncoding(_ types: UnsafePointer<CChar>) -> Bool {
 private func unpackInvocation(_ invocation: AnyObject) -> [Any?] {
 	let invocation = invocation as AnyObject
 	let methodSignature = invocation.objcMethodSignature!
-	let count = UInt(methodSignature.numberOfArguments!)
+	let count = methodSignature.objcNumberOfArguments!
 
 	var bridged = [Any?]()
 	bridged.reserveCapacity(Int(count - 2))
 
 	// Ignore `self` and `_cmd` at index 0 and 1.
 	for position in 2 ..< count {
-		let rawEncoding = methodSignature.argumentType(at: position)
+		let rawEncoding = methodSignature.objcArgumentType(at: position)
 		let encoding = ObjCTypeEncoding(rawValue: rawEncoding.pointee) ?? .undefined
 
 		func extract<U>(_ type: U.Type) -> U {
@@ -414,7 +414,7 @@ private func unpackInvocation(_ invocation: AnyObject) -> [Any?] {
 				                   alignedTo: MemoryLayout<U>.alignment)
 			}
 
-			invocation.copy(to: pointer, forArgumentAt: Int(position))
+			invocation.objcCopy(to: pointer, forArgumentAt: Int(position))
 			return pointer.assumingMemoryBound(to: type).pointee
 		}
 
@@ -459,7 +459,7 @@ private func unpackInvocation(_ invocation: AnyObject) -> [Any?] {
 			let buffer = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: alignment)
 			defer { buffer.deallocate(bytes: size, alignedTo: alignment) }
 
-			invocation.copy(to: buffer, forArgumentAt: Int(position))
+			invocation.objcCopy(to: buffer, forArgumentAt: Int(position))
 			value = NSValue(bytes: buffer, objCType: rawEncoding)
 		}
 

--- a/ReactiveCocoa/NSObject+Intercepting.swift
+++ b/ReactiveCocoa/NSObject+Intercepting.swift
@@ -162,9 +162,9 @@ private func enableMessageForwarding(_ realClass: AnyClass, _ selectorCache: Sel
 			typeEncoding = String(cString: runtimeTypeEncoding)
 		} else {
 			let methodSignature = (objectRef.takeUnretainedValue() as AnyObject)
-				.methodSignature(for: selector)
-			let encodings = (0 ..< methodSignature.numberOfArguments!)
-				.map { UInt8(methodSignature.getArgumentType(at: $0).pointee) }
+				.objcMethodSignature(for: selector)
+			let encodings = (0 ..< methodSignature.objcNumberOfArguments!)
+				.map { UInt8(methodSignature.objcArgumentType(at: $0).pointee) }
 			typeEncoding = String(bytes: encodings, encoding: .ascii)!
 		}
 

--- a/ReactiveCocoa/ObjC+Messages.swift
+++ b/ReactiveCocoa/ObjC+Messages.swift
@@ -16,7 +16,7 @@ internal let NSMethodSignature: AnyClass = NSClassFromString("NSMethodSignature"
 	var objcClass: AnyClass! { get }
 
 	@objc(methodSignatureForSelector:)
-	func methodSignature(for selector: Selector) -> AnyObject
+	func objcMethodSignature(for selector: Selector) -> AnyObject
 }
 
 // Methods of `NSInvocation`.

--- a/ReactiveCocoa/ObjC+Messages.swift
+++ b/ReactiveCocoa/ObjC+Messages.swift
@@ -22,27 +22,29 @@ internal let NSMethodSignature: AnyClass = NSClassFromString("NSMethodSignature"
 // Methods of `NSInvocation`.
 @objc internal protocol ObjCInvocation {
 	@objc(setSelector:)
-	func setSelector(_ selector: Selector)
+	func objcSetSelector(_ selector: Selector)
 
 	@objc(methodSignature)
 	var objcMethodSignature: AnyObject { get }
 
 	@objc(getArgument:atIndex:)
-	func copy(to buffer: UnsafeMutableRawPointer?, forArgumentAt index: Int)
+	func objcCopy(to buffer: UnsafeMutableRawPointer?, forArgumentAt index: Int)
 
-	func invoke()
+	@objc(invoke)
+	func objcInvoke()
 
 	@objc(invocationWithMethodSignature:)
-	static func invocation(withMethodSignature signature: AnyObject) -> AnyObject
+	static func objcInvocation(withMethodSignature signature: AnyObject) -> AnyObject
 }
 
 // Methods of `NSMethodSignature`.
 @objc internal protocol ObjCMethodSignature {
-	var numberOfArguments: UInt { get }
+	@objc(numberOfArguments)
+	var objcNumberOfArguments: UInt { get }
 
 	@objc(getArgumentTypeAtIndex:)
-	func argumentType(at index: UInt) -> UnsafePointer<CChar>
+	func objcArgumentType(at index: UInt) -> UnsafePointer<CChar>
 
 	@objc(signatureWithObjCTypes:)
-	static func signature(withObjCTypes typeEncoding: UnsafePointer<Int8>) -> AnyObject
+	static func objcSignature(withObjCTypes typeEncoding: UnsafePointer<Int8>) -> AnyObject
 }


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-7299

Doesn't break Swift 4.1.

#### Checklist
- [ ] Updated CHANGELOG.md.
