### PR TITLE
Conform `Observer` to `BindingTargetProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 *Please put new entries at the top.
 
 # 8.0.0-rc.1
-1. Add support for Cocoapods 1.5.0 static frameworks (#3590, kudos to @mishagray)
-
-1. Add `becomeFirstResponder` and `resignFirstResponder` extensions to `UIResponder`. (#3585, kudos to @Marcocanc)
-2. Added `title` binding target to `UIViewController` (#3588, kudos to @cocoahero).
-3. Added several trigger signals for view lifecycle events to `UIViewController` (#3588, kudos to @cocoahero).
+1. Conform `Signal.Observer` to `BindingTargetProvider` (#3609, kudos to @olejnjak)
+2. Add support for Cocoapods 1.5.0 static frameworks (#3590, kudos to @mishagray)
+3. Add `becomeFirstResponder` and `resignFirstResponder` extensions to `UIResponder`. (#3585, kudos to @Marcocanc)
+4. Added `title` binding target to `UIViewController` (#3588, kudos to @cocoahero).
+5. Added several trigger signals for view lifecycle events to `UIViewController` (#3588, kudos to @cocoahero).
 
 # 7.2.0
 1. Fixed a compilation issue related to [SR-7299](https://bugs.swift.org/browse/SR-7299). (#3580)
@@ -59,7 +59,7 @@
 
    Sources that use the MapKit bindings are now required to import ReactiveMapKit.
 
-   For all Xcode project users (including Carthage), targets need to be configured to link against ReactiveMapKit. For CocoaPods users, the framework is offered as a standalone podspec, so the Podfile needs to be updated with a new entry. 
+   For all Xcode project users (including Carthage), targets need to be configured to link against ReactiveMapKit. For CocoaPods users, the framework is offered as a standalone podspec, so the Podfile needs to be updated with a new entry.
 
 # 6.1.0-alpha.2
 # 6.1.0-alpha.1
@@ -165,16 +165,16 @@ Lots has changed, but if you're already migrating to Swift 3 then that should no
 #### Foundation: Object Interception
 
 RAC 5.0 includes a few object interception tools from ReactiveObjC, remastered for ReactiveSwift.
-	
+
 1. **Method Call Interception**
 
 	Create signals that are sourced by intercepting Objective-C objects.
-	
+
 	```swift
 	// Notify after every time `viewWillAppear(_:)` is called.
 	let appearing = viewController.reactive.trigger(for: #selector(UIViewController.viewWillAppear(_:)))
 	```
-	
+
 1. **Object Lifetime**
 
 	Obtain a `Lifetime` token for any `NSObject` to observe their deinitialization.
@@ -188,7 +188,7 @@ RAC 5.0 includes a few object interception tools from ReactiveObjC, remastered f
 
 	Establish key-value observations in the form of [`SignalProducer`][]s and
 	strong-typed `DynamicProperty`s, and enjoy the inherited composability.
-	
+
 	```swift
 	// A producer that sends the current value of `keyPath`, followed by
 	// subsequent changes.
@@ -196,7 +196,7 @@ RAC 5.0 includes a few object interception tools from ReactiveObjC, remastered f
 	// Terminate the KVO observation if the lifetime of `self` ends.
 	let producer = object.reactive.values(forKeyPath: #keyPath(key))
 		.take(during: self.reactive.lifetime)
-	
+
 	// A parameterized property that represents the supplied key path of the
 	// wrapped object. It holds a weak reference to the wrapped object.
 	let property = DynamicProperty<String>(object: person,
@@ -223,19 +223,19 @@ UI components now expose a collection of binding targets to which can be bound f
 
 	Interactive UI components expose [`Signal`][]s for control events
 	and updates in the control value upon user interactions.
-	
+
 	A selected set of controls provide a convenience, expressive binding
 	API for [`Action`][]s.
-	
-	
+
+
 	```swift
 	// Update `allowsCookies` whenever the toggle is flipped.
-	preferences.allowsCookies <~ toggle.reactive.isOnValues 
-	
+	preferences.allowsCookies <~ toggle.reactive.isOnValues
+
 	// Compute live character counts from the continuous stream of user initiated
 	// changes in the text.
 	textField.reactive.continuousTextValues.map { $0.characters.count }
-	
+
 	// Trigger `commit` whenever the button is pressed.
 	button.reactive.pressed = CocoaAction(viewModel.commit)
 	```
@@ -290,7 +290,7 @@ let old = atomicCount.modify { value in
 The new `BindingTargetProtocol` protocol has been formally introduced to represent an entity to which can form a unidirectional binding using the `<~` operator. A new type `BindingTarget` has also been introduced to represent non-observable targets that are expected to only be written to.
 
 ```swift
-// The `UIControl` exposes a `isEnabled` binding target. 
+// The `UIControl` exposes a `isEnabled` binding target.
 control.isEnabled <~ viewModel.isEnabled
 ```
 
@@ -302,7 +302,7 @@ control.isEnabled <~ viewModel.isEnabled
 public final class MyController {
 	private let token = Lifetime.Token()
 	public let lifetime: Lifetime
-	
+
 	public init() {
 		lifetime = Lifetime(token)
 	}

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -52,6 +52,9 @@
 		696CCF1720FE0682003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1620FE0682003981E8 /* Observer.swift */; };
 		696CCF1820FE069C003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1620FE0682003981E8 /* Observer.swift */; };
 		696CCF1920FE069D003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1620FE0682003981E8 /* Observer.swift */; };
+		696CCF1D20FE073A003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1B20FE0732003981E8 /* Observer.swift */; };
+		696CCF1E20FE073A003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1B20FE0732003981E8 /* Observer.swift */; };
+		696CCF1F20FE073C003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1B20FE0732003981E8 /* Observer.swift */; };
 		7A8BA0FA1FCC86FC003241C7 /* NSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8BA0F91FCC86FC003241C7 /* NSTextView.swift */; };
 		7DFBED081CDB8C9500EE435B /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */; };
 		7DFBED141CDB8CE600EE435B /* test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = D03766B119EDA60000A782A9 /* test-data.json */; };
