### PR TITLE
Change 'impl' to optional

### DIFF
--- a/ReactiveCocoa/NSObject+Intercepting.swift
+++ b/ReactiveCocoa/NSObject+Intercepting.swift
@@ -215,7 +215,7 @@ private func enableMessageForwarding(_ realClass: AnyClass, _ selectorCache: Sel
 			return
 		}
 
-		let impl: IMP = method.map(method_getImplementation) ?? _rac_objc_msgForward
+		let impl: IMP? = method.map(method_getImplementation) ?? _rac_objc_msgForward
 		if impl != _rac_objc_msgForward {
 			// The perceived class, or its ancestors, responds to the selector.
 			//

--- a/ReactiveCocoa/NSObject+Intercepting.swift
+++ b/ReactiveCocoa/NSObject+Intercepting.swift
@@ -215,7 +215,11 @@ private func enableMessageForwarding(_ realClass: AnyClass, _ selectorCache: Sel
 			return
 		}
 
-		let impl: IMP? = method.map(method_getImplementation) ?? _rac_objc_msgForward
+		#if swift(>=4.2)
+			let impl: IMP? = method.map(method_getImplementation) ?? _rac_objc_msgForward
+		#else
+			let impl: IMP = method.map(method_getImplementation) ?? _rac_objc_msgForward
+		#endif
 		if impl != _rac_objc_msgForward {
 			// The perceived class, or its ancestors, responds to the selector.
 			//


### PR DESCRIPTION
I have changed the `impl` variable to optional. Because, it failed to compile in Xcode 10 due to the following error,
`Cannot convert value of type 'OpaquePointer?' to specified type 'IMP' (aka 'OpaquePointer')`