### PR TITLE
Add a binding target for the barTintColor of UINavigationBar

### DIFF
--- a/ReactiveCocoa/UIKit/UINavigationBar.swift
+++ b/ReactiveCocoa/UIKit/UINavigationBar.swift
@@ -1,0 +1,9 @@
+import ReactiveSwift
+import UIKit
+
+extension Reactive where Base: UINavigationBar {
+	/// Sets the barTintColor of the navigation bar.
+	public var barTintColor: BindingTarget<UIColor?> {
+		return makeBindingTarget { $0.barTintColor = $1 }
+	}
+}


### PR DESCRIPTION
Exposes binding sugar for the `barTintColor` on `UINavigationBar`.