### PR TITLE
Avoid flag override when intergrated with CocoaPods.

### DIFF
--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'ReactiveSwift', '~> 3.1'
 
-  s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "-suppress-warnings" }
+  s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
 end

--- a/ReactiveMapKit.podspec
+++ b/ReactiveMapKit.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'ReactiveCocoa', "#{s.version}"
 
-  s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "-suppress-warnings" }
+  s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
 end


### PR DESCRIPTION
By adding `$(inherited)` to `OTHER_SWIFT_FLAGS[cnnfig=Release]`.

Fix issue mentioned in https://github.com/ReactiveCocoa/ReactiveSwift/issues/628

#### Checklist
- [ ] Updated CHANGELOG.md.
