### PR TITLE
Update to ReactiveSwift 6.0 and remove antitypical/Result

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "Carthage/Checkouts/xcconfigs"]
 	path = Carthage/Checkouts/xcconfigs
 	url = https://github.com/jspahrsummers/xcconfigs.git
-[submodule "Carthage/Checkouts/Result"]
-	path = Carthage/Checkouts/Result
-	url = https://github.com/antitypical/Result.git
 [submodule "Carthage/Checkouts/ReactiveSwift"]
 	path = Carthage/Checkouts/ReactiveSwift
 	url = https://github.com/ReactiveCocoa/ReactiveSwift.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # master
 *Please put new entries at the top.
 
+1. Update ReactiveSwift to 6.0
+1. Remove dependency on antitypical/Result
+
 # 9.0.0
 1. Make UITextField and UITextView text and attributedText values non-optional. (#3591, kudos to @Marcocanc)
 1. KVO observations can now be made with Smart Key Path in Swift 3.2+, using `producer(for:)` and `signal(for:)` available on `NSObject.reactive`. (#3491, kudos to @andersio)

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveSwift" ~> 5.0
+github "ReactiveCocoa/ReactiveSwift" ~> 6.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "Quick/Nimble" "v8.0.1"
 github "Quick/Quick" "v2.0.0"
-github "ReactiveCocoa/ReactiveSwift" "5.0.0"
-github "antitypical/Result" "4.1.0"
+github "ReactiveCocoa/ReactiveSwift" "6.0.0"
 github "jspahrsummers/xcconfigs" "3d9d99634cae6d586e272543d527681283b33eb0"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ ReactiveCocoa to your `Cartfile`:
 github "ReactiveCocoa/ReactiveCocoa" ~> 8.0
 ```
 
-If you use Carthage to build your dependencies, make sure you have added `ReactiveCocoa.framework`, `ReactiveSwift.framework`, and `Result.framework` to the "_Linked Frameworks and Libraries_" section of your target, and have included them in your Carthage framework copying build phase.
+If you use Carthage to build your dependencies, make sure you have added `ReactiveCocoa.framework` and `ReactiveSwift.framework` to the "_Linked Frameworks and Libraries_" section of your target, and have included them in your Carthage framework copying build phase.
 
 #### CocoaPods
 
@@ -119,13 +119,10 @@ pod 'ReactiveCocoa', '~> 8.0'
  1. Add the ReactiveCocoa repository as a [submodule][] of your
     application’s repository.
  1. Run `git submodule update --init --recursive` from within the ReactiveCocoa folder.
- 1. Drag and drop `ReactiveCocoa.xcodeproj`,
-    `Carthage/Checkouts/ReactiveSwift/ReactiveSwift.xcodeproj`, and
-    `Carthage/Checkouts/Result/Result.xcodeproj` into your application’s Xcode
+ 1. Drag and drop `ReactiveCocoa.xcodeproj` and `Carthage/Checkouts/ReactiveSwift/ReactiveSwift.xcodeproj` into your application’s Xcode
     project or workspace.
  1. On the “General” tab of your application target’s settings, add
-    `ReactiveCocoa.framework`, `ReactiveSwift.framework`, and `Result.framework`
-    to the “Embedded Binaries” section.
+    `ReactiveCocoa.framework` and `ReactiveSwift.framework` to the “Embedded Binaries” section.
  1. If your application target does not contain Swift code at all, you should also
     set the `EMBEDDED_CONTENT_CONTAINS_SWIFT` build setting to “Yes”.
 

--- a/ReactiveCocoa-iOS.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa-iOS.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -6,14 +6,12 @@
 **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
 - `carthage checkout --no-use-binaries`
 1. Open `ReactiveCocoa.xcworkspace`
-1. Build `Result-iOS` scheme
 1. Build `ReactiveSwift-iOS` scheme
 1. Build `ReactiveCocoa-iOS` scheme
 1. Finally open the `ReactiveCocoa-iOS.playground`
 1. Choose `View > Show Debug Area`
 */
 
-import Result
 import ReactiveCocoa
 import ReactiveSwift
 import UIKit

--- a/ReactiveCocoa-macOS.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa-macOS.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -6,14 +6,12 @@
 **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
 - `carthage checkout --no-use-binaries`
 1. Open `ReactiveCocoa.xcworkspace`
-1. Build `Result-Mac` scheme
 1. Build `ReactiveSwift-macOS` scheme
 1. Build `ReactiveCocoa-macOS` scheme
 1. Finally open the `ReactiveCocoa-macOS.playground`
 1. Choose `View > Show Debug Area`
 */
 
-import Result
 import ReactiveCocoa
 import ReactiveSwift
 import AppKit

--- a/ReactiveCocoa-tvOS.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
+++ b/ReactiveCocoa-tvOS.playground/Pages/Sandbox.xcplaygroundpage/Contents.swift
@@ -6,14 +6,12 @@
 **OR**, if you have [Carthage](https://github.com/Carthage/Carthage) installed
 - `carthage checkout --no-use-binaries`
 1. Open `ReactiveCocoa.xcworkspace`
-1. Build `Result-tvOS` scheme
 1. Build `ReactiveSwift-tvOS` scheme
 1. Build `ReactiveCocoa-tvOS` scheme
 1. Finally open the `ReactiveCocoa-tvOS.playground`
 1. Choose `View > Show Debug Area`
 */
 
-import Result
 import ReactiveCocoa
 import ReactiveSwift
 import UIKit

--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.watchos.source_files = "ReactiveCocoa/WatchKit/*.{swift}"
   s.module_name = 'ReactiveCocoa'
 
-  s.dependency 'ReactiveSwift', '~> 5.0'
+  s.dependency 'ReactiveSwift', '~> 6.0'
 
   s.pod_target_xcconfig = { "OTHER_SWIFT_FLAGS[config=Release]" => "$(inherited) -suppress-warnings" }
   s.swift_version = '4.2'

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -51,7 +51,6 @@
 		538DCB7F1DCA5E9B00332880 /* NSLayoutConstraintSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 538DCB7C1DCA5E9B00332880 /* NSLayoutConstraintSpec.swift */; };
 		53AC46CC1DD6F97400C799E1 /* UISlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AC46CB1DD6F97400C799E1 /* UISlider.swift */; };
 		53AC46CF1DD6FC0000C799E1 /* UISliderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53AC46CE1DD6FC0000C799E1 /* UISliderSpec.swift */; };
-		57A4D2081BA13D7A00F7D4B1 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		57A4D20A1BA13D7A00F7D4B1 /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		654DE7B02205F9DE0048FE14 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D04725EA19E49ED7006002AA /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		654DE7B22205FA0A0048FE14 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D047260C19E49F82006002AA /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -172,20 +171,15 @@
 		9A73DFFE216D3CEE0069AD76 /* MKMapViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A6BED51DD4BD2C0016C058 /* MKMapViewSpec.swift */; };
 		9A73E015216D3E660069AD76 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D04725EA19E49ED7006002AA /* ReactiveCocoa.framework */; };
 		9A73E01C216D3E700069AD76 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D047260C19E49F82006002AA /* ReactiveCocoa.framework */; };
-		9A73E030216D3FAF0069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		9A73E036216D3FC50069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E038216D3FC50069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E039216D3FEB0069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
 		9A73E03A216D3FF10069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
 		9A73E03B216D3FF50069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
 		9A73E03C216D3FFC0069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
 		9A73E03D216D40070069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
 		9A73E03E216D400D0069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E03F216D400D0069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E040216D40170069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E041216D40170069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E042216D40280069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E043216D40280069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E049216D40800069AD76 /* ReactiveMapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73DFCC216D3C570069AD76 /* ReactiveMapKit.framework */; };
 		9A73E04A216D40850069AD76 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */; };
 		9A73E04C216D408D0069AD76 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E04B216D408D0069AD76 /* Nimble.framework */; };
@@ -197,13 +191,9 @@
 		9A73E053216D40C80069AD76 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D04725EA19E49ED7006002AA /* ReactiveCocoa.framework */; };
 		9A73E054216D40CD0069AD76 /* ReactiveMapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AC03A571F7CC3BF00EC33C1 /* ReactiveMapKit.framework */; };
 		9A73E055216D40D10069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E056216D40D10069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E059216D40E30069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E05A216D40E30069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E05B216D40EC0069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E05C216D40EC0069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E05D216D40F70069AD76 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */; };
-		9A73E05E216D40F70069AD76 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A73E037216D3FC50069AD76 /* Result.framework */; };
 		9A73E05F216D41FA0069AD76 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */; };
 		9A7488481E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
 		9A7488491E3B8ACE00CD0317 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */; };
@@ -293,7 +283,6 @@
 		9AFCBFE41EB1ABC0004B4C74 /* KVOKVCExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFCBFE21EB1ABC0004B4C74 /* KVOKVCExtensionSpec.swift */; };
 		9AFCBFE51EB1ABC0004B4C74 /* KVOKVCExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFCBFE21EB1ABC0004B4C74 /* KVOKVCExtensionSpec.swift */; };
 		A91244E820389AEA0001BBCB /* MKLocalSearchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91244E720389AEA0001BBCB /* MKLocalSearchRequest.swift */; };
-		A9B315C91B3940980001CB9C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		A9B315CA1B3940AB0001CB9C /* ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D04725EF19E49ED7006002AA /* ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A9D8BA71207CD7090031733D /* UIResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA70207CD7090031733D /* UIResponder.swift */; };
 		A9D8BA72207CD7090031733D /* UIResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D8BA70207CD7090031733D /* UIResponder.swift */; };
@@ -332,8 +321,6 @@
 		CD8401831CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */; };
 		CD8401841CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */; };
 		CD8401851CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */; };
-		CDC42E2F1AE7AB8B00965373 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
-		CDC42E311AE7AB8B00965373 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; };
 		CDC42E331AE7AC6D00965373 /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDF066CA1CDC1CA200199626 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D05E662419EDD82000904ACA /* Nimble.framework */; };
 		CDF066CB1CDC1CA200199626 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D037672B19EDA75D00A782A9 /* Quick.framework */; };
@@ -660,7 +647,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				57A4D2081BA13D7A00F7D4B1 /* Result.framework in Frameworks */,
 				9A73E03C216D3FFC0069AD76 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -673,7 +659,6 @@
 				CDF066CB1CDC1CA200199626 /* Quick.framework in Frameworks */,
 				7DFBED081CDB8C9500EE435B /* ReactiveCocoa.framework in Frameworks */,
 				9A73E059216D40E30069AD76 /* ReactiveSwift.framework in Frameworks */,
-				9A73E05A216D40E30069AD76 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -681,7 +666,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9A73E043216D40280069AD76 /* Result.framework in Frameworks */,
 				9A73E042216D40280069AD76 /* ReactiveSwift.framework in Frameworks */,
 				9A73E052216D40AC0069AD76 /* ReactiveCocoa.framework in Frameworks */,
 				9A73E051216D40A20069AD76 /* ReactiveMapKit.framework in Frameworks */,
@@ -696,7 +680,6 @@
 			files = (
 				9A73E01C216D3E700069AD76 /* ReactiveCocoa.framework in Frameworks */,
 				9A73E03E216D400D0069AD76 /* ReactiveSwift.framework in Frameworks */,
-				9A73E03F216D400D0069AD76 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -706,7 +689,6 @@
 			files = (
 				9A73E05F216D41FA0069AD76 /* ReactiveCocoa.framework in Frameworks */,
 				9A73E036216D3FC50069AD76 /* ReactiveSwift.framework in Frameworks */,
-				9A73E038216D3FC50069AD76 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -716,7 +698,6 @@
 			files = (
 				9A3C54F121726BD200E98207 /* Nimble.framework in Frameworks */,
 				9A3C54F321726BD200E98207 /* Quick.framework in Frameworks */,
-				9A73E056216D40D10069AD76 /* Result.framework in Frameworks */,
 				9A73E055216D40D10069AD76 /* ReactiveSwift.framework in Frameworks */,
 				9A73E053216D40C80069AD76 /* ReactiveCocoa.framework in Frameworks */,
 				9A73E054216D40CD0069AD76 /* ReactiveMapKit.framework in Frameworks */,
@@ -727,7 +708,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9A73E041216D40170069AD76 /* Result.framework in Frameworks */,
 				9A73E040216D40170069AD76 /* ReactiveSwift.framework in Frameworks */,
 				9A73E04A216D40850069AD76 /* ReactiveCocoa.framework in Frameworks */,
 				9A73E049216D40800069AD76 /* ReactiveMapKit.framework in Frameworks */,
@@ -740,7 +720,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9A73E030216D3FAF0069AD76 /* Result.framework in Frameworks */,
 				9A73E03D216D40070069AD76 /* ReactiveSwift.framework in Frameworks */,
 				9A73E015216D3E660069AD76 /* ReactiveCocoa.framework in Frameworks */,
 			);
@@ -750,7 +729,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A9B315C91B3940980001CB9C /* Result.framework in Frameworks */,
 				9A73E03B216D3FF50069AD76 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -759,7 +737,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CDC42E2F1AE7AB8B00965373 /* Result.framework in Frameworks */,
 				9A73E039216D3FEB0069AD76 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -772,7 +749,6 @@
 				9A3C54ED21726A1200E98207 /* Quick.framework in Frameworks */,
 				D04725F619E49ED7006002AA /* ReactiveCocoa.framework in Frameworks */,
 				9A73E05D216D40F70069AD76 /* ReactiveSwift.framework in Frameworks */,
-				9A73E05E216D40F70069AD76 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -780,7 +756,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CDC42E311AE7AB8B00965373 /* Result.framework in Frameworks */,
 				9A73E03A216D3FF10069AD76 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -793,7 +768,6 @@
 				D037672F19EDA78B00A782A9 /* Quick.framework in Frameworks */,
 				D047261719E49F82006002AA /* ReactiveCocoa.framework in Frameworks */,
 				9A73E05B216D40EC0069AD76 /* ReactiveSwift.framework in Frameworks */,
-				9A73E05C216D40EC0069AD76 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -61,7 +61,6 @@
 		7DFBED1E1CDB8D7000EE435B /* ReactiveCocoa.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 57A4D2411BA13D7A00F7D4B1 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DFBED1F1CDB8D7800EE435B /* Quick.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D037672B19EDA75D00A782A9 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DFBED201CDB8D7D00EE435B /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D05E662419EDD82000904ACA /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7DFBED211CDB8D8300EE435B /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DFBED281CDB8DE300EE435B /* DynamicPropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A2260D1A72F16D00D33B74 /* DynamicPropertySpec.swift */; };
 		7DFBED6D1CDB8F7D00EE435B /* SignalProducerNimbleMatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA6B94A1A76044800C846D1 /* SignalProducerNimbleMatchers.swift */; };
 		834DE1011E4109750099F4E5 /* NSImageViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834DE1001E4109750099F4E5 /* NSImageViewSpec.swift */; };
@@ -321,7 +320,6 @@
 		CD8401831CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */; };
 		CD8401841CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */; };
 		CD8401851CEE8ED7009F0ABF /* CocoaActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */; };
-		CDC42E331AE7AC6D00965373 /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = CDC42E2E1AE7AB8B00965373 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDF066CA1CDC1CA200199626 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D05E662419EDD82000904ACA /* Nimble.framework */; };
 		CDF066CB1CDC1CA200199626 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D037672B19EDA75D00A782A9 /* Quick.framework */; };
 		D01B7B6219EDD8FE00D26E01 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D05E662419EDD82000904ACA /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -425,7 +423,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				7DFBED211CDB8D8300EE435B /* Result.framework in Copy Frameworks */,
 				7DFBED201CDB8D7D00EE435B /* Nimble.framework in Copy Frameworks */,
 				7DFBED1F1CDB8D7800EE435B /* Quick.framework in Copy Frameworks */,
 				7DFBED1E1CDB8D7000EE435B /* ReactiveCocoa.framework in Copy Frameworks */,
@@ -439,7 +436,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				CDC42E331AE7AC6D00965373 /* Result.framework in Copy Frameworks */,
 				D01B7B6219EDD8FE00D26E01 /* Nimble.framework in Copy Frameworks */,
 				D01B7B6319EDD8FE00D26E01 /* Quick.framework in Copy Frameworks */,
 				D01B7B6419EDD94B00D26E01 /* ReactiveCocoa.framework in Copy Frameworks */,
@@ -543,7 +539,6 @@
 		9A73DFF8216D3CEB0069AD76 /* ReactiveMapKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveMapKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A73E013216D3CEE0069AD76 /* ReactiveMapKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReactiveMapKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ReactiveSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A73E037216D3FC50069AD76 /* Result.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A73E04B216D408D0069AD76 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A73E04D216D408D0069AD76 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A7488471E3B8ACE00CD0317 /* DelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxy.swift; sourceTree = "<group>"; };
@@ -606,7 +601,6 @@
 		CD0C45DD1CC9A288009F5BF0 /* DynamicProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicProperty.swift; sourceTree = "<group>"; };
 		CD42C69A1E951F6900AA9504 /* ReactiveCocoaTestsConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveCocoaTestsConfiguration.swift; sourceTree = "<group>"; };
 		CD8401821CEE8ED7009F0ABF /* CocoaActionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaActionSpec.swift; sourceTree = "<group>"; };
-		CDC42E2E1AE7AB8B00965373 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D03766B119EDA60000A782A9 /* test-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "test-data.json"; sourceTree = "<group>"; };
 		D037672B19EDA75D00A782A9 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D04725EA19E49ED7006002AA /* ReactiveCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -906,7 +900,6 @@
 				9A73E04B216D408D0069AD76 /* Nimble.framework */,
 				9A73E04D216D408D0069AD76 /* Quick.framework */,
 				9A73E035216D3FC50069AD76 /* ReactiveSwift.framework */,
-				9A73E037216D3FC50069AD76 /* Result.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1040,7 +1033,6 @@
 				9A1D06751D9415FB00ACF44C /* ObjCRuntimeAliases.h */,
 				9AA0BD971DDE7A2200531FCF /* ObjCRuntimeAliases.m */,
 				9AE7C2A21DDD768500F7534C /* module.modulemap */,
-				CDC42E2E1AE7AB8B00965373 /* Result.framework */,
 				D04725EE19E49ED7006002AA /* Info.plist */,
 			);
 			name = "Supporting Files";

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-iOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-iOS.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D454807C1A957361009D7229"
-               BuildableName = "Result.framework"
-               BlueprintName = "Result-iOS"
-               ReferencedContainer = "container:Carthage/Checkouts/Result/Result.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "D047260B19E49F82006002AA"
                BuildableName = "ReactiveSwift.framework"
                BlueprintName = "ReactiveSwift-iOS"

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-macOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-macOS.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D45480561A9572F5009D7229"
-               BuildableName = "Result.framework"
-               BlueprintName = "Result-Mac"
-               ReferencedContainer = "container:Carthage/Checkouts/Result/Result.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "D04725E919E49ED7006002AA"
                BuildableName = "ReactiveSwift.framework"
                BlueprintName = "ReactiveSwift-macOS"

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-tvOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveCocoa-tvOS.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "57FCDE3C1BA280DC00130C48"
-               BuildableName = "Result.framework"
-               BlueprintName = "Result-tvOS"
-               ReferencedContainer = "container:Carthage/Checkouts/Result/Result.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "57A4D1AF1BA13D7A00F7D4B1"
                BuildableName = "ReactiveSwift.framework"
                BlueprintName = "ReactiveSwift-tvOS"

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveMapKit-iOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveMapKit-iOS.xcscheme
@@ -42,20 +42,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D454807C1A957361009D7229"
-               BuildableName = "Result.framework"
-               BlueprintName = "Result-iOS"
-               ReferencedContainer = "container:Carthage/Checkouts/Result/Result.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "D047260B19E49F82006002AA"
                BuildableName = "ReactiveSwift.framework"
                BlueprintName = "ReactiveSwift-iOS"

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveMapKit-macOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveMapKit-macOS.xcscheme
@@ -42,20 +42,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D45480561A9572F5009D7229"
-               BuildableName = "Result.framework"
-               BlueprintName = "Result-Mac"
-               ReferencedContainer = "container:Carthage/Checkouts/Result/Result.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "D04725E919E49ED7006002AA"
                BuildableName = "ReactiveSwift.framework"
                BlueprintName = "ReactiveSwift-macOS"

--- a/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveMapKit-tvOS.xcscheme
+++ b/ReactiveCocoa.xcodeproj/xcshareddata/xcschemes/ReactiveMapKit-tvOS.xcscheme
@@ -42,20 +42,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "57FCDE3C1BA280DC00130C48"
-               BuildableName = "Result.framework"
-               BlueprintName = "Result-tvOS"
-               ReferencedContainer = "container:Carthage/Checkouts/Result/Result.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "57A4D1AF1BA13D7A00F7D4B1"
                BuildableName = "ReactiveSwift.framework"
                BlueprintName = "ReactiveSwift-tvOS"

--- a/ReactiveCocoa.xcworkspace/contents.xcworkspacedata
+++ b/ReactiveCocoa.xcworkspace/contents.xcworkspacedata
@@ -20,9 +20,6 @@
       location = "group:Carthage/Checkouts/Nimble/Nimble.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:Carthage/Checkouts/Result/Result.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:Carthage/Checkouts/ReactiveSwift/ReactiveSwift.xcodeproj">
    </FileRef>
 </Workspace>

--- a/ReactiveCocoa/AppKit/ActionProxy.swift
+++ b/ReactiveCocoa/AppKit/ActionProxy.swift
@@ -1,18 +1,17 @@
 import AppKit
 import ReactiveSwift
-import enum Result.NoError
 
 internal final class ActionProxy<Owner: AnyObject>: NSObject {
 	internal weak var target: AnyObject?
 	internal var action: Selector?
-	internal let invoked: Signal<Owner, NoError>
+	internal let invoked: Signal<Owner, Never>
 
-	private let observer: Signal<Owner, NoError>.Observer
+	private let observer: Signal<Owner, Never>.Observer
 	private unowned let owner: Owner
 
 	internal init(owner: Owner, lifetime: Lifetime) {
 		self.owner = owner
-		(invoked, observer) = Signal<Owner, NoError>.pipe()
+		(invoked, observer) = Signal<Owner, Never>.pipe()
 		lifetime.ended.observeCompleted(observer.sendCompleted)
 	}
 

--- a/ReactiveCocoa/AppKit/NSButton.swift
+++ b/ReactiveCocoa/AppKit/NSButton.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import AppKit
 
 extension Reactive where Base: NSButton {
@@ -29,7 +28,7 @@ extension Reactive where Base: NSButton {
 
 	#if swift(>=4.0)
 	/// A signal of integer states (On, Off, Mixed), emitted by the button.
-	public var states: Signal<NSControl.StateValue, NoError> {
+	public var states: Signal<NSControl.StateValue, Never> {
 		return proxy.invoked.map { $0.state }
 	}
 
@@ -39,7 +38,7 @@ extension Reactive where Base: NSButton {
 	}
 	#else
 	/// A signal of integer states (On, Off, Mixed), emitted by the button.
-	public var states: Signal<Int, NoError> {
+	public var states: Signal<Int, Never> {
 		return proxy.invoked.map { $0.state }
 	}
 

--- a/ReactiveCocoa/AppKit/NSControl.swift
+++ b/ReactiveCocoa/AppKit/NSControl.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import AppKit
 
 extension NSControl: ActionMessageSending {}
@@ -16,7 +15,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `NSAttributedString`, emitted by the control.
-	public var attributedStringValues: Signal<NSAttributedString, NoError> {
+	public var attributedStringValues: Signal<NSAttributedString, Never> {
 		return proxy.invoked.map { $0.attributedStringValue }
 	}
 
@@ -30,7 +29,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `Bool`, emitted by the control.
-	public var boolValues: Signal<Bool, NoError> {
+	public var boolValues: Signal<Bool, Never> {
 		#if swift(>=4.0)
 		return proxy.invoked.map { $0.integerValue != NSControl.StateValue.off.rawValue }
 		#else
@@ -44,7 +43,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `Double`, emitted by the control.
-	public var doubleValues: Signal<Double, NoError> {
+	public var doubleValues: Signal<Double, Never> {
 		return proxy.invoked.map { $0.doubleValue }
 	}
 
@@ -54,7 +53,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `Float`, emitted by the control.
-	public var floatValues: Signal<Float, NoError> {
+	public var floatValues: Signal<Float, Never> {
 		return proxy.invoked.map { $0.floatValue }
 	}
 
@@ -64,7 +63,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `Int32`, emitted by the control.
-	public var intValues: Signal<Int32, NoError> {
+	public var intValues: Signal<Int32, Never> {
 		return proxy.invoked.map { $0.intValue }
 	}
 
@@ -74,7 +73,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `Int`, emitted by the control.
-	public var integerValues: Signal<Int, NoError> {
+	public var integerValues: Signal<Int, Never> {
 		return proxy.invoked.map { $0.integerValue }
 	}
 
@@ -84,7 +83,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `Any?`, emitted by the control.
-	public var objectValues: Signal<Any?, NoError> {
+	public var objectValues: Signal<Any?, Never> {
 		return proxy.invoked.map { $0.objectValue }
 	}
 
@@ -94,7 +93,7 @@ extension Reactive where Base: NSControl {
 	}
 
 	/// A signal of values in `String`, emitted by the control.
-	public var stringValues: Signal<String, NoError> {
+	public var stringValues: Signal<String, Never> {
 		return proxy.invoked.map { $0.stringValue }
 	}
 }

--- a/ReactiveCocoa/AppKit/NSImageView.swift
+++ b/ReactiveCocoa/AppKit/NSImageView.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import AppKit
 
 extension Reactive where Base: NSImageView {

--- a/ReactiveCocoa/AppKit/NSPopUpButton.swift
+++ b/ReactiveCocoa/AppKit/NSPopUpButton.swift
@@ -1,11 +1,10 @@
 import ReactiveSwift
 import AppKit
-import enum Result.NoError
 
 extension Reactive where Base: NSPopUpButton {
 	
 	/// A signal of selected indexes
-	public var selectedIndexes: Signal<Int, NoError> {
+	public var selectedIndexes: Signal<Int, Never> {
 		return proxy.invoked.map { $0.indexOfSelectedItem }
 	}
 	
@@ -17,7 +16,7 @@ extension Reactive where Base: NSPopUpButton {
 	}
 	
 	/// A signal of selected title
-	public var selectedTitles: Signal<String, NoError> {
+	public var selectedTitles: Signal<String, Never> {
 		return proxy.invoked.map { $0.titleOfSelectedItem }.skipNil()
 	}
 	
@@ -29,13 +28,13 @@ extension Reactive where Base: NSPopUpButton {
 		}
 	}
 
-	public var selectedItems: Signal<NSMenuItem, NoError> {
+	public var selectedItems: Signal<NSMenuItem, Never> {
 		return proxy.invoked.map { $0.selectedItem }.skipNil()
 	}
 
 
 	/// A signal of selected tags
-	public var selectedTags: Signal<Int, NoError> {
+	public var selectedTags: Signal<Int, Never> {
 		return proxy.invoked.map { $0.selectedTag() }
 	}
 

--- a/ReactiveCocoa/AppKit/NSSegmentedControl.swift
+++ b/ReactiveCocoa/AppKit/NSSegmentedControl.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import AppKit
 
 extension Reactive where Base: NSSegmentedControl {
@@ -9,7 +8,7 @@ extension Reactive where Base: NSSegmentedControl {
 	}
 
 	/// A signal of indexes of selections emitted by the segmented control.
-	public var selectedSegments: Signal<Int, NoError> {
+	public var selectedSegments: Signal<Int, Never> {
 		return proxy.invoked.map { $0.selectedSegment }
 	}
 
@@ -18,5 +17,5 @@ extension Reactive where Base: NSSegmentedControl {
 	/// Changes the selected segment of the segmented control.
 	public var selectedSegmentIndex: BindingTarget<Int> { return selectedSegment }
 	/// A signal of indexes of selections emitted by the segmented control.
-	public var selectedSegmentIndexes: Signal<Int, NoError> { return selectedSegments }
+	public var selectedSegmentIndexes: Signal<Int, Never> { return selectedSegments }
 }

--- a/ReactiveCocoa/AppKit/NSSlider.swift
+++ b/ReactiveCocoa/AppKit/NSSlider.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import AppKit
 
 extension Reactive where Base: NSSlider {
@@ -7,5 +6,5 @@ extension Reactive where Base: NSSlider {
 	// Provided for cross-platform compatibility
 
 	public var value: BindingTarget<Float> { return floatValue }
-	public var values: Signal<Float, NoError> { return floatValues }
+	public var values: Signal<Float, Never> { return floatValues }
 }

--- a/ReactiveCocoa/AppKit/NSTextField.swift
+++ b/ReactiveCocoa/AppKit/NSTextField.swift
@@ -1,9 +1,8 @@
 import ReactiveSwift
 import AppKit
-import enum Result.NoError
 
 extension Reactive where Base: NSTextField {
-	private var notifications: Signal<Notification, NoError> {
+	private var notifications: Signal<Notification, Never> {
 		#if swift(>=4.0)
 		let name = NSControl.textDidChangeNotification
 		#else
@@ -17,14 +16,14 @@ extension Reactive where Base: NSTextField {
 	}
 
 	/// A signal of values in `String` from the text field upon any changes.
-	public var continuousStringValues: Signal<String, NoError> {
+	public var continuousStringValues: Signal<String, Never> {
 		return notifications
 			.map { ($0.object as! NSTextField).stringValue }
 	}
 
 	/// A signal of values in `NSAttributedString` from the text field upon any
 	/// changes.
-	public var continuousAttributedStringValues: Signal<NSAttributedString, NoError> {
+	public var continuousAttributedStringValues: Signal<NSAttributedString, Never> {
 		return notifications
 			.map { ($0.object as! NSTextField).attributedStringValue }
 	}

--- a/ReactiveCocoa/AppKit/NSTextView.swift
+++ b/ReactiveCocoa/AppKit/NSTextView.swift
@@ -1,9 +1,8 @@
 import ReactiveSwift
 import AppKit
-import enum Result.NoError
 
 extension Reactive where Base: NSTextView {
-	private var notifications: Signal<Notification, NoError> {
+	private var notifications: Signal<Notification, Never> {
 		#if swift(>=4.0)
 		let name = NSTextView.didChangeNotification
 		#else
@@ -17,7 +16,7 @@ extension Reactive where Base: NSTextView {
 	}
 
 	/// A signal of values in `String` from the text field upon any changes.
-	public var continuousStringValues: Signal<String, NoError> {
+	public var continuousStringValues: Signal<String, Never> {
 		return notifications
 			.map { notification in
 				let textView = notification.object as! NSTextView
@@ -31,7 +30,7 @@ extension Reactive where Base: NSTextView {
 
 	/// A signal of values in `NSAttributedString` from the text field upon any
 	/// changes.
-	public var continuousAttributedStringValues: Signal<NSAttributedString, NoError> {
+	public var continuousAttributedStringValues: Signal<NSAttributedString, Never> {
 		return notifications
 			.map { ($0.object as! NSTextView).attributedString() }
 	}

--- a/ReactiveCocoa/AppKit/NSView.swift
+++ b/ReactiveCocoa/AppKit/NSView.swift
@@ -1,6 +1,5 @@
 import ReactiveSwift
 import AppKit
-import enum Result.NoError
 
 extension Reactive where Base: NSView {
 	/// Sets the visibility of the view.

--- a/ReactiveCocoa/AppKit/ReusableComponents.swift
+++ b/ReactiveCocoa/AppKit/ReusableComponents.swift
@@ -1,16 +1,15 @@
 import AppKit
 import ReactiveSwift
-import enum Result.NoError
 
 extension Reactive where Base: NSView {
-	public var prepareForReuse: Signal<(), NoError> {
+	public var prepareForReuse: Signal<(), Never> {
 		return trigger(for: #selector(base.prepareForReuse))
 	}
 }
 
 extension Reactive where Base: NSObject, Base: NSCollectionViewElement {
 	@available(macOS 10.11, *)
-	public var prepareForReuse: Signal<(), NoError> {
+	public var prepareForReuse: Signal<(), Never> {
 		return trigger(for: #selector(base.prepareForReuse))
 	}
 }

--- a/ReactiveCocoa/CocoaAction.swift
+++ b/ReactiveCocoa/CocoaAction.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ReactiveSwift
-import enum Result.NoError
 
 /// CocoaAction wraps an `Action` for use by a UI control (such as `NSControl` or
 /// `UIControl`).

--- a/ReactiveCocoa/CocoaTarget.swift
+++ b/ReactiveCocoa/CocoaTarget.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ReactiveSwift
-import enum Result.NoError
 
 /// A target that accepts action messages.
 internal final class CocoaTarget<Value>: NSObject {
@@ -9,12 +8,12 @@ internal final class CocoaTarget<Value>: NSObject {
 		case sending(queue: [Value])
 	}
 
-	private let observer: Signal<Value, NoError>.Observer
+	private let observer: Signal<Value, Never>.Observer
 	private let transform: (Any?) -> Value
 
 	private var state: State
 
-	internal init(_ observer: Signal<Value, NoError>.Observer, transform: @escaping (Any?) -> Value) {
+	internal init(_ observer: Signal<Value, Never>.Observer, transform: @escaping (Any?) -> Value) {
 		self.observer = observer
 		self.transform = transform
 		self.state = .idle
@@ -53,7 +52,7 @@ internal final class CocoaTarget<Value>: NSObject {
 }
 
 extension CocoaTarget where Value == Void {
-	internal convenience init(_ observer: Signal<(), NoError>.Observer) {
+	internal convenience init(_ observer: Signal<(), Never>.Observer) {
 		self.init(observer, transform: { _ in })
 	}
 }

--- a/ReactiveCocoa/DelegateProxy.swift
+++ b/ReactiveCocoa/DelegateProxy.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 
 internal class DelegateProxy<Delegate: NSObjectProtocol>: NSObject {
 	internal weak var forwardee: Delegate? {
@@ -22,13 +21,13 @@ internal class DelegateProxy<Delegate: NSObjectProtocol>: NSObject {
 		return interceptedSelectors.contains(selector) ? nil : forwardee
 	}
 
-	func intercept(_ selector: Selector) -> Signal<(), NoError> {
+	func intercept(_ selector: Selector) -> Signal<(), Never> {
 		interceptedSelectors.insert(selector)
 		originalSetter(self)
 		return self.reactive.trigger(for: selector).take(during: lifetime)
 	}
 
-	func intercept(_ selector: Selector) -> Signal<[Any?], NoError> {
+	func intercept(_ selector: Selector) -> Signal<[Any?], Never> {
 		interceptedSelectors.insert(selector)
 		originalSetter(self)
 		return self.reactive.signal(for: selector).take(during: lifetime)

--- a/ReactiveCocoa/Deprecations+Removals.swift
+++ b/ReactiveCocoa/Deprecations+Removals.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 
 extension Action {
 	@available(*, unavailable, message:"Use the `CocoaAction` initializers instead.")
@@ -8,7 +7,7 @@ extension Action {
 
 extension Reactive where Base: NSObject {
 	@available(*, deprecated, renamed: "producer(forKeyPath:)")
-	public func values(forKeyPath keyPath: String) -> SignalProducer<Any?, NoError> {
+	public func values(forKeyPath keyPath: String) -> SignalProducer<Any?, Never> {
 		return producer(forKeyPath: keyPath)
 	}
 }

--- a/ReactiveCocoa/DynamicProperty.swift
+++ b/ReactiveCocoa/DynamicProperty.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ReactiveSwift
-import enum Result.NoError
 
 /// A typed mutable property view to a certain key path of an Objective-C object using
 /// Key-Value Coding and Key-Value Observing.
@@ -38,11 +37,11 @@ public final class DynamicProperty<Value>: MutablePropertyProtocol {
 	///
 	/// - important: This only works if the object given to init() is KVO-compliant.
 	///              Most UI controls are not!
-	public var producer: SignalProducer<Value, NoError> {
+	public var producer: SignalProducer<Value, Never> {
 		return cache.producer
 	}
 
-	public var signal: Signal<Value, NoError> {
+	public var signal: Signal<Value, Never> {
 		return cache.signal
 	}
 

--- a/ReactiveCocoa/NSObject+Intercepting.swift
+++ b/ReactiveCocoa/NSObject+Intercepting.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ReactiveSwift
-import enum Result.NoError
 
 /// Whether the runtime subclass has already been prepared for method
 /// interception.
@@ -27,7 +26,7 @@ extension Reactive where Base: NSObject {
 	///   - selector: The selector to observe.
 	///
 	/// - returns: A trigger signal.
-	public func trigger(for selector: Selector) -> Signal<(), NoError> {
+	public func trigger(for selector: Selector) -> Signal<(), Never> {
 		return base.intercept(selector).map { _ in }
 	}
 
@@ -44,7 +43,7 @@ extension Reactive where Base: NSObject {
 	///   - selector: The selector to observe.
 	///
 	/// - returns: A signal that sends an array of bridged arguments.
-	public func signal(for selector: Selector) -> Signal<[Any?], NoError> {
+	public func signal(for selector: Selector) -> Signal<[Any?], Never> {
 		return base.intercept(selector).map(unpackInvocation)
 	}
 }
@@ -58,7 +57,7 @@ extension NSObject {
 	///
 	/// - returns: A signal that sends the corresponding `NSInvocation` after 
 	///            every invocation of the method.
-	@nonobjc fileprivate func intercept(_ selector: Selector) -> Signal<AnyObject, NoError> {
+	@nonobjc fileprivate func intercept(_ selector: Selector) -> Signal<AnyObject, Never> {
 		guard let method = class_getInstanceMethod(objcClass, selector) else {
 			fatalError("Selector `\(selector)` does not exist in class `\(String(describing: objcClass))`.")
 		}
@@ -278,7 +277,7 @@ private func setupMethodSignatureCaching(_ realClass: AnyClass, _ signatureCache
 
 /// The state of an intercepted method specific to an instance.
 private final class InterceptingState {
-	let (signal, observer) = Signal<AnyObject, NoError>.pipe()
+	let (signal, observer) = Signal<AnyObject, Never>.pipe()
 
 	/// Initialize a state specific to an instance.
 	///

--- a/ReactiveCocoa/NSObject+KeyValueObserving.swift
+++ b/ReactiveCocoa/NSObject+KeyValueObserving.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ReactiveSwift
-import enum Result.NoError
 
 extension Reactive where Base: NSObject {
 	/// Create a producer which sends the current value and all the subsequent
@@ -13,7 +12,7 @@ extension Reactive where Base: NSObject {
 	///
 	/// - returns: A producer emitting values of the property specified by the
 	///            key path.
-	public func producer(forKeyPath keyPath: String) -> SignalProducer<Any?, NoError> {
+	public func producer(forKeyPath keyPath: String) -> SignalProducer<Any?, Never> {
 		return SignalProducer { observer, lifetime in
 			let disposable = KeyValueObserver.observe(
 				self.base,
@@ -42,7 +41,7 @@ extension Reactive where Base: NSObject {
 	///
 	/// - returns: A producer emitting values of the property specified by the 
 	///            key path.
-	public func signal(forKeyPath keyPath: String) -> Signal<Any?, NoError> {
+	public func signal(forKeyPath keyPath: String) -> Signal<Any?, Never> {
 		return Signal { observer, signalLifetime in
 			signalLifetime += KeyValueObserver.observe(
 				self.base,
@@ -57,7 +56,7 @@ extension Reactive where Base: NSObject {
 	private func producer<U>(
 		for keyPath: KeyPath<Base, U>,
 		transform: @escaping (Any?) -> U
-	) -> SignalProducer<U, NoError> {
+	) -> SignalProducer<U, Never> {
 		guard let kvcKeyPath = keyPath._kvcKeyPathString else {
 			fatalError("Cannot use `producer(for:)` on a non Objective-C property.")
 		}
@@ -77,7 +76,7 @@ extension Reactive where Base: NSObject {
 	private func signal<U>(
 		for keyPath: KeyPath<Base, U>,
 		transform: @escaping (Any?) -> U
-	) -> Signal<U, NoError> {
+	) -> Signal<U, Never> {
 		guard let kvcKeyPath = keyPath._kvcKeyPathString else {
 			fatalError("Cannot use `signal(for:)` on a non Objective-C property.")
 		}
@@ -103,7 +102,7 @@ extension Reactive where Base: NSObject {
 	///
 	/// - returns: A producer emitting values of the property specified by the
 	///            key path.
-	public func producer<U>(for keyPath: KeyPath<Base, U?>) -> SignalProducer<U?, NoError> {
+	public func producer<U>(for keyPath: KeyPath<Base, U?>) -> SignalProducer<U?, Never> {
 		return producer(for: keyPath) { $0 as! U? }
 	}
 
@@ -119,7 +118,7 @@ extension Reactive where Base: NSObject {
 	///
 	/// - returns: A producer emitting values of the property specified by the
 	///            key path.
-	public func signal<U>(for keyPath: KeyPath<Base, U?>) -> Signal<U?, NoError> {
+	public func signal<U>(for keyPath: KeyPath<Base, U?>) -> Signal<U?, Never> {
 		return signal(for: keyPath) { $0 as! U? }
 	}
 
@@ -133,7 +132,7 @@ extension Reactive where Base: NSObject {
 	///
 	/// - returns: A producer emitting values of the property specified by the
 	///            key path.
-	public func producer<U>(for keyPath: KeyPath<Base, U>) -> SignalProducer<U, NoError> {
+	public func producer<U>(for keyPath: KeyPath<Base, U>) -> SignalProducer<U, Never> {
 		return producer(for: keyPath) { $0 as! U }
 	}
 
@@ -149,7 +148,7 @@ extension Reactive where Base: NSObject {
 	///
 	/// - returns: A producer emitting values of the property specified by the
 	///            key path.
-	public func signal<U>(for keyPath: KeyPath<Base, U>) -> Signal<U, NoError> {
+	public func signal<U>(for keyPath: KeyPath<Base, U>) -> Signal<U, Never> {
 		return signal(for: keyPath) { $0 as! U }
 	}
 }
@@ -186,10 +185,10 @@ extension Property {
 // `Property(_:)` uses only the producer is explioted here to achieve the same effect.
 private final class UnsafeKVOProperty<Value>: PropertyProtocol {
 	var value: Value { fatalError() }
-	var signal: Signal<Value, NoError> { fatalError() }
-	let producer: SignalProducer<Value, NoError>
+	var signal: Signal<Value, Never> { fatalError() }
+	let producer: SignalProducer<Value, Never>
 	
-	init(producer: SignalProducer<Value, NoError>) {
+	init(producer: SignalProducer<Value, Never>) {
 		self.producer = producer
 	}
 	

--- a/ReactiveCocoa/UIKit/ReusableComponents.swift
+++ b/ReactiveCocoa/UIKit/ReusableComponents.swift
@@ -1,13 +1,12 @@
 import UIKit
 import ReactiveSwift
-import enum Result.NoError
 
 @objc public protocol Reusable: class {
 	func prepareForReuse()
 }
 
 extension Reactive where Base: NSObject, Base: Reusable {
-	public var prepareForReuse: Signal<(), NoError> {
+	public var prepareForReuse: Signal<(), Never> {
 		return trigger(for: #selector(base.prepareForReuse))
 	}
 }

--- a/ReactiveCocoa/UIKit/UIControl.swift
+++ b/ReactiveCocoa/UIKit/UIControl.swift
@@ -1,6 +1,5 @@
 import ReactiveSwift
 import UIKit
-import enum Result.NoError
 
 extension Reactive where Base: UIControl {
 	/// The current associated action of `self`, with its registered event mask
@@ -48,7 +47,7 @@ extension Reactive where Base: UIControl {
 	///   - controlEvents: The control event mask.
 	///
 	/// - returns: A signal that sends the control each time the control event occurs.
-	public func controlEvents(_ controlEvents: UIControl.Event) -> Signal<Base, NoError> {
+	public func controlEvents(_ controlEvents: UIControl.Event) -> Signal<Base, Never> {
 		return mapControlEvents(controlEvents, { $0 })
 	}
 
@@ -71,7 +70,7 @@ extension Reactive where Base: UIControl {
 	///
 	/// - returns: A signal that sends the reduced value from the control each time the
 	///            control event occurs.
-	public func mapControlEvents<Value>(_ controlEvents: UIControl.Event, _ transform: @escaping (Base) -> Value) -> Signal<Value, NoError> {
+	public func mapControlEvents<Value>(_ controlEvents: UIControl.Event, _ transform: @escaping (Base) -> Value) -> Signal<Value, Never> {
 		return Signal { observer, signalLifetime in
 			let receiver = CocoaTarget(observer) { transform($0 as! Base) }
 			base.addTarget(receiver,
@@ -91,7 +90,7 @@ extension Reactive where Base: UIControl {
 	}
 
 	@available(*, unavailable, renamed: "controlEvents(_:)")
-	public func trigger(for controlEvents: UIControl.Event) -> Signal<(), NoError> {
+	public func trigger(for controlEvents: UIControl.Event) -> Signal<(), Never> {
 		fatalError()
 	}
 

--- a/ReactiveCocoa/UIKit/UIGestureRecognizer.swift
+++ b/ReactiveCocoa/UIKit/UIGestureRecognizer.swift
@@ -1,12 +1,11 @@
 import ReactiveSwift
 import UIKit
-import enum Result.NoError
 
 extension Reactive where Base: UIGestureRecognizer {
 	/// Create a signal which sends a `next` event for each gesture event
 	///
 	/// - returns: A trigger signal.
-	public var stateChanged: Signal<Base, NoError> {
+	public var stateChanged: Signal<Base, Never> {
 		return Signal { observer, signalLifetime in
 			let receiver = CocoaTarget<Base>(observer) { gestureRecognizer in
 				return gestureRecognizer as! Base

--- a/ReactiveCocoa/UIKit/UISegmentedControl.swift
+++ b/ReactiveCocoa/UIKit/UISegmentedControl.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UISegmentedControl {
@@ -9,7 +8,7 @@ extension Reactive where Base: UISegmentedControl {
 	}
 
 	/// A signal of indexes of selections emitted by the segmented control.
-	public var selectedSegmentIndexes: Signal<Int, NoError> {
+	public var selectedSegmentIndexes: Signal<Int, Never> {
 		return mapControlEvents(.valueChanged) { $0.selectedSegmentIndex }
 	}
 }

--- a/ReactiveCocoa/UIKit/UITextField.swift
+++ b/ReactiveCocoa/UIKit/UITextField.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UITextField {
@@ -12,14 +11,14 @@ extension Reactive where Base: UITextField {
 	///
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
-	public var textValues: Signal<String, NoError> {
+	public var textValues: Signal<String, Never> {
 		return mapControlEvents([.editingDidEnd, .editingDidEndOnExit]) { $0.text ?? "" }
 	}
 
 	/// A signal of text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
-	public var continuousTextValues: Signal<String, NoError> {
+	public var continuousTextValues: Signal<String, Never> {
 		return mapControlEvents(.allEditingEvents) { $0.text ?? "" }
 	}
 	
@@ -42,14 +41,14 @@ extension Reactive where Base: UITextField {
 	///
 	/// - note: To observe attributed text values that change on all editing events,
 	///   see `continuousAttributedTextValues`.
-	public var attributedTextValues: Signal<NSAttributedString, NoError> {
+	public var attributedTextValues: Signal<NSAttributedString, Never> {
 		return mapControlEvents([.editingDidEnd, .editingDidEndOnExit]) { $0.attributedText ?? NSAttributedString() }
 	}
 	
 	/// A signal of attributed text values emitted by the text field upon any changes.
 	///
 	/// - note: To observe attributed text values only when editing ends, see `attributedTextValues`.
-	public var continuousAttributedTextValues: Signal<NSAttributedString, NoError> {
+	public var continuousAttributedTextValues: Signal<NSAttributedString, Never> {
 		return mapControlEvents(.allEditingEvents) { $0.attributedText ?? NSAttributedString() }
 	}
 

--- a/ReactiveCocoa/UIKit/UITextView.swift
+++ b/ReactiveCocoa/UIKit/UITextView.swift
@@ -1,6 +1,5 @@
 import ReactiveSwift
 import UIKit
-import enum Result.NoError
 
 private class TextViewDelegateProxy: DelegateProxy<UITextViewDelegate>, UITextViewDelegate {
 	@objc func textViewDidChangeSelection(_ textView: UITextView) {
@@ -20,7 +19,7 @@ extension Reactive where Base: UITextView {
 		return makeBindingTarget { $0.text = $1 }
 	}
 
-	private func textValues(forName name: NSNotification.Name) -> Signal<String, NoError> {
+	private func textValues(forName name: NSNotification.Name) -> Signal<String, Never> {
 		return NotificationCenter.default
 			.reactive
 			.notifications(forName: name, object: base)
@@ -32,14 +31,14 @@ extension Reactive where Base: UITextView {
 	///
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
-	public var textValues: Signal<String, NoError> {
+	public var textValues: Signal<String, Never> {
 		return textValues(forName: UITextView.textDidEndEditingNotification)
 	}
 
 	/// A signal of text values emitted by the text view upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
-	public var continuousTextValues: Signal<String, NoError> {
+	public var continuousTextValues: Signal<String, Never> {
 		return textValues(forName: UITextView.textDidChangeNotification)
 	}
 	
@@ -48,7 +47,7 @@ extension Reactive where Base: UITextView {
 		return makeBindingTarget { $0.attributedText = $1 }
 	}
 	
-	private func attributedTextValues(forName name: NSNotification.Name) -> Signal<NSAttributedString, NoError> {
+	private func attributedTextValues(forName name: NSNotification.Name) -> Signal<NSAttributedString, Never> {
 		return NotificationCenter.default
 			.reactive
 			.notifications(forName: name, object: base)
@@ -60,19 +59,19 @@ extension Reactive where Base: UITextView {
 	///
 	/// - note: To observe attributed text values that change on all editing events,
 	///   see `continuousAttributedTextValues`.
-	public var attributedTextValues: Signal<NSAttributedString, NoError> {
+	public var attributedTextValues: Signal<NSAttributedString, Never> {
 		return attributedTextValues(forName: UITextView.textDidEndEditingNotification)
 	}
 	
 	/// A signal of attributed text values emitted by the text view upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `attributedTextValues`.
-	public var continuousAttributedTextValues: Signal<NSAttributedString, NoError> {
+	public var continuousAttributedTextValues: Signal<NSAttributedString, Never> {
 		return attributedTextValues(forName: UITextView.textDidChangeNotification)
 	}
 
 	/// A signal of range values emitted by the text view upon any selection change.
-	public var selectedRangeValues: Signal<NSRange, NoError> {
+	public var selectedRangeValues: Signal<NSRange, Never> {
 		return proxy.intercept(#selector(UITextViewDelegate.textViewDidChangeSelection))
 			.map { [unowned base] in base.selectedRange }
 	}

--- a/ReactiveCocoa/UIKit/UIViewController.swift
+++ b/ReactiveCocoa/UIKit/UIViewController.swift
@@ -1,6 +1,5 @@
 import ReactiveSwift
 import UIKit
-import enum Result.NoError
 
 extension Reactive where Base: UIViewController {
 	/// Set's the title of the view controller.
@@ -9,32 +8,32 @@ extension Reactive where Base: UIViewController {
 	}
 
 	/// A signal that sends a value event every time `viewWillAppear` is invoked.
-	public var viewWillAppear: Signal<Void, NoError> {
+	public var viewWillAppear: Signal<Void, Never> {
 		return trigger(for: #selector(Base.viewWillAppear))
 	}
 
 	/// A signal that sends a value event every time `viewDidAppear` is invoked.
-	public var viewDidAppear: Signal<Void, NoError> {
+	public var viewDidAppear: Signal<Void, Never> {
 		return trigger(for: #selector(Base.viewDidAppear))
 	}
 
 	/// A signal that sends a value event every time `viewWillDisappear` is invoked.
-	public var viewWillDisappear: Signal<Void, NoError> {
+	public var viewWillDisappear: Signal<Void, Never> {
 		return trigger(for: #selector(Base.viewWillDisappear))
 	}
 
 	/// A signal that sends a value event every time `viewDidDisappear` is invoked.
-	public var viewDidDisappear: Signal<Void, NoError> {
+	public var viewDidDisappear: Signal<Void, Never> {
 		return trigger(for: #selector(Base.viewDidDisappear))
 	}
 
 	/// A signal that sends a value event every time `viewWillLayoutSubviews` is invoked.
-	public var viewWillLayoutSubviews: Signal<Void, NoError> {
+	public var viewWillLayoutSubviews: Signal<Void, Never> {
 		return trigger(for: #selector(Base.viewWillLayoutSubviews))
 	}
 
 	/// A signal that sends a value event every time `viewDidLayoutSubviews` is invoked.
-	public var viewDidLayoutSubviews: Signal<Void, NoError> {
+	public var viewDidLayoutSubviews: Signal<Void, Never> {
 		return trigger(for: #selector(Base.viewDidLayoutSubviews))
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIDatePicker.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UIDatePicker {
@@ -9,7 +8,7 @@ extension Reactive where Base: UIDatePicker {
 	}
 
 	/// A signal of dates emitted by the date picker.
-	public var dates: Signal<Date, NoError> {
+	public var dates: Signal<Date, Never> {
 		return mapControlEvents(.valueChanged) { $0.date }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIKeyboard.swift
@@ -1,6 +1,5 @@
 import UIKit
 import ReactiveSwift
-import enum Result.NoError
 
 /// The type of system keyboard events.
 public enum KeyboardEvent {
@@ -81,7 +80,7 @@ extension Reactive where Base: NotificationCenter {
 	///   - event:  The type of system keyboard event to observe.
 	///
 	/// - returns: A `Signal` that emits the context of system keyboard event.
-	public func keyboard(_ event: KeyboardEvent) -> Signal<KeyboardChangeContext, NoError> {
+	public func keyboard(_ event: KeyboardEvent) -> Signal<KeyboardChangeContext, Never> {
 		return notifications(forName: event.notificationName)
 			.map { notification in KeyboardChangeContext(userInfo: notification.userInfo!, event: event) }
 	}
@@ -94,7 +93,7 @@ extension Reactive where Base: NotificationCenter {
 	///   - tail: Rest of the types of system keyboard events to observe.
 	///
 	/// - returns: A `Signal` that emits the context of system keyboard events.
-	public func keyboard(_ first: KeyboardEvent, _ second: KeyboardEvent, _ tail: KeyboardEvent...) -> Signal<KeyboardChangeContext, NoError> {
+	public func keyboard(_ first: KeyboardEvent, _ second: KeyboardEvent, _ tail: KeyboardEvent...) -> Signal<KeyboardChangeContext, Never> {
 		let events = [first, second] + tail
 		return .merge(events.map(keyboard))
 	}
@@ -104,7 +103,7 @@ extension Reactive where Base: NotificationCenter {
 	///
 	/// - returns: A `Signal` that emits the context of every change in the
 	///            system keyboard's frame.
-	public var keyboardChange: Signal<KeyboardChangeContext, NoError> {
+	public var keyboardChange: Signal<KeyboardChangeContext, Never> {
 		return keyboard(.willChangeFrame)
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIPickerView.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 private class PickerViewDelegateProxy: DelegateProxy<UIPickerViewDelegate>, UIPickerViewDelegate {
@@ -35,7 +34,7 @@ extension Reactive where Base: UIPickerView {
 	/// Create a signal which sends a `value` event for each row selection
 	///
 	/// - returns: A trigger signal.
-	public var selections: Signal<(row: Int, component: Int), NoError> {
+	public var selections: Signal<(row: Int, component: Int), Never> {
 		return proxy.intercept(#selector(UIPickerViewDelegate.pickerView(_:didSelectRow:inComponent:)))
 			.map { (row: $0[1] as! Int, component: $0[2] as! Int) }
 	}

--- a/ReactiveCocoa/UIKit/iOS/UIRefreshControl.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIRefreshControl.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UIRefreshControl {

--- a/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISearchBar.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 private class SearchBarDelegateProxy: DelegateProxy<UISearchBarDelegate>, UISearchBarDelegate {
@@ -57,7 +56,7 @@ extension Reactive where Base: UISearchBar {
 	///
 	/// - note: To observe text values that change on all editing events,
 	///   see `continuousTextValues`.
-	public var textValues: Signal<String?, NoError> {
+	public var textValues: Signal<String?, Never> {
 		return proxy.intercept(#selector(UISearchBarDelegate.searchBarTextDidEndEditing))
 			.map { [unowned base] in base.text }
 	}
@@ -65,44 +64,44 @@ extension Reactive where Base: UISearchBar {
 	/// A signal of text values emitted by the search bar upon any changes.
 	///
 	/// - note: To observe text values only when editing ends, see `textValues`.
-	public var continuousTextValues: Signal<String?, NoError> {
+	public var continuousTextValues: Signal<String?, Never> {
 		return proxy.intercept(#selector(proxy.searchBar(_:textDidChange:)))
 			.map { [unowned base] in base.text }
 	}
 
 	/// A signal of the latest selected scope button index upon any user selection.
-	public var selectedScopeButtonIndices: Signal<Int, NoError> {
+	public var selectedScopeButtonIndices: Signal<Int, Never> {
 		return proxy.intercept(#selector(proxy.searchBar(_:selectedScopeButtonIndexDidChange:)))
 			.map { $0[1] as! Int }
 	}
 
 	/// A void signal emitted by the search bar upon any click on the cancel button
-	public var cancelButtonClicked: Signal<Void, NoError> {
+	public var cancelButtonClicked: Signal<Void, Never> {
 		return proxy.intercept(#selector(proxy.searchBarCancelButtonClicked))
 	}
 
 	/// A void signal emitted by the search bar upon any click on the search button
-	public var searchButtonClicked: Signal<Void, NoError> {
+	public var searchButtonClicked: Signal<Void, Never> {
 		return proxy.intercept(#selector(proxy.searchBarSearchButtonClicked(_:)))
 	}
 
 	/// A void signal emitted by the search bar upon any click on the bookmark button
-	public var bookmarkButtonClicked: Signal<Void, NoError> {
+	public var bookmarkButtonClicked: Signal<Void, Never> {
 		return proxy.intercept(#selector(proxy.searchBarBookmarkButtonClicked))
 	}
 
 	/// A void signal emitted by the search bar upon any click on the bookmark button
-	public var resultsListButtonClicked: Signal<Void, NoError> {
+	public var resultsListButtonClicked: Signal<Void, Never> {
 		return proxy.intercept(#selector(proxy.searchBarResultsListButtonClicked))
 	}
 
 	/// A void signal emitted by the search bar upon start of editing
-	public var textDidBeginEditing: Signal<Void, NoError> {
+	public var textDidBeginEditing: Signal<Void, Never> {
 		return proxy.intercept(#selector(proxy.searchBarTextDidBeginEditing))
 	}
 
 	/// A void signal emitted by the search bar upon end of editing
-	public var textDidEndEditing: Signal<Void, NoError> {
+	public var textDidEndEditing: Signal<Void, Never> {
 		return proxy.intercept(#selector(proxy.searchBarTextDidEndEditing))
 	}
 

--- a/ReactiveCocoa/UIKit/iOS/UISlider.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISlider.swift
@@ -1,6 +1,5 @@
 import UIKit
 import ReactiveSwift
-import enum Result.NoError
 
 extension Reactive where Base: UISlider {
 
@@ -24,7 +23,7 @@ extension Reactive where Base: UISlider {
 	///
 	/// - note: If slider's `isContinuous` property is `false` then values are
 	///         sent only when user releases the slider.
-	public var values: Signal<Float, NoError> {
+	public var values: Signal<Float, Never> {
 		return mapControlEvents(.valueChanged) { $0.value }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UIStepper.swift
+++ b/ReactiveCocoa/UIKit/iOS/UIStepper.swift
@@ -1,6 +1,5 @@
 import UIKit
 import ReactiveSwift
-import enum Result.NoError
 
 extension Reactive where Base: UIStepper {
 
@@ -21,7 +20,7 @@ extension Reactive where Base: UIStepper {
 
 	/// A signal of double values emitted by the stepper upon each user's
 	/// interaction.
-	public var values: Signal<Double, NoError> {
+	public var values: Signal<Double, Never> {
 		return mapControlEvents(.valueChanged) { $0.value }
 	}
 }

--- a/ReactiveCocoa/UIKit/iOS/UISwitch.swift
+++ b/ReactiveCocoa/UIKit/iOS/UISwitch.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 extension Reactive where Base: UISwitch {
@@ -24,7 +23,7 @@ extension Reactive where Base: UISwitch {
 	}
 
 	/// A signal of on-off states in `Bool` emitted by the switch.
-	public var isOnValues: Signal<Bool, NoError> {
+	public var isOnValues: Signal<Bool, Never> {
 		return mapControlEvents(.valueChanged) { $0.isOn }
 	}
 }

--- a/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
+++ b/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import enum Result.NoError
 import ReactiveSwift
 @testable import ReactiveCocoa
 

--- a/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
@@ -3,7 +3,6 @@ import Nimble
 import ReactiveSwift
 import ReactiveCocoa
 import AppKit
-import enum Result.NoError
 
 class NSButtonSpec: QuickSpec {
 	override func spec() {
@@ -30,7 +29,7 @@ class NSButtonSpec: QuickSpec {
 		it("should accept changes from bindings to its enabling state") {
 			button.isEnabled = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			button.reactive.isEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -44,7 +43,7 @@ class NSButtonSpec: QuickSpec {
 			button.allowsMixedState = true
 			button.state = RACNSOffState
 
-			let (pipeSignal, observer) = Signal<RACNSControlState, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<RACNSControlState, Never>.pipe()
 			button.reactive.state <~ SignalProducer(pipeSignal)
 
 			observer.send(value: RACNSOffState)
@@ -129,8 +128,8 @@ class NSButtonSpec: QuickSpec {
 
 			let pressed = MutableProperty(false)
 
-			let (executionSignal, observer) = Signal<Bool, NoError>.pipe()
-			let action = Action<(), Bool, NoError> { _ in
+			let (executionSignal, observer) = Signal<Bool, Never>.pipe()
+			let action = Action<(), Bool, Never> { _ in
 				SignalProducer(executionSignal)
 			}
 

--- a/ReactiveCocoaTests/AppKit/NSCollectionViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSCollectionViewSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveCocoa
 import ReactiveSwift
-import Result
 import AppKit
 
 @available(macOS 10.11, *)
@@ -15,13 +14,13 @@ final class NSCollectionViewSpec: QuickSpec {
 		}
 
 		describe("reloadData") {
-			var bindingSignal: Signal<(), NoError>!
-			var bindingObserver: Signal<(), NoError>.Observer!
+			var bindingSignal: Signal<(), Never>!
+			var bindingObserver: Signal<(), Never>.Observer!
 
 			var reloadDataCount = 0
 
 			beforeEach {
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				(bindingSignal, bindingObserver) = (signal, observer)
 
 				reloadDataCount = 0
@@ -45,8 +44,8 @@ final class NSCollectionViewSpec: QuickSpec {
 
 @available(macOS 10.11, *)
 private final class TestCollectionView: NSCollectionView {
-	let reloadDataSignal: Signal<(), NoError>
-	private let reloadDataObserver: Signal<(), NoError>.Observer
+	let reloadDataSignal: Signal<(), Never>
+	private let reloadDataObserver: Signal<(), Never>.Observer
 
 	override init(frame: CGRect) {
 		(reloadDataSignal, reloadDataObserver) = Signal.pipe()

--- a/ReactiveCocoaTests/AppKit/NSControlSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSControlSpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import Result
 import ReactiveSwift
 import ReactiveCocoa
 import AppKit

--- a/ReactiveCocoaTests/AppKit/NSImageViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSImageViewSpec.swift
@@ -3,7 +3,6 @@ import Nimble
 import ReactiveSwift
 import ReactiveCocoa
 import AppKit
-import enum Result.NoError
 
 class NSImageViewSpec: QuickSpec {
 	override func spec() {
@@ -23,7 +22,7 @@ class NSImageViewSpec: QuickSpec {
 		it("should accept changes from bindings to its enabling state") {
 			imageView.isEnabled = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			imageView.reactive.isEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -35,7 +34,7 @@ class NSImageViewSpec: QuickSpec {
 
 		it("should accept changes from bindings to its image") {
 
-			let (pipeSignal, observer) = Signal<NSImage?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<NSImage?, Never>.pipe()
 			imageView.reactive.image <~ SignalProducer(pipeSignal)
 
 			let theImage = NSImage(named: NSImage.userName)

--- a/ReactiveCocoaTests/AppKit/NSPopUpButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSPopUpButtonSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveCocoa
 import ReactiveSwift
-import Result
 import AppKit
 
 final class NSPopUpButtonSpec: QuickSpec {
@@ -56,7 +55,7 @@ final class NSPopUpButtonSpec: QuickSpec {
 			}
 			
 			it("should accept changes from its bindings to its index values") {
-				let (signal, observer) = Signal<Int?, NoError>.pipe()
+				let (signal, observer) = Signal<Int?, Never>.pipe()
 				button.reactive.selectedIndex <~ SignalProducer(signal)
 				
 				observer.send(value: 1)
@@ -71,7 +70,7 @@ final class NSPopUpButtonSpec: QuickSpec {
 			}
 			
 			it("should accept changes from its bindings to its title values") {
-				let (signal, observer) = Signal<String?, NoError>.pipe()
+				let (signal, observer) = Signal<String?, Never>.pipe()
 				button.reactive.selectedTitle <~ SignalProducer(signal)
 				
 				observer.send(value: "1")
@@ -107,7 +106,7 @@ final class NSPopUpButtonSpec: QuickSpec {
 			}
 
 			it("should accept changes from its bindings to its tag values") {
-				let (signal, observer) = Signal<Int, NoError>.pipe()
+				let (signal, observer) = Signal<Int, Never>.pipe()
 				button.reactive.selectedTag <~ SignalProducer(signal)
 
 				observer.send(value: 1001)

--- a/ReactiveCocoaTests/AppKit/NSTableViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSTableViewSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveCocoa
 import ReactiveSwift
-import Result
 import AppKit
 
 final class NSTableViewSpec: QuickSpec {
@@ -14,13 +13,13 @@ final class NSTableViewSpec: QuickSpec {
 		}
 
 		describe("reloadData") {
-			var bindingSignal: Signal<(), NoError>!
-			var bindingObserver: Signal<(), NoError>.Observer!
+			var bindingSignal: Signal<(), Never>!
+			var bindingObserver: Signal<(), Never>.Observer!
 
 			var reloadDataCount = 0
 
 			beforeEach {
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				(bindingSignal, bindingObserver) = (signal, observer)
 
 				reloadDataCount = 0
@@ -43,8 +42,8 @@ final class NSTableViewSpec: QuickSpec {
 }
 
 private final class TestTableView: NSTableView {
-	let reloadDataSignal: Signal<(), NoError>
-	private let reloadDataObserver: Signal<(), NoError>.Observer
+	let reloadDataSignal: Signal<(), Never>
+	private let reloadDataObserver: Signal<(), Never>.Observer
 
 	override init(frame: CGRect) {
 		(reloadDataSignal, reloadDataObserver) = Signal.pipe()

--- a/ReactiveCocoaTests/AppKit/NSViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSViewSpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import Result
 import ReactiveSwift
 import ReactiveCocoa
 import AppKit
@@ -15,7 +14,7 @@ class NSViewSpec: QuickSpec {
 			}
 
 			it("should allow binding of `isHidden` property") {
-				let (hSignal, hSink) = Signal<Bool, NoError>.pipe()
+				let (hSignal, hSink) = Signal<Bool, Never>.pipe()
 				expect(view.isHidden) == false
 
 				view.reactive.isHidden <~ hSignal
@@ -25,7 +24,7 @@ class NSViewSpec: QuickSpec {
 			}
 
 			it("should allow binding of `alphaValue` property") {
-				let (avSignal, avSink) = Signal<CGFloat, NoError>.pipe()
+				let (avSignal, avSink) = Signal<CGFloat, Never>.pipe()
 				expect(view.alphaValue) == 1.0
 
 				view.reactive.alphaValue <~ avSignal

--- a/ReactiveCocoaTests/AppKit/ReusableComponentsSpec.swift
+++ b/ReactiveCocoaTests/AppKit/ReusableComponentsSpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import Result
 import ReactiveSwift
 import ReactiveCocoa
 import AppKit

--- a/ReactiveCocoaTests/AssociationSpec.swift
+++ b/ReactiveCocoaTests/AssociationSpec.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import Nimble
 import Quick
 @testable import ReactiveCocoa

--- a/ReactiveCocoaTests/BindingTargetSpec.swift
+++ b/ReactiveCocoaTests/BindingTargetSpec.swift
@@ -1,6 +1,5 @@
 import ReactiveSwift
 import ReactiveCocoa
-import Result
 import Quick
 import Nimble
 
@@ -30,7 +29,7 @@ class BindingTargetSpec: QuickSpec {
 				}
 				expect(object.value) == 0
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				target <~ signal
 				expect(object.value) == 0
 
@@ -50,7 +49,7 @@ class BindingTargetSpec: QuickSpec {
 				}
 				expect(object.value) == 0
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				target <~ signal
 				observer.send(value: ())
 				expect(object.value) == 0
@@ -74,7 +73,7 @@ class BindingTargetSpec: QuickSpec {
 				}
 				expect(object.value) == 0
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				target <~ signal
 				expect(object.value) == 0
 
@@ -94,7 +93,7 @@ class BindingTargetSpec: QuickSpec {
 				}
 				expect(object.value) == 0
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				target <~ signal
 				observer.send(value: ())
 				expect(object.value) == 0

--- a/ReactiveCocoaTests/CocoaActionSpec.swift
+++ b/ReactiveCocoaTests/CocoaActionSpec.swift
@@ -1,12 +1,11 @@
 import ReactiveSwift
-import Result
 import Nimble
 import Quick
 import ReactiveCocoa
 
 class CocoaActionSpec: QuickSpec {
 	override func spec() {
-		var action: Action<Int, Int, NoError>!
+		var action: Action<Int, Int, Never>!
 		#if os(OSX)
 			var cocoaAction: CocoaAction<NSControl>!
 		#else

--- a/ReactiveCocoaTests/DelegateProxySpec.swift
+++ b/ReactiveCocoaTests/DelegateProxySpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import enum Result.NoError
 import ReactiveSwift
 @testable import ReactiveCocoa
 
@@ -106,7 +105,7 @@ class DelegateProxySpec: QuickSpec {
 			it("should complete its signals when the object deinitializes") {
 				var isCompleted = false
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), Never> = proxy.intercept(#selector(ObjectDelegate.foo))
 				foo.observeCompleted { isCompleted = true }
 
 				expect(isCompleted) == false
@@ -120,7 +119,7 @@ class DelegateProxySpec: QuickSpec {
 
 				object = nil
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), Never> = proxy.intercept(#selector(ObjectDelegate.foo))
 				foo.observeInterrupted { isInterrupted = true }
 
 				expect(isInterrupted) == true
@@ -130,10 +129,10 @@ class DelegateProxySpec: QuickSpec {
 				var fooCount = 0
 				var barCount = 0
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), Never> = proxy.intercept(#selector(ObjectDelegate.foo))
 				foo.observeValues { fooCount += 1 }
 
-				let bar: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.bar))
+				let bar: Signal<(), Never> = proxy.intercept(#selector(ObjectDelegate.bar))
 				bar.observeValues { barCount += 1 }
 
 				expect(fooCount) == 0
@@ -168,7 +167,7 @@ class DelegateProxySpec: QuickSpec {
 
 				var fooCount = 0
 
-				let foo: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+				let foo: Signal<(), Never> = proxy.intercept(#selector(ObjectDelegate.foo))
 				foo.observeValues { fooCount += 1 }
 
 				expect(fooCount) == 0
@@ -189,7 +188,7 @@ class DelegateProxySpec: QuickSpec {
 
 				var barCount = 0
 
-				let bar: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.bar))
+				let bar: Signal<(), Never> = proxy.intercept(#selector(ObjectDelegate.bar))
 				bar.observeValues { barCount += 1 }
 
 				object.delegate?.bar?()
@@ -238,7 +237,7 @@ class DelegateProxySpec: QuickSpec {
 					                                  setter: #selector(setter: object.delegate),
 					                                  getter: #selector(getter: object.delegate))
 
-					let signal: Signal<(), NoError> = proxy.intercept(#selector(ObjectDelegate.foo))
+					let signal: Signal<(), Never> = proxy.intercept(#selector(ObjectDelegate.foo))
 					signal.observeValues { fooCounter += 1 }
 				}
 

--- a/ReactiveCocoaTests/DeprecationsSpec.swift
+++ b/ReactiveCocoaTests/DeprecationsSpec.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ReactiveCocoa
 import ReactiveSwift
-import enum Result.NoError
 import Quick
 import Nimble
 

--- a/ReactiveCocoaTests/DynamicPropertySpec.swift
+++ b/ReactiveCocoaTests/DynamicPropertySpec.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import Nimble
 import Quick
 import ReactiveCocoa
@@ -260,14 +259,14 @@ class DynamicPropertySpec: QuickSpec {
 				}
 
 				it("should bridge values sent on a signal to Objective-C") {
-					let (signal, observer) = Signal<Int, NoError>.pipe()
+					let (signal, observer) = Signal<Int, Never>.pipe()
 					property <~ signal
 					observer.send(value: 1)
 					expect(object.rac_value) == 1
 				}
 
 				it("should bridge values sent on a signal producer to Objective-C") {
-					let producer = SignalProducer<Int, NoError>(value: 1)
+					let producer = SignalProducer<Int, Never>(value: 1)
 					property <~ producer
 					expect(object.rac_value) == 1
 				}
@@ -279,7 +278,7 @@ class DynamicPropertySpec: QuickSpec {
 				}
 
 				it("should bridge values sent on a signal to Objective-C, even if the view has deinitialized") {
-					let (signal, observer) = Signal<Int, NoError>.pipe()
+					let (signal, observer) = Signal<Int, Never>.pipe()
 					property <~ signal
 					property = nil
 
@@ -288,7 +287,7 @@ class DynamicPropertySpec: QuickSpec {
 				}
 
 				it("should bridge values sent on a signal producer to Objective-C, even if the view has deinitialized") {
-					let producer = SignalProducer<Int, NoError>(value: 1)
+					let producer = SignalProducer<Int, Never>(value: 1)
 					property <~ producer
 					property = nil
 

--- a/ReactiveCocoaTests/InterceptingSpec.swift
+++ b/ReactiveCocoaTests/InterceptingSpec.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ReactiveCocoa
 import ReactiveSwift
-import enum Result.NoError
 import Quick
 import Nimble
 import CoreGraphics

--- a/ReactiveCocoaTests/KVOKVCExtensionSpec.swift
+++ b/ReactiveCocoaTests/KVOKVCExtensionSpec.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 import Nimble
 import Quick
 import ReactiveCocoa

--- a/ReactiveCocoaTests/KeyValueObservingSpec+Swift4.swift
+++ b/ReactiveCocoaTests/KeyValueObservingSpec+Swift4.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ReactiveCocoa
 import ReactiveSwift
-import enum Result.NoError
 import Quick
 import Nimble
 
@@ -82,7 +81,7 @@ fileprivate class KeyValueObservingSwift4SpecConfiguration: QuickConfiguration {
 			self.context = context
 		}
 
-		func observe<Object: NSObject, U>(_ object: Object, _ keyPath: KeyPath<Object, U?>) -> SignalProducer<U?, NoError> {
+		func observe<Object: NSObject, U>(_ object: Object, _ keyPath: KeyPath<Object, U?>) -> SignalProducer<U?, Never> {
 			switch context["observe"] {
 			case let context as String where context == "signal":
 				return SignalProducer(object.reactive.signal(for: keyPath))
@@ -95,7 +94,7 @@ fileprivate class KeyValueObservingSwift4SpecConfiguration: QuickConfiguration {
 			}
 		}
 
-		func observe<Object: NSObject, U>(_ object: Object, _ keyPath: KeyPath<Object, U>) -> SignalProducer<U, NoError> {
+		func observe<Object: NSObject, U>(_ object: Object, _ keyPath: KeyPath<Object, U>) -> SignalProducer<U, Never> {
 			switch context["observe"] {
 			case let context as String where context == "signal":
 				return SignalProducer(object.reactive.signal(for: keyPath))
@@ -108,31 +107,31 @@ fileprivate class KeyValueObservingSwift4SpecConfiguration: QuickConfiguration {
 			}
 		}
 
-		func isFinished(_ object: Operation) -> SignalProducer<Bool, NoError> {
+		func isFinished(_ object: Operation) -> SignalProducer<Bool, Never> {
 			return observe(object, \.isFinished)
 		}
 
-		func changes(_ object: ObservableObject) -> SignalProducer<Int, NoError> {
+		func changes(_ object: ObservableObject) -> SignalProducer<Int, Never> {
 			return observe(object, \.rac_value)
 		}
 
-		func nestedChanges(_ object: NestedObservableObject) -> SignalProducer<Int, NoError> {
+		func nestedChanges(_ object: NestedObservableObject) -> SignalProducer<Int, Never> {
 			return observe(object, \.rac_object.rac_value)
 		}
 
-		func weakNestedChanges(_ object: NestedObservableObject) -> SignalProducer<Int?, NoError> {
+		func weakNestedChanges(_ object: NestedObservableObject) -> SignalProducer<Int?, Never> {
 			return observe(object, \.rac_weakObject?.rac_value)
 		}
 
-		func strongReferenceChanges(_ object: ObservableObject) -> SignalProducer<AnyObject?, NoError> {
+		func strongReferenceChanges(_ object: ObservableObject) -> SignalProducer<AnyObject?, Never> {
 			return observe(object, \.target)
 		}
 
-		func weakReferenceChanges(_ object: ObservableObject) -> SignalProducer<AnyObject?, NoError> {
+		func weakReferenceChanges(_ object: ObservableObject) -> SignalProducer<AnyObject?, Never> {
 			return observe(object, \.weakTarget)
 		}
 
-		func dependentKeyChanges(_ object: ObservableObject) -> SignalProducer<NSDecimalNumber, NoError> {
+		func dependentKeyChanges(_ object: ObservableObject) -> SignalProducer<NSDecimalNumber, Never> {
 			return observe(object, \.rac_value_plusOne)
 		}
 	}

--- a/ReactiveCocoaTests/KeyValueObservingSpec.swift
+++ b/ReactiveCocoaTests/KeyValueObservingSpec.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import ReactiveCocoa
 @testable import ReactiveSwift
-import enum Result.NoError
 import Quick
 import Nimble
 
@@ -138,42 +137,42 @@ fileprivate class KeyValueObservingSpecConfiguration: QuickConfiguration {
 			self.context = context
 		}
 
-		func observe(_ object: NSObject, _ keyPath: String) -> SignalProducer<Any?, NoError> {
-			if let block = context["observe"] as? (NSObject, String) -> Signal<Any?, NoError> {
+		func observe(_ object: NSObject, _ keyPath: String) -> SignalProducer<Any?, Never> {
+			if let block = context["observe"] as? (NSObject, String) -> Signal<Any?, Never> {
 				return SignalProducer(block(object, keyPath))
-			} else if let block = context["observe"] as? (NSObject, String) -> SignalProducer<Any?, NoError> {
+			} else if let block = context["observe"] as? (NSObject, String) -> SignalProducer<Any?, Never> {
 				return block(object, keyPath).skip(first: 1)
 			} else {
 				fatalError("What is this?")
 			}
 		}
 
-		func isFinished(_ object: Operation) -> SignalProducer<Any?, NoError> {
+		func isFinished(_ object: Operation) -> SignalProducer<Any?, Never> {
 			return observe(object, #keyPath(Operation.isFinished))
 		}
 
-		func changes(_ object: NSObject) -> SignalProducer<Any?, NoError> {
+		func changes(_ object: NSObject) -> SignalProducer<Any?, Never> {
 			return observe(object, #keyPath(ObservableObject.rac_value))
 		}
 
-		func nestedChanges(_ object: NSObject) -> SignalProducer<Any?, NoError> {
+		func nestedChanges(_ object: NSObject) -> SignalProducer<Any?, Never> {
 			return observe(object, #keyPath(NestedObservableObject.rac_object.rac_value))
 		}
 
-		func weakNestedChanges(_ object: NSObject) -> SignalProducer<Any?, NoError> {
+		func weakNestedChanges(_ object: NSObject) -> SignalProducer<Any?, Never> {
 			// `#keyPath` does not work with weak relationships.
 			return observe(object, "rac_weakObject.rac_value")
 		}
 
-		func strongReferenceChanges(_ object: NSObject) -> SignalProducer<Any?, NoError> {
+		func strongReferenceChanges(_ object: NSObject) -> SignalProducer<Any?, Never> {
 			return observe(object, #keyPath(ObservableObject.target))
 		}
 
-		func weakReferenceChanges(_ object: NSObject) -> SignalProducer<Any?, NoError> {
+		func weakReferenceChanges(_ object: NSObject) -> SignalProducer<Any?, Never> {
 			return observe(object, #keyPath(ObservableObject.weakTarget))
 		}
 
-		func dependentKeyChanges(_ object: NSObject) -> SignalProducer<Any?, NoError> {
+		func dependentKeyChanges(_ object: NSObject) -> SignalProducer<Any?, Never> {
 			return observe(object, #keyPath(ObservableObject.rac_value_plusOne))
 		}
 	}

--- a/ReactiveCocoaTests/LifetimeSpec.swift
+++ b/ReactiveCocoaTests/LifetimeSpec.swift
@@ -1,7 +1,6 @@
 import Foundation
 import ReactiveCocoa
 import ReactiveSwift
-import enum Result.NoError
 import Quick
 import Nimble
 
@@ -97,7 +96,7 @@ class LifetimeSpec: QuickSpec {
 				weak var weakObject = object
 				var isCompleted = false
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 
 				withExtendedLifetime(observer) {
 					signal
@@ -119,7 +118,7 @@ class LifetimeSpec: QuickSpec {
 				weak var weakObject = object
 				var isCompleted = false
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 
 				withExtendedLifetime(observer) {
 					signal
@@ -143,7 +142,7 @@ class LifetimeSpec: QuickSpec {
 				weak var weakObject = object
 				var isCompleted = false
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 
 				withExtendedLifetime(observer) {
 					SignalProducer(signal)
@@ -165,7 +164,7 @@ class LifetimeSpec: QuickSpec {
 				weak var weakObject = object
 				var isCompleted = false
 
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 
 				withExtendedLifetime(observer) {
 					SignalProducer(signal)

--- a/ReactiveCocoaTests/Shared/NSLayoutConstraintSpec.swift
+++ b/ReactiveCocoaTests/Shared/NSLayoutConstraintSpec.swift
@@ -2,7 +2,6 @@ import ReactiveSwift
 import ReactiveCocoa
 import Quick
 import Nimble
-import enum Result.NoError
 
 class NSLayoutConstraintSpec: QuickSpec {
     override func spec() {
@@ -22,7 +21,7 @@ class NSLayoutConstraintSpec: QuickSpec {
 		it("should accept changes from bindings to its constant") {
 			expect(constraint.constant).to(equal(0.0))
 
-			let (pipeSignal, observer) = Signal<CGFloat, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<CGFloat, Never>.pipe()
 
 			constraint.reactive.constant <~ pipeSignal
 

--- a/ReactiveCocoaTests/TestError.swift
+++ b/ReactiveCocoaTests/TestError.swift
@@ -1,6 +1,5 @@
 import ReactiveCocoa
 import ReactiveSwift
-import Result
 
 internal enum TestError: Int {
 	case `default` = 0
@@ -16,7 +15,7 @@ internal extension SignalProducer {
 	/// Halts if an error is emitted in the receiver signal.
 	/// This is useful in tests to be able to just use `startWithNext`
 	/// in cases where we know that an error won't be emitted.
-	func assumeNoErrors() -> SignalProducer<Value, NoError> {
+	func assumeNoErrors() -> SignalProducer<Value, Never> {
 		return lift { $0.assumeNoErrors() }
 	}
 }
@@ -25,7 +24,7 @@ internal extension Signal {
 	/// Halts if an error is emitted in the receiver signal.
 	/// This is useful in tests to be able to just use `startWithNext`
 	/// in cases where we know that an error won't be emitted.
-	func assumeNoErrors() -> Signal<Value, NoError> {
+	func assumeNoErrors() -> Signal<Value, Never> {
 		return mapError { error in
 			fatalError("Unexpected error: \(error)")
 

--- a/ReactiveCocoaTests/UIKit/ReusableComponentsSpec.swift
+++ b/ReactiveCocoaTests/UIKit/ReusableComponentsSpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import Result
 import ReactiveSwift
 import ReactiveCocoa
 import UIKit

--- a/ReactiveCocoaTests/UIKit/UIActivityIndicatorViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIActivityIndicatorViewSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveSwift
 import ReactiveCocoa
-import Result
 
 class UIActivityIndicatorSpec: QuickSpec {
 	override func spec() {
@@ -20,7 +19,7 @@ class UIActivityIndicatorSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its animating state") {
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			activityIndicatorView.reactive.isAnimating <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)

--- a/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIBarButtonItemSpec.swift
@@ -3,7 +3,6 @@ import Nimble
 import ReactiveSwift
 import ReactiveCocoa
 import UIKit
-import enum Result.NoError
 
 class UIBarButtonItemSpec: QuickSpec {
 	override func spec() {
@@ -21,12 +20,12 @@ class UIBarButtonItemSpec: QuickSpec {
 		}
 
 		it("should not be retained with the presence of a `pressed` action") {
-			let action = Action<(),(),NoError> { SignalProducer(value: ()) }
+			let action = Action<(),(),Never> { SignalProducer(value: ()) }
 			barButtonItem.reactive.pressed = CocoaAction(action)
 		}
 
 		it("should accept changes from bindings to its enabling state") {
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			barButtonItem.reactive.isEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: false)
@@ -37,7 +36,7 @@ class UIBarButtonItemSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its title") {
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			barButtonItem.reactive.title <~ SignalProducer(pipeSignal)
 
 			observer.send(value: "title")
@@ -48,7 +47,7 @@ class UIBarButtonItemSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its image") {
-			let (pipeSignal, observer) = Signal<UIImage?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIImage?, Never>.pipe()
 			barButtonItem.reactive.image <~ SignalProducer(pipeSignal)
 
 			let image = UIImage()
@@ -62,7 +61,7 @@ class UIBarButtonItemSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its style") {
-			let (pipeSignal, observer) = Signal<UIBarButtonItem.Style, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIBarButtonItem.Style, Never>.pipe()
 			barButtonItem.reactive.style <~ SignalProducer(pipeSignal)
 
 			observer.send(value: .done)
@@ -73,7 +72,7 @@ class UIBarButtonItemSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its width") {
-			let (pipeSignal, observer) = Signal<CGFloat, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<CGFloat, Never>.pipe()
 			barButtonItem.reactive.width <~ SignalProducer(pipeSignal)
 
 			observer.send(value: 42.0)
@@ -87,7 +86,7 @@ class UIBarButtonItemSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its possible titles") {
-			let (pipeSignal, observer) = Signal<Set<String>?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Set<String>?, Never>.pipe()
 			barButtonItem.reactive.possibleTitles <~ SignalProducer(pipeSignal)
 
 			let possibleTitles = Set(["Unread (123,456,789)", "Unread"])
@@ -107,7 +106,7 @@ class UIBarButtonItemSpec: QuickSpec {
 
 			barButtonItem.customView = nil
 
-			let (pipeSignal, observer) = Signal<UIView?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIView?, Never>.pipe()
 			barButtonItem.reactive.customView <~ pipeSignal
 
 			observer.send(value: firstChange)

--- a/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIButtonSpec.swift
@@ -3,7 +3,6 @@ import Nimble
 import ReactiveSwift
 import ReactiveCocoa
 import UIKit
-import enum Result.NoError
 
 class UIButtonSpec: QuickSpec {
 	override func spec() {
@@ -24,7 +23,7 @@ class UIButtonSpec: QuickSpec {
 			let firstTitle = "First title"
 			let secondTitle = "Second title"
 
-			let (pipeSignal, observer) = Signal<String, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String, Never>.pipe()
 			button.reactive.title <~ SignalProducer(pipeSignal)
 			button.setTitle("", for: .selected)
 			button.setTitle("", for: .highlighted)
@@ -45,7 +44,7 @@ class UIButtonSpec: QuickSpec {
 			button.isUserInteractionEnabled = true
 
 			let pressed = MutableProperty(false)
-			let action = Action<(), Bool, NoError> { _ in
+			let action = Action<(), Bool, Never> { _ in
 				SignalProducer(value: true)
 			}
 

--- a/ReactiveCocoaTests/UIKit/UICollectionViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UICollectionViewSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveCocoa
 import ReactiveSwift
-import Result
 import UIKit
 
 final class UICollectionViewSpec: QuickSpec {
@@ -14,13 +13,13 @@ final class UICollectionViewSpec: QuickSpec {
 		}
 
 		describe("reloadData") {
-			var bindingSignal: Signal<(), NoError>!
-			var bindingObserver: Signal<(), NoError>.Observer!
+			var bindingSignal: Signal<(), Never>!
+			var bindingObserver: Signal<(), Never>.Observer!
 
 			var reloadDataCount = 0
 
 			beforeEach {
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				(bindingSignal, bindingObserver) = (signal, observer)
 
 				reloadDataCount = 0
@@ -43,8 +42,8 @@ final class UICollectionViewSpec: QuickSpec {
 }
 
 private final class TestCollectionView: UICollectionView {
-	let reloadDataSignal: Signal<(), NoError>
-	private let reloadDataObserver: Signal<(), NoError>.Observer
+	let reloadDataSignal: Signal<(), Never>
+	private let reloadDataObserver: Signal<(), Never>.Observer
 
 	init() {
 		(reloadDataSignal, reloadDataObserver) = Signal.pipe()

--- a/ReactiveCocoaTests/UIKit/UIControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIControlSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UIControlSpec: QuickSpec {
 	override func spec() {
@@ -22,7 +21,7 @@ class UIControlSpec: QuickSpec {
 		it("should accept changes from bindings to its enabling state") {
 			control.isEnabled = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			control.reactive.isEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -35,7 +34,7 @@ class UIControlSpec: QuickSpec {
 		it("should accept changes from bindings to its selecting state") {
 			control.isSelected = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			control.reactive.isSelected <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -48,7 +47,7 @@ class UIControlSpec: QuickSpec {
 		it("should accept changes from bindings to its highlighting state") {
 			control.isHighlighted = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			control.reactive.isHighlighted <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -62,8 +61,8 @@ class UIControlSpec: QuickSpec {
 			control.isSelected = false
 			control.isEnabled = false
 
-			let (pipeSignalSelected, observerSelected) = Signal<Bool, NoError>.pipe()
-			let (pipeSignalEnabled, observerEnabled) = Signal<Bool, NoError>.pipe()
+			let (pipeSignalSelected, observerSelected) = Signal<Bool, Never>.pipe()
+			let (pipeSignalEnabled, observerEnabled) = Signal<Bool, Never>.pipe()
 			control.reactive.isSelected <~ SignalProducer(pipeSignalSelected)
 			control.reactive.isEnabled <~ SignalProducer(pipeSignalEnabled)
 

--- a/ReactiveCocoaTests/UIKit/UIGestureRecognizerSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIGestureRecognizerSpec.swift
@@ -3,7 +3,6 @@ import Nimble
 import ReactiveSwift
 import ReactiveCocoa
 import UIKit
-import enum Result.NoError
 
 class UIGestureRecognizerSpec: QuickSpec {
 	override func spec() {

--- a/ReactiveCocoaTests/UIKit/UIImageViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIImageViewSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UIImageViewSpec: QuickSpec {
 	override func spec() {
@@ -24,7 +23,7 @@ class UIImageViewSpec: QuickSpec {
 			let firstChange = UIImage()
 			let secondChange = UIImage()
 
-			let (pipeSignal, observer) = Signal<UIImage?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIImage?, Never>.pipe()
 			imageView.reactive.image <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
@@ -38,7 +37,7 @@ class UIImageViewSpec: QuickSpec {
 			let firstChange = UIImage()
 			let secondChange = UIImage()
 
-			let (pipeSignal, observer) = Signal<UIImage?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIImage?, Never>.pipe()
 			imageView.reactive.highlightedImage <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)

--- a/ReactiveCocoaTests/UIKit/UILabelSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UILabelSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UILabelSpec: QuickSpec {
 	override func spec() {
@@ -26,7 +25,7 @@ class UILabelSpec: QuickSpec {
 
 			label.text = ""
 
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			label.reactive.text <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
@@ -45,7 +44,7 @@ class UILabelSpec: QuickSpec {
 
 			label.attributedText = NSAttributedString(string: "")
 
-			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<NSAttributedString?, Never>.pipe()
 			label.reactive.attributedText <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
@@ -61,7 +60,7 @@ class UILabelSpec: QuickSpec {
 
 			let label = UILabel(frame: .zero)
 
-			let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIColor, Never>.pipe()
 			label.textColor = UIColor.black
 			label.reactive.textColor <~ SignalProducer(pipeSignal)
 

--- a/ReactiveCocoaTests/UIKit/UINavigationItemSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UINavigationItemSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UINavigationItemSpec: QuickSpec {
 	override func spec() {
@@ -26,7 +25,7 @@ class UINavigationItemSpec: QuickSpec {
 			
 			navigationItem.title = ""
 			
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			navigationItem.reactive.title <~ pipeSignal
 			
 			observer.send(value: firstChange)
@@ -48,7 +47,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.titleView = nil
 
-			let (pipeSignal, observer) = Signal<UIView?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIView?, Never>.pipe()
 			navigationItem.reactive.titleView <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -68,7 +67,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.prompt = ""
 
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			navigationItem.reactive.prompt <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -87,7 +86,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.backBarButtonItem = nil
 
-			let (pipeSignal, observer) = Signal<UIBarButtonItem?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIBarButtonItem?, Never>.pipe()
 			navigationItem.reactive.backBarButtonItem <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -106,7 +105,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.hidesBackButton = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			navigationItem.reactive.hidesBackButton <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -130,7 +129,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.leftBarButtonItems = nil
 
-			let (pipeSignal, observer) = Signal<[UIBarButtonItem]?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<[UIBarButtonItem]?, Never>.pipe()
 			navigationItem.reactive.leftBarButtonItems <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -156,7 +155,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.rightBarButtonItems = nil
 
-			let (pipeSignal, observer) = Signal<[UIBarButtonItem]?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<[UIBarButtonItem]?, Never>.pipe()
 			navigationItem.reactive.rightBarButtonItems <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -175,7 +174,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.leftBarButtonItem = nil
 
-			let (pipeSignal, observer) = Signal<UIBarButtonItem?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIBarButtonItem?, Never>.pipe()
 			navigationItem.reactive.leftBarButtonItem <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -194,7 +193,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.rightBarButtonItem = nil
 
-			let (pipeSignal, observer) = Signal<UIBarButtonItem?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIBarButtonItem?, Never>.pipe()
 			navigationItem.reactive.rightBarButtonItem <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -214,7 +213,7 @@ class UINavigationItemSpec: QuickSpec {
 
 			navigationItem.leftItemsSupplementBackButton = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			navigationItem.reactive.leftItemsSupplementBackButton <~ pipeSignal
 
 			observer.send(value: firstChange)
@@ -231,7 +230,7 @@ class UINavigationItemSpec: QuickSpec {
 
 				navigationItem.largeTitleDisplayMode = .automatic
 
-				let (pipeSignal, observer) = Signal<UINavigationItem.LargeTitleDisplayMode, NoError>.pipe()
+				let (pipeSignal, observer) = Signal<UINavigationItem.LargeTitleDisplayMode, Never>.pipe()
 				navigationItem.reactive.largeTitleDisplayMode <~ pipeSignal
 
 				observer.send(value: firstChange)
@@ -250,7 +249,7 @@ class UINavigationItemSpec: QuickSpec {
 
 				navigationItem.searchController = nil
 
-				let (pipeSignal, observer) = Signal<UISearchController?, NoError>.pipe()
+				let (pipeSignal, observer) = Signal<UISearchController?, Never>.pipe()
 				navigationItem.reactive.searchController <~ pipeSignal
 
 				observer.send(value: firstChange)
@@ -269,7 +268,7 @@ class UINavigationItemSpec: QuickSpec {
 
 				navigationItem.hidesSearchBarWhenScrolling = false
 
-				let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+				let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 				navigationItem.reactive.hidesSearchBarWhenScrolling <~ pipeSignal
 
 				observer.send(value: firstChange)

--- a/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIPickerViewSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 private final class PickerDataSource: NSObject, UIPickerViewDataSource {
 	@objc func numberOfComponents(in pickerView: UIPickerView) -> Int {
@@ -42,10 +41,10 @@ final class UIPickerViewSpec: QuickSpec {
 
 		it("should accept changes from bindings to selected rows") {
 
-			let (pipeSignal, observer) = Signal<Int, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Int, Never>.pipe()
 			pickerView.reactive.selectedRow(inComponent: 0) <~ SignalProducer(pipeSignal)
 
-			let (anotherPipeSignal, anotherObserver) = Signal<Int, NoError>.pipe()
+			let (anotherPipeSignal, anotherObserver) = Signal<Int, Never>.pipe()
 			pickerView.reactive.selectedRow(inComponent: 1) <~ SignalProducer(anotherPipeSignal)
 
 			observer.send(value: 1)
@@ -76,7 +75,7 @@ final class UIPickerViewSpec: QuickSpec {
 		}
 
 		it("invokes reloadAllComponents whenever the bound signal sends a value") {
-			let (signal, observer) = Signal<(), NoError>.pipe()
+			let (signal, observer) = Signal<(), Never>.pipe()
 
 			var reloadAllComponentsCount = 0
 
@@ -93,7 +92,7 @@ final class UIPickerViewSpec: QuickSpec {
 		}
 
 		it("invokes reloadComponent whenever the bound signal sends a value") {
-			let (signal, observer) = Signal<Int, NoError>.pipe()
+			let (signal, observer) = Signal<Int, Never>.pipe()
 
 			var reloadFirstComponentCount = 0
 			var reloadSecondComponentCount = 0
@@ -123,11 +122,11 @@ final class UIPickerViewSpec: QuickSpec {
 }
 
 private final class TestPickerView: UIPickerView {
-	let reloadAllComponentsSignal: Signal<(), NoError>
-	private let reloadAllComponentsObserver: Signal<(), NoError>.Observer
+	let reloadAllComponentsSignal: Signal<(), Never>
+	private let reloadAllComponentsObserver: Signal<(), Never>.Observer
 
-	let reloadComponentSignal: Signal<Int, NoError>
-	private let reloadComponentObserver: Signal<Int, NoError>.Observer
+	let reloadComponentSignal: Signal<Int, Never>
+	private let reloadComponentObserver: Signal<Int, Never>.Observer
 
 	init() {
 		(reloadAllComponentsSignal, reloadAllComponentsObserver) = Signal.pipe()

--- a/ReactiveCocoaTests/UIKit/UIProgressViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIProgressViewSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UIProgressViewSpec: QuickSpec {
 	override func spec() {
@@ -26,7 +25,7 @@ class UIProgressViewSpec: QuickSpec {
 
 			progressView.progress = 1.0
 
-			let (pipeSignal, observer) = Signal<Float, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Float, Never>.pipe()
 			progressView.reactive.progress <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)

--- a/ReactiveCocoaTests/UIKit/UIRefreshControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIRefreshControlSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveSwift
 import ReactiveCocoa
-import Result
 
 class UIRefreshControlSpec: QuickSpec {
 	override func spec() {
@@ -20,7 +19,7 @@ class UIRefreshControlSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its refreshing state") {
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			refreshControl.reactive.isRefreshing <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -31,7 +30,7 @@ class UIRefreshControlSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its attributed title state") {
-			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<NSAttributedString?, Never>.pipe()
 			refreshControl.reactive.attributedTitle <~ SignalProducer(pipeSignal)
 
 			let string = NSAttributedString(string: "test")
@@ -51,7 +50,7 @@ class UIRefreshControlSpec: QuickSpec {
 			refreshControl.isUserInteractionEnabled = true
 
 			let refreshed = MutableProperty(false)
-			let action = Action<(), Bool, NoError> { _ in
+			let action = Action<(), Bool, Never> { _ in
 				SignalProducer(value: true)
 			}
 
@@ -68,7 +67,7 @@ class UIRefreshControlSpec: QuickSpec {
 			refreshControl.isEnabled = true
 			refreshControl.isUserInteractionEnabled = true
 
-			let action = Action<(), Bool, NoError> { _ in
+			let action = Action<(), Bool, Never> { _ in
 				SignalProducer(value: true).delay(1, on: QueueScheduler.main)
 			}
 

--- a/ReactiveCocoaTests/UIKit/UIScrollViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIScrollViewSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 private final class UIScrollViewDelegateForZooming: NSObject, UIScrollViewDelegate {
 	func viewForZooming(in scrollView: UIScrollView) -> UIView? {
@@ -29,7 +28,7 @@ class UIScrollViewSpec: QuickSpec {
 		it("should accept changes from bindings to its content inset value") {
 			scrollView.contentInset = .zero
 
-			let (pipeSignal, observer) = Signal<UIEdgeInsets, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIEdgeInsets, Never>.pipe()
 			scrollView.reactive.contentInset <~ SignalProducer(pipeSignal)
 
 			observer.send(value: UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
@@ -42,7 +41,7 @@ class UIScrollViewSpec: QuickSpec {
 		it("should accept changes from bindings to its scroll indicator insets value") {
 			scrollView.scrollIndicatorInsets = .zero
 
-			let (pipeSignal, observer) = Signal<UIEdgeInsets, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIEdgeInsets, Never>.pipe()
 			scrollView.reactive.scrollIndicatorInsets <~ SignalProducer(pipeSignal)
 
 			observer.send(value: UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
@@ -55,7 +54,7 @@ class UIScrollViewSpec: QuickSpec {
 		it("should accept changes from bindings to its scroll enabled state") {
 			scrollView.isScrollEnabled = true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			scrollView.reactive.isScrollEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -75,7 +74,7 @@ class UIScrollViewSpec: QuickSpec {
 			scrollView.maximumZoomScale = 5
 			scrollView.zoomScale = 1
 
-			let (pipeSignal, observer) = Signal<CGFloat, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<CGFloat, Never>.pipe()
 			scrollView.reactive.zoomScale <~ SignalProducer(pipeSignal)
 
 			observer.send(value: 3)
@@ -87,7 +86,7 @@ class UIScrollViewSpec: QuickSpec {
 		it("should accept changes from bindings to its minimum zoom scale value") {
 			scrollView.minimumZoomScale = 0
 
-			let (pipeSignal, observer) = Signal<CGFloat, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<CGFloat, Never>.pipe()
 			scrollView.reactive.minimumZoomScale <~ SignalProducer(pipeSignal)
 
 			observer.send(value: 42)
@@ -99,7 +98,7 @@ class UIScrollViewSpec: QuickSpec {
 		it("should accept changes from bindings to its maximum zoom scale value") {
 			scrollView.maximumZoomScale = 0
 
-			let (pipeSignal, observer) = Signal<CGFloat, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<CGFloat, Never>.pipe()
 			scrollView.reactive.maximumZoomScale <~ SignalProducer(pipeSignal)
 
 			observer.send(value: 42)
@@ -111,7 +110,7 @@ class UIScrollViewSpec: QuickSpec {
 		it("should accept changes from bindings to its scrolls to top state") {
 			scrollView.scrollsToTop = true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			scrollView.reactive.scrollsToTop <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)

--- a/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISearchBarSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UISearchBarSpec: QuickSpec {
 	override func spec() {
@@ -37,7 +36,7 @@ class UISearchBarSpec: QuickSpec {
 
 			searchBar.text = ""
 
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			searchBar.reactive.text <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
@@ -86,7 +85,7 @@ class UISearchBarSpec: QuickSpec {
 
 			searchBar.scopeButtonTitles = ["First", "Second", "Third"]
 
-			let (pipeSignal, observer) = Signal<Int, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Int, Never>.pipe()
 			searchBar.reactive.selectedScopeButtonIndex <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
@@ -204,7 +203,7 @@ class UISearchBarSpec: QuickSpec {
 		it("should accept changes from bindings to its hidden state of the cancel button") {
 			searchBar.showsCancelButton = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			searchBar.reactive.showsCancelButton <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)

--- a/ReactiveCocoaTests/UIKit/UISegmentedControlSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISegmentedControlSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveSwift
 import ReactiveCocoa
-import Result
 
 class UISegmentedControlSpec: QuickSpec {
 	override func spec() {
@@ -11,7 +10,7 @@ class UISegmentedControlSpec: QuickSpec {
 			s.selectedSegmentIndex = UISegmentedControl.noSegment
 			expect(s.numberOfSegments) == 3
 
-			let (pipeSignal, observer) = Signal<Int, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Int, Never>.pipe()
 			s.reactive.selectedSegmentIndex <~ SignalProducer(pipeSignal)
 
 			expect(s.selectedSegmentIndex) == UISegmentedControl.noSegment

--- a/ReactiveCocoaTests/UIKit/UISliderSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISliderSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveCocoa
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 class UISliderSpec: QuickSpec {
@@ -23,7 +22,7 @@ class UISliderSpec: QuickSpec {
 		it("should accept changes from bindings to its value") {
 			expect(slider.value) == 0.0
 
-			let (pipeSignal, observer) = Signal<Float, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Float, Never>.pipe()
 
 			slider.reactive.value <~ pipeSignal
 
@@ -34,7 +33,7 @@ class UISliderSpec: QuickSpec {
 		it("should accept changes from bindings to its minimum value") {
 			expect(slider.minimumValue) == 0.0
 
-			let (pipeSignal, observer) = Signal<Float, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Float, Never>.pipe()
 
 			slider.reactive.minimumValue <~ pipeSignal
 
@@ -45,7 +44,7 @@ class UISliderSpec: QuickSpec {
 		it("should accept changes from bindings to its maximum value") {
 			expect(slider.maximumValue) == 1.0
 
-			let (pipeSignal, observer) = Signal<Float, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Float, Never>.pipe()
 
 			slider.reactive.maximumValue <~ pipeSignal
 

--- a/ReactiveCocoaTests/UIKit/UIStepperSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIStepperSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveCocoa
 import ReactiveSwift
-import enum Result.NoError
 import UIKit
 
 class UIStepperSpec: QuickSpec {
@@ -23,7 +22,7 @@ class UIStepperSpec: QuickSpec {
 		it("should accept changes from bindings to its value") {
 			expect(stepper.value) == 0.0
 
-			let (pipeSignal, observer) = Signal<Double, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Double, Never>.pipe()
 
 			stepper.reactive.value <~ pipeSignal
 
@@ -34,7 +33,7 @@ class UIStepperSpec: QuickSpec {
 		it("should accept changes from bindings to its minimum value") {
 			expect(stepper.minimumValue) == 0.0
 
-			let (pipeSignal, observer) = Signal<Double, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Double, Never>.pipe()
 
 			stepper.reactive.minimumValue <~ pipeSignal
 
@@ -45,7 +44,7 @@ class UIStepperSpec: QuickSpec {
 		it("should accept changes from bindings to its maximum value") {
 			expect(stepper.maximumValue) == 100.0
 
-			let (pipeSignal, observer) = Signal<Double, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Double, Never>.pipe()
 
 			stepper.reactive.maximumValue <~ pipeSignal
 

--- a/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UISwitchSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveSwift
 import ReactiveCocoa
-import Result
 
 class UISwitchSpec: QuickSpec {
 	override func spec() {
@@ -24,7 +23,7 @@ class UISwitchSpec: QuickSpec {
 		it("should accept changes from bindings to its `isOn` state") {
 			toggle.isOn = false
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			toggle.reactive.isOn <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -49,7 +48,7 @@ class UISwitchSpec: QuickSpec {
 			toggle.isUserInteractionEnabled = true
 			
 			let isOn = MutableProperty(false)
-			let action = Action<Bool, Bool, NoError> { isOn in
+			let action = Action<Bool, Bool, Never> { isOn in
 				return SignalProducer(value: isOn)
 			}
 			isOn <~ SignalProducer(action.values)

--- a/ReactiveCocoaTests/UIKit/UITabBarItemSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITabBarItemSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UITabBarSpec: QuickSpec {
 	override func spec() {
@@ -26,7 +25,7 @@ class UITabBarSpec: QuickSpec {
 			
 			tabBarItem.badgeValue = ""
 			
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			tabBarItem.reactive.badgeValue <~ pipeSignal
 			
 			observer.send(value: firstChange)
@@ -46,7 +45,7 @@ class UITabBarSpec: QuickSpec {
 				
 				tabBarItem.badgeColor = .blue
 				
-				let (pipeSignal, observer) = Signal<UIColor?, NoError>.pipe()
+				let (pipeSignal, observer) = Signal<UIColor?, Never>.pipe()
 				tabBarItem.reactive.badgeColor <~ pipeSignal
 				
 				observer.send(value: firstChange)

--- a/ReactiveCocoaTests/UIKit/UITableViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITableViewSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveCocoa
 import ReactiveSwift
-import Result
 import UIKit
 
 final class UITableViewSpec: QuickSpec {
@@ -14,13 +13,13 @@ final class UITableViewSpec: QuickSpec {
 		}
 
 		describe("reloadData") {
-			var bindingSignal: Signal<(), NoError>!
-			var bindingObserver: Signal<(), NoError>.Observer!
+			var bindingSignal: Signal<(), Never>!
+			var bindingObserver: Signal<(), Never>.Observer!
 
 			var reloadDataCount = 0
 
 			beforeEach {
-				let (signal, observer) = Signal<(), NoError>.pipe()
+				let (signal, observer) = Signal<(), Never>.pipe()
 				(bindingSignal, bindingObserver) = (signal, observer)
 
 				reloadDataCount = 0
@@ -43,8 +42,8 @@ final class UITableViewSpec: QuickSpec {
 }
 
 private final class TestTableView: UITableView {
-	let reloadDataSignal: Signal<(), NoError>
-	private let reloadDataObserver: Signal<(), NoError>.Observer
+	let reloadDataSignal: Signal<(), Never>
+	private let reloadDataObserver: Signal<(), Never>.Observer
 
 	override init(frame: CGRect, style: UITableView.Style) {
 		(reloadDataSignal, reloadDataObserver) = Signal.pipe()

--- a/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextFieldSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UITextFieldSpec: QuickSpec {
 	override func spec() {
@@ -70,7 +69,7 @@ class UITextFieldSpec: QuickSpec {
 			
 			textField.attributedText = NSAttributedString(string: "")
 			
-			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<NSAttributedString?, Never>.pipe()
 			textField.reactive.attributedText <~ SignalProducer(pipeSignal)
 			
 			observer.send(value: firstChange)
@@ -119,7 +118,7 @@ class UITextFieldSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its placeholder attribute") {
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			textField.reactive.placeholder <~ pipeSignal
 
 			observer.send(value: "A placeholder")
@@ -133,7 +132,7 @@ class UITextFieldSpec: QuickSpec {
 		}
 
 		it("should accept changes from bindings to its secureTextEntry attribute") {
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			textField.reactive.isSecureTextEntry <~ pipeSignal
 
 			observer.send(value: true)
@@ -144,7 +143,7 @@ class UITextFieldSpec: QuickSpec {
 		}
 		
 		it("should accept changes from bindings to its textColor attribute") {
-			let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIColor, Never>.pipe()
 			textField.reactive.textColor <~ pipeSignal
 			
 			observer.send(value: UIColor.red)

--- a/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UITextViewSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UITextViewSpec: QuickSpec {
 	override func spec() {
@@ -66,7 +65,7 @@ class UITextViewSpec: QuickSpec {
 			
 			textView.attributedText = NSAttributedString(string: "")
 			
-			let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<NSAttributedString?, Never>.pipe()
 			textView.reactive.attributedText <~ SignalProducer(pipeSignal)
 			
 			observer.send(value: firstChange)

--- a/ReactiveCocoaTests/UIKit/UIViewControllerSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIViewControllerSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UIViewControllerSpec: QuickSpec {
 	override func spec() {
@@ -26,7 +25,7 @@ class UIViewControllerSpec: QuickSpec {
 
 			viewController.title = ""
 
-			let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<String?, Never>.pipe()
 			viewController.reactive.title <~ pipeSignal
 
 			observer.send(value: firstChange)

--- a/ReactiveCocoaTests/UIKit/UIViewSpec.swift
+++ b/ReactiveCocoaTests/UIKit/UIViewSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import UIKit
 import Quick
 import Nimble
-import enum Result.NoError
 
 class UIViewSpec: QuickSpec {
 	override func spec() {
@@ -23,7 +22,7 @@ class UIViewSpec: QuickSpec {
 		it("should accept changes from bindings to its hiding state") {
 			view.isHidden = true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			view.reactive.isHidden <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -39,7 +38,7 @@ class UIViewSpec: QuickSpec {
 			let firstChange = CGFloat(0.5)
 			let secondChange = CGFloat(0.7)
 
-			let (pipeSignal, observer) = Signal<CGFloat, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<CGFloat, Never>.pipe()
 			view.reactive.alpha <~ SignalProducer(pipeSignal)
 
 			observer.send(value: firstChange)
@@ -52,7 +51,7 @@ class UIViewSpec: QuickSpec {
 		it("should accept changes from bindings to its user interaction enabling state") {
 			view.isUserInteractionEnabled = true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 			view.reactive.isUserInteractionEnabled <~ SignalProducer(pipeSignal)
 
 			observer.send(value: true)
@@ -65,7 +64,7 @@ class UIViewSpec: QuickSpec {
 		it("should accept changes from bindings to its background color") {
 			view.backgroundColor = .white
 
-			let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIColor, Never>.pipe()
 			view.reactive.backgroundColor <~ SignalProducer(pipeSignal)
 
 			observer.send(value: .yellow)
@@ -81,7 +80,7 @@ class UIViewSpec: QuickSpec {
 		it("should accept changes from bindings to its tint color") {
 			view.tintColor = .white
 			
-			let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<UIColor, Never>.pipe()
 			view.reactive.tintColor <~ SignalProducer(pipeSignal)
 			
 			observer.send(value: .yellow)

--- a/ReactiveMapKit/MKLocalSearchRequest.swift
+++ b/ReactiveMapKit/MKLocalSearchRequest.swift
@@ -1,6 +1,5 @@
 import ReactiveSwift
 import ReactiveCocoa
-import Result
 import MapKit
 
 private let defaultLocalSearchError = NSError(domain: "org.reactivecocoa.ReactiveCocoa.Reactivity.MKLocalSearchRequest",
@@ -9,7 +8,7 @@ private let defaultLocalSearchError = NSError(domain: "org.reactivecocoa.Reactiv
 @available(tvOS 9.2, *)
 extension Reactive where Base: MKLocalSearch.Request {
 	/// A SignalProducer which performs an `MKLocalSearch`.
-	public var search: SignalProducer<MKLocalSearch.Response, AnyError> {
+	public var search: SignalProducer<MKLocalSearch.Response, Swift.Error> {
 		return SignalProducer {[base = self.base] observer, lifetime in
 			let search = MKLocalSearch(request: base)
 			search.start { response, error in
@@ -17,7 +16,7 @@ extension Reactive where Base: MKLocalSearch.Request {
 					observer.send(value: response)
 					observer.sendCompleted()
 				} else {
-					observer.send(error: AnyError(error ?? defaultLocalSearchError))
+					observer.send(error: error ?? defaultLocalSearchError)
 				}
 			}
 			lifetime.observeEnded(search.cancel)

--- a/ReactiveMapKitTests/MKMapViewSpec.swift
+++ b/ReactiveMapKitTests/MKMapViewSpec.swift
@@ -3,7 +3,6 @@ import ReactiveCocoa
 import ReactiveMapKit
 import Quick
 import Nimble
-import enum Result.NoError
 import MapKit
 
 @available(tvOS 9.2, *)
@@ -35,7 +34,7 @@ class MKMapViewSpec: QuickSpec {
 		it("should accept changes from bindings to its map type") {
 			expect(mapView.mapType) == MKMapType.standard
 
-			let (pipeSignal, observer) = Signal<MKMapType, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<MKMapType, Never>.pipe()
 
 			mapView.reactive.mapType <~ pipeSignal
 
@@ -49,7 +48,7 @@ class MKMapViewSpec: QuickSpec {
 		it("should accept changes from bindings to its zoom enabled state") {
 			expect(mapView.isZoomEnabled) == true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 
 			mapView.reactive.isZoomEnabled <~ pipeSignal
 
@@ -60,7 +59,7 @@ class MKMapViewSpec: QuickSpec {
 		it("should accept changes from bindings to its scroll enabled state") {
 			expect(mapView.isScrollEnabled) == true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 
 			mapView.reactive.isScrollEnabled <~ pipeSignal
 
@@ -72,7 +71,7 @@ class MKMapViewSpec: QuickSpec {
 		it("should accept changes from bindings to its pitch enabled state") {
 			expect(mapView.isPitchEnabled) == true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 
 			mapView.reactive.isPitchEnabled <~ pipeSignal
 
@@ -83,7 +82,7 @@ class MKMapViewSpec: QuickSpec {
 		it("should accept changes from bindings to its rotate enabled state") {
 			expect(mapView.isRotateEnabled) == true
 
-			let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
+			let (pipeSignal, observer) = Signal<Bool, Never>.pipe()
 
 			mapView.reactive.isRotateEnabled <~ pipeSignal
 


### PR DESCRIPTION
Once this is merged, I'll open a PR to release ReactiveCocoa X. (Unless someone beats me to it.)

#### Checklist
- [x] Updated CHANGELOG.md.