### PR TITLE
Update version in README to 9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you use [Carthage][] to manage your dependencies, simply add
 ReactiveCocoa to your `Cartfile`:
 
 ```
-github "ReactiveCocoa/ReactiveCocoa" ~> 8.0
+github "ReactiveCocoa/ReactiveCocoa" ~> 9.0
 ```
 
 If you use Carthage to build your dependencies, make sure you have added `ReactiveCocoa.framework` and `ReactiveSwift.framework` to the "_Linked Frameworks and Libraries_" section of your target, and have included them in your Carthage framework copying build phase.
@@ -111,7 +111,7 @@ If you use [CocoaPods][] to manage your dependencies, simply add
 ReactiveCocoa to your `Podfile`:
 
 ```
-pod 'ReactiveCocoa', '~> 8.0'
+pod 'ReactiveCocoa', '~> 9.0'
 ```
 
 #### Git submodule


### PR DESCRIPTION
SOME PEOPLE (definitely not me) might be lazy and just copy this out of the README and dump it in their (Cart|Pod)file (again, _definitely_ not me). For those people (not me) we should probably advertise the newest version so that they (not me) aren't confused when it doesn't compile with Xcode 10.2.