@@ -435,6 +438,7 @@
 		57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		57A4D2471BA13F9700F7D4B1 /* tvOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		696CCF1620FE0682003981E8 /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
+		696CCF1B20FE0732003981E8 /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
 		7A8BA0F91FCC86FC003241C7 /* NSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSTextView.swift; sourceTree = "<group>"; };
 		7DFBED031CDB8C9500EE435B /* ReactiveCocoaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveCocoaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		834DE1001E4109750099F4E5 /* NSImageViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSImageViewSpec.swift; sourceTree = "<group>"; };
@@ -689,6 +693,7 @@
 			isa = PBXGroup;
 			children = (
 				538DCB7C1DCA5E9B00332880 /* NSLayoutConstraintSpec.swift */,
+				696CCF1B20FE0732003981E8 /* Observer.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1480,6 +1485,7 @@
 				9AD841DE204C29B90040F0C0 /* MessageForwardingEntity.m in Sources */,
 				A9EB3D2B1E94F3D9002A9BCC /* UITabBarItemSpec.swift in Sources */,
 				7DFBED6D1CDB8F7D00EE435B /* SignalProducerNimbleMatchers.swift in Sources */,
+				696CCF1F20FE073C003981E8 /* Observer.swift in Sources */,
 				9ADFE5A31DBFFBCF001E11F7 /* LifetimeSpec.swift in Sources */,
 				9A1D06411D93EA7E00ACF44C /* UIControlSpec.swift in Sources */,
 				9AFCBFE51EB1ABC0004B4C74 /* KVOKVCExtensionSpec.swift in Sources */,
@@ -1591,6 +1597,7 @@
 				9ADE4A8F1DA6DA20005C2AC8 /* NSControlSpec.swift in Sources */,
 				D0A2260E1A72F16D00D33B74 /* DynamicPropertySpec.swift in Sources */,
 				9AFCBFE31EB1ABC0004B4C74 /* KVOKVCExtensionSpec.swift in Sources */,
