### PR TITLE
Add support for macOS Catalyst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # master
-*Please put new entries at the top.
+1. Don't include code which uses unavailable classes (like `NSSlider`) when targeting macOS Catalyst (#3698, kudos to @nkristek)
 
 # 10.2.0
 1. Update ReactiveSwift to 6.2.

--- a/ReactiveCocoa/AppKit/ActionProxy.swift
+++ b/ReactiveCocoa/AppKit/ActionProxy.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/AppKitReusableComponents.swift
+++ b/ReactiveCocoa/AppKit/AppKitReusableComponents.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSButton.swift
+++ b/ReactiveCocoa/AppKit/NSButton.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSCollectionView.swift
+++ b/ReactiveCocoa/AppKit/NSCollectionView.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSControl.swift
+++ b/ReactiveCocoa/AppKit/NSControl.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSImageView.swift
+++ b/ReactiveCocoa/AppKit/NSImageView.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSPopUpButton.swift
+++ b/ReactiveCocoa/AppKit/NSPopUpButton.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSSegmentedControl.swift
+++ b/ReactiveCocoa/AppKit/NSSegmentedControl.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSSlider.swift
+++ b/ReactiveCocoa/AppKit/NSSlider.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSTableView.swift
+++ b/ReactiveCocoa/AppKit/NSTableView.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSTextField.swift
+++ b/ReactiveCocoa/AppKit/NSTextField.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSTextView.swift
+++ b/ReactiveCocoa/AppKit/NSTextView.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/AppKit/NSView.swift
+++ b/ReactiveCocoa/AppKit/NSView.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import ReactiveSwift
 

--- a/ReactiveCocoa/Shared/NSLayoutConstraint.swift
+++ b/ReactiveCocoa/Shared/NSLayoutConstraint.swift
@@ -1,7 +1,7 @@
 #if !os(watchOS)
 import ReactiveSwift
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 #else
 import UIKit

--- a/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
+++ b/ReactiveCocoaTests/AppKit/ActionProxySpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Foundation
 import Quick
 import Nimble

--- a/ReactiveCocoaTests/AppKit/AppKitReusableComponentsSpec.swift
+++ b/ReactiveCocoaTests/AppKit/AppKitReusableComponentsSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveSwift

--- a/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveSwift

--- a/ReactiveCocoaTests/AppKit/NSCollectionViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSCollectionViewSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveCocoa

--- a/ReactiveCocoaTests/AppKit/NSControlSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSControlSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveSwift

--- a/ReactiveCocoaTests/AppKit/NSImageViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSImageViewSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveSwift

--- a/ReactiveCocoaTests/AppKit/NSPopUpButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSPopUpButtonSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveCocoa

--- a/ReactiveCocoaTests/AppKit/NSTableViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSTableViewSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveCocoa

--- a/ReactiveCocoaTests/AppKit/NSViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSViewSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import Quick
 import Nimble
 import ReactiveSwift

--- a/ReactiveCocoaTests/AppKit/Swift4TestInteroperability.swift
+++ b/ReactiveCocoaTests/AppKit/Swift4TestInteroperability.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 #if swift(>=4.0)

--- a/ReactiveCocoaTests/CocoaActionSpec.swift
+++ b/ReactiveCocoaTests/CocoaActionSpec.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 #endif
 import ReactiveSwift
@@ -9,7 +9,7 @@ import ReactiveCocoa
 class CocoaActionSpec: QuickSpec {
 	override func spec() {
 		var action: Action<Int, Int, Never>!
-		#if canImport(AppKit)
+		#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 			var cocoaAction: CocoaAction<NSControl>!
 		#else
 			var cocoaAction: CocoaAction<UIControl>!
@@ -23,7 +23,7 @@ class CocoaActionSpec: QuickSpec {
 			expect(cocoaAction.isEnabled.value).toEventually(beTruthy())
 		}
 
-		#if canImport(AppKit)
+		#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 			it("should be compatible with AppKit") {
 				let control = NSControl(frame: NSZeroRect)
 				control.target = cocoaAction

--- a/ReactiveCocoaTests/Shared/NSLayoutConstraintSpec.swift
+++ b/ReactiveCocoaTests/Shared/NSLayoutConstraintSpec.swift
@@ -1,6 +1,6 @@
 #if canImport(AppKit) || canImport(UIKit)
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 #elseif canImport(UIKit)
 import UIKit


### PR DESCRIPTION
This PR adds support for macOS Catalyst by adding `#if !targetEnvironment(macCatalyst)` checks for types which aren't available in macOS Catalyst. This is needed, since when targeting macOS Catalyst you can import both UIKit and AppKit, but you can't use classes like `NSSlider`. 

**Please note:** These checks probably need to be removed once the types eventually become available. For now, it is required to use this library at all.

#### Checklist
- [x] Updated CHANGELOG.md.

#### Additional notes

- closes #3697
