### PR TITLE
Allow for observable enum values

### DIFF
--- a/ReactiveCocoa/NSObject+KeyValueObserving.swift
+++ b/ReactiveCocoa/NSObject+KeyValueObserving.swift
@@ -106,6 +106,22 @@ extension Reactive where Base: NSObject {
 		return producer(for: keyPath) { $0 as! U? }
 	}
 
+	/// Create a producer which sends the current value and all the subsequent
+	/// changes of the property specified by the key path.
+	///
+	/// The producer completes when the object deinitializes.
+	///
+	/// - parameters:
+	///   - keyPath: The key path of the property to be observed.
+	///
+	/// - returns: A producer emitting values of the property specified by the
+	///            key path.
+	public func producer<U>(for keyPath: KeyPath<Base, U?>) -> SignalProducer<U?, Never> where U: RawRepresentable {
+		return producer(for: keyPath) {
+			$0.flatMap { value in U(rawValue: value as! U.RawValue)! }
+		}
+	}
+
 	/// Create a signal all changes of the property specified by the key path.
 	///
 	/// The signal completes when the object deinitializes.
@@ -122,6 +138,24 @@ extension Reactive where Base: NSObject {
 		return signal(for: keyPath) { $0 as! U? }
 	}
 
+	/// Create a signal all changes of the property specified by the key path.
+	///
+	/// The signal completes when the object deinitializes.
+	///
+	/// - note:
+	///	  Does not send the initial value. See `producer(forKeyPath:)`.
+	///
+	/// - parameters:
+	///   - keyPath: The key path of the property to be observed.
+	///
+	/// - returns: A producer emitting values of the property specified by the
+	///            key path.
+	public func signal<U>(for keyPath: KeyPath<Base, U?>) -> Signal<U?, Never> where U: RawRepresentable {
+		return signal(for: keyPath) {
+			$0.flatMap { value in U(rawValue: value as! U.RawValue) }
+		}
+	}
+
 	/// Create a producer which sends the current value and all the subsequent
 	/// changes of the property specified by the key path.
 	///
@@ -134,6 +168,20 @@ extension Reactive where Base: NSObject {
 	///            key path.
 	public func producer<U>(for keyPath: KeyPath<Base, U>) -> SignalProducer<U, Never> {
 		return producer(for: keyPath) { $0 as! U }
+	}
+
+	/// Create a producer which sends the current value and all the subsequent
+	/// changes of the property specified by the key path.
+	///
+	/// The producer completes when the object deinitializes.
+	///
+	/// - parameters:
+	///   - keyPath: The key path of the property to be observed.
+	///
+	/// - returns: A producer emitting values of the property specified by the
+	///            key path.
+	public func producer<U>(for keyPath: KeyPath<Base, U>) -> SignalProducer<U, Never> where U: RawRepresentable {
+		return producer(for: keyPath) { U(rawValue: $0 as! U.RawValue)! }
 	}
 
 	/// Create a signal all changes of the property specified by the key path.
@@ -150,6 +198,22 @@ extension Reactive where Base: NSObject {
 	///            key path.
 	public func signal<U>(for keyPath: KeyPath<Base, U>) -> Signal<U, Never> {
 		return signal(for: keyPath) { $0 as! U }
+	}
+
+	/// Create a signal all changes of the property specified by the key path.
+	///
+	/// The signal completes when the object deinitializes.
+	///
+	/// - note:
+	///	  Does not send the initial value. See `producer(forKeyPath:)`.
+	///
+	/// - parameters:
+	///   - keyPath: The key path of the property to be observed.
+	///
+	/// - returns: A producer emitting values of the property specified by the
+	///            key path.
+	public func signal<U>(for keyPath: KeyPath<Base, U>) -> Signal<U, Never> where U: RawRepresentable {
+		return signal(for: keyPath) { U(rawValue: $0 as! U.RawValue)! }
 	}
 }
 

--- a/ReactiveCocoaTests/KeyValueObservingSpec+Swift4.swift
+++ b/ReactiveCocoaTests/KeyValueObservingSpec+Swift4.swift
@@ -7,7 +7,7 @@ import Nimble
 #if swift(>=3.2)
 class KeyValueObservingSwift4Spec: QuickSpec {
 	override func spec() {
-		describe("NSObject.signal(forKeyPath:)") {
+		describe("NSObject.signal(for:)") {
 			it("should not send the initial value") {
 				let object = ObservableObject()
 				var values: [Int] = []
@@ -24,7 +24,7 @@ class KeyValueObservingSwift4Spec: QuickSpec {
 			}
 		}
 
-		describe("NSObject.producer(forKeyPath:)") {
+		describe("NSObject.producer(for:)") {
 			it("should send the initial value") {
 				let object = ObservableObject()
 				var values: [Int] = []

--- a/ReactiveCocoaTests/KeyValueObservingSpec+Swift4.swift
+++ b/ReactiveCocoaTests/KeyValueObservingSpec+Swift4.swift
@@ -19,6 +19,19 @@ class KeyValueObservingSwift4Spec: QuickSpec {
 				expect(values) == []
 			}
 
+			it("automatically converts enums") {
+				let object = ObservableObject()
+				var values: [ObservableEnum] = []
+
+				object.reactive
+					.signal(for: \.rac_enum)
+					.observeValues { values.append($0) }
+
+				object.rac_enum = .two
+
+				expect(values) == [.two]
+			}
+
 			itBehavesLike("a reactive key value observer using Swift 4 Smart Key Path") {
 				["observe": "signal"]
 			}
@@ -62,6 +75,21 @@ class KeyValueObservingSwift4Spec: QuickSpec {
 					.startWithValues { values.append(($0 as! NSNumber).intValue) }
 
 				expect(values) == [0]
+			}
+
+			it("should automatically convert enums") {
+				let object = ObservableObject()
+				var values: [ObservableEnum] = []
+
+				object.reactive
+					.producer(for: \.rac_enum)
+					.startWithValues { value in
+						values.append(value)
+				}
+
+				object.rac_enum = .one
+
+				expect(values) == [.zero, .one]
 			}
 
 			itBehavesLike("a reactive key value observer using Swift 4 Smart Key Path") {
@@ -584,8 +612,15 @@ fileprivate class KeyValueObservingSwift4SpecConfiguration: QuickConfiguration {
 
 private final class Token {}
 
+@objc private enum ObservableEnum: Int {
+	case zero
+	case one
+	case two
+}
+
 private class ObservableObject: NSObject {
 	@objc dynamic var rac_value: Int = 0
+	@objc dynamic var rac_enum: ObservableEnum = .zero
 
 	@objc dynamic var target: AnyObject?
 	@objc dynamic weak var weakTarget: AnyObject?


### PR DESCRIPTION
Previously, when using the `NSObject.producer/signal(for:)` syntax with
Swift 4 KeyPaths, we were force-casting the resulting value to the expected
type. This works for native Objective-C types, but breaks for Objective-C
enums, which are sent as their raw Integer types. This means the force-cast
would result in a crash if you tried to observe an enum value.

To fix this, we can add a special override for the KeyPath observation API 
that handles the RawRepresentable conversion automatically. This will then
be used if the user specifies a KeyPath that points to a RawRepresentable
type.

I ran into this need when trying to observe `\AVPlayer.timeControlStatus`,
which is an enum value. The runtime crash was unexpected and hard to
understand at first. This issue is solvable in the consuming codebase by
mapping the value over the enum initializer manually, but it would be _really_
nice to not have this edge case in the first place.

The added tests will result in a crash without the new code. I can add more
tests around the specific optional behavior if needed.