### PR TITLE
bump min deployment target to iOS 9 in podspecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # master
-
+1. Fix iOS deployment targets in ReactiveCocoa.podspec and ReactiveMapKit.podspec
 
 # 11.1.0
 # 11.0.01. Binding for `WKInterfaceActivityRing` has been removed, since it causes watchOS builds to be linked with HealthKit, leading to potential App Store rejections for apps who do not use HealthKit. (#3706)

--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author       = "ReactiveCocoa"
 
   s.osx.deployment_target = "10.9"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "2.0"
 

--- a/ReactiveMapKit.podspec
+++ b/ReactiveMapKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author       = "ReactiveCocoa"
 
   s.osx.deployment_target = "10.9"
-  s.ios.deployment_target = "8.0"
+  s.ios.deployment_target = "9.0"
   s.tvos.deployment_target = "9.0"
 
   s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "#{s.version}" }


### PR DESCRIPTION
Fixes https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3720

#### Checklist
- [x] Updated CHANGELOG.md.