+				696CCF1D20FE073A003981E8 /* Observer.swift in Sources */,
 				9ADFE5A11DBFFBCF001E11F7 /* LifetimeSpec.swift in Sources */,
 				4ABEFE331DCFD0630066A8C2 /* NSCollectionViewSpec.swift in Sources */,
 				B696FB811A7640C00075236D /* TestError.swift in Sources */,
@@ -1704,6 +1711,7 @@
 				9A9DFEEA1DA7EFB60039EE1B /* AssociationSpec.swift in Sources */,
 				9A54A2121DDF5B4D001739B3 /* InterceptingPerformanceTests.swift in Sources */,
 				A9D8BA74207CD8430031733D /* UIResponderSpec.swift in Sources */,
+				696CCF1E20FE073A003981E8 /* Observer.swift in Sources */,
 				9ADFE5A21DBFFBCF001E11F7 /* LifetimeSpec.swift in Sources */,
 				9A1D06421D93EA7E00ACF44C /* UIDatePickerSpec.swift in Sources */,
 				53AC46CF1DD6FC0000C799E1 /* UISliderSpec.swift in Sources */,

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		53AC46CF1DD6FC0000C799E1 /* UISliderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AC46CE1DD6FC0000C799E1 /* UISliderSpec.swift */; };
 		57A4D2081BA13D7A00F7D4B1 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		57A4D20A1BA13D7A00F7D4B1 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		696CCF1720FE0682003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1620FE0682003981E8 /* Observer.swift */; };
+		696CCF1820FE069C003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1620FE0682003981E8 /* Observer.swift */; };
+		696CCF1920FE069D003981E8 /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696CCF1620FE0682003981E8 /* Observer.swift */; };
 		7A8BA0FA1FCC86FC003241C7 /* NSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8BA0F91FCC86FC003241C7 /* NSTextView.swift */; };
 		7DFBED081CDB8C9500EE435B /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */; };
 		7DFBED141CDB8CE600EE435B /* test-data.json in Resources */ = {isa = PBXBuildFile; fileRef = D03766B119EDA60000A782A9 /* test-data.json */; };
@@ -431,6 +434,7 @@
 		57A4D2451BA13F9700F7D4B1 /* tvOS-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Base.xcconfig"; sourceTree = "<group>"; };
 		57A4D2461BA13F9700F7D4B1 /* tvOS-Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-Framework.xcconfig"; sourceTree = "<group>"; };
 		57A4D2471BA13F9700F7D4B1 /* tvOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "tvOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
+		696CCF1620FE0682003981E8 /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
 		7A8BA0F91FCC86FC003241C7 /* NSTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSTextView.swift; sourceTree = "<group>"; };
 		7DFBED031CDB8C9500EE435B /* ReactiveCocoaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveCocoaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		834DE1001E4109750099F4E5 /* NSImageViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSImageViewSpec.swift; sourceTree = "<group>"; };
@@ -676,6 +680,7 @@
 			isa = PBXGroup;
 			children = (
 				538DCB781DCA5E6C00332880 /* NSLayoutConstraint.swift */,
+				696CCF1620FE0682003981E8 /* Observer.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1419,6 +1424,7 @@
 				538DCB7B1DCA5E6C00332880 /* NSLayoutConstraint.swift in Sources */,
 				9AA0BD9B1DDE7A2200531FCF /* ObjCRuntimeAliases.m in Sources */,
 				9ADE4A941DA6EA40005C2AC8 /* NSObject+ReactiveExtensionsProvider.swift in Sources */,
+				696CCF1920FE069D003981E8 /* Observer.swift in Sources */,
 				9A1D05E31D93E99100ACF44C /* NSObject+Association.swift in Sources */,
 				419139491DB910570043C9D1 /* UIGestureRecognizer.swift in Sources */,
 				9A1D06161D93EA0100ACF44C /* UIControl.swift in Sources */,
