### PR TITLE
Add swift version to podspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 *Please put new entries at the top.
 
+1. Add `swift_version` to podspecs
 1. Introduce Lifetime.of(_:) which retrieves the lifetime of any Objective-C or Swift native object. (#3614, kudos to @ra1028)
 
 # 8.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # master
 *Please put new entries at the top.
 
-1. Add `swift_version` to podspecs
+1. Add `swift_version` to podspecs (#3622, kudos to @olejnjak)
 1. Introduce Lifetime.of(_:) which retrieves the lifetime of any Objective-C or Swift native object. (#3614, kudos to @ra1028)
 
 # 8.0.0

--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -26,4 +26,5 @@ Pod::Spec.new do |s|
   s.dependency 'ReactiveSwift', '~> 4.0'
 
   s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
+  s.swift_version = '4.2'
 end

--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.dependency 'ReactiveSwift', '~> 4.0'
 
   s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
-  s.swift_version = '4.2'
+  s.swift_version = '4.1.2'
 end

--- a/ReactiveMapKit.podspec
+++ b/ReactiveMapKit.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.dependency 'ReactiveCocoa', "#{s.version}"
 
   s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
+  s.swift_version = '4.2'
 end

--- a/ReactiveMapKit.podspec
+++ b/ReactiveMapKit.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.dependency 'ReactiveCocoa', "#{s.version}"
 
   s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
-  s.swift_version = '4.2'
+  s.swift_version = '4.1.2'
 end


### PR DESCRIPTION
Now with the latest Xcode release it is unable to integrate ReactiveCocoa without further changes like adding post install hook into Podfile. For libraries that depend on ReactiveCocoa it is even more complicated.

#### Checklist
- [x] Updated CHANGELOG.md.
