### PR TITLE
Work around an issue where NSButtonSpec test fails

### DIFF
--- a/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
@@ -103,6 +103,12 @@ class NSButtonSpec: QuickSpec {
 				let stackView = NSStackView()
 				stackView.addArrangedSubview(button1)
 				stackView.addArrangedSubview(button2)
+
+				// The following works around an issue where the NSStackView can't remove
+				// itself as an observer of the "isHidden" property from the added NSButtons,
+				// due to either bugs in the OS or some issue with class/method swizzling.
+				// See https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3690
+				stackView.detachesHiddenViews = false
 				
 				window.contentView?.addSubview(stackView)
 				


### PR DESCRIPTION
This works around the failing test that is blocking #3693. 

I've done some research and the failing test seems to be the same issue reported in #3690. Setting `stackView.detachesHiddenViews = false` "solves" the issue, but it's probably not the proper solution. Investigating this further however requires far higher knowledge about Obj-C class/method swizzling (and how RAC does this) than what I currently possess.

Thought I would set up a PR anyway to work around the issue for now, so other PR's could get merged before a more proper fix is in place. Please feel free to close this PR if a proper fix is required.


#### Checklist
- [ ] Updated CHANGELOG.md.