@@ -1559,6 +1565,7 @@
 				7A8BA0FA1FCC86FC003241C7 /* NSTextView.swift in Sources */,
 				9A2E425E1DAA6737006D909F /* CocoaTarget.swift in Sources */,
 				9AB15C7A1E26CD9A00997378 /* Deprecations+Removals.swift in Sources */,
+				696CCF1720FE0682003981E8 /* Observer.swift in Sources */,
 				8392D8FD1DB93E5E00504ED4 /* NSImageView.swift in Sources */,
 				9ADE4A891DA6D206005C2AC8 /* NSControl.swift in Sources */,
 				9AF0EA751D9A7FF700F27DDF /* NSObject+BindingTarget.swift in Sources */,
@@ -1650,6 +1657,7 @@
 				9ADE4A921DA6EA40005C2AC8 /* NSObject+ReactiveExtensionsProvider.swift in Sources */,
 				9ADFE5A61DC0001C001E11F7 /* NSObject+Synchronizing.swift in Sources */,
 				9AD0F06B1D48BA4800ADFAB7 /* NSObject+KeyValueObserving.swift in Sources */,
+				696CCF1820FE069C003981E8 /* Observer.swift in Sources */,
 				4ABEFE1F1DCFCEF60066A8C2 /* UITableView.swift in Sources */,
 				9A1D06081D93EA0000ACF44C /* UIProgressView.swift in Sources */,
 				531866F81DD7920400D1285F /* UIStepper.swift in Sources */,

--- a/ReactiveCocoa/Shared/Observer.swift
+++ b/ReactiveCocoa/Shared/Observer.swift
@@ -1,0 +1,15 @@
+//
+//  Observer.swift
+//  ReactiveCocoa-macOS
+//
+//  Created by Jakub Olejník on 17/07/2018.
+//  Copyright © 2018 GitHub. All rights reserved.
+//
+
+import ReactiveSwift
+
+extension Signal.Observer: BindingTargetProvider {
+	public var bindingTarget: BindingTarget<Value> {
+		return BindingTarget(lifetime: lifetime(of: self)) { [weak self] in self?.send(value: $0) }
+	}
+}

--- a/ReactiveCocoaTests/Shared/Observer.swift
+++ b/ReactiveCocoaTests/Shared/Observer.swift
@@ -1,0 +1,46 @@
+import ReactiveSwift
+import ReactiveCocoa
+import Quick
+import Nimble
+import enum Result.NoError
+
+class ObserverSpec: QuickSpec {
+	override func spec() {
+		typealias SignalType = Signal<Void, NoError>
+		
+		var signal: SignalType!
+		weak var _signal: SignalType?
+		
+		var observer: SignalType.Observer!
+		weak var _observer: SignalType.Observer?
+		
+		beforeEach {
+			let pipe = SignalType.pipe()
+			signal = pipe.output
+			observer = pipe.input
+			
+			_signal = signal
+			_observer = observer
+		}
+		
+		afterEach {
+			signal = nil
+			observer = nil
+			expect(_signal).to(beNil())
+			expect(_observer).to(beNil())
+		}
+		
+		it("should accept changes from bindings") {
+			let (pipeSignal, pipeObserver) = SignalType.pipe()
+			
+			observer <~ pipeSignal
+
+			waitUntil(action: { done in
+				signal.take(first: 1).observeValues {
+					done()
+				}
+				pipeObserver.send(value: ())
+			})
+		}
+	}
+}


### PR DESCRIPTION
#### Checklist
- [x] Updated CHANGELOG.md.

I was wondering whether there is a reason that `Signal.Observer` doesn't conform to `BindingTargetProvider`? 

Sometimes I need to chain some signals so this would come in handy. And I think that code 
```swift
observer <~ action.completed
```

is much more readable than

```swift
action.completed.take(duringLifetimeOf: self).observeValues { [weak self] in self?.observer.send(value: ()) }
```

If there's a reason this not possible, of course close the PR 🙂