### PR TITLE
Fix spm xcode 12.5 missing Foundation import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 
+1. Adds support for Xcode 12.5
 
 # 11.2.0
 

--- a/ReactiveCocoaObjC/include/ObjCRuntimeAliases.h
+++ b/ReactiveCocoaObjC/include/ObjCRuntimeAliases.h
@@ -1,5 +1,6 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
#### Checklist
- [x] Updated CHANGELOG.md.

Fixes #3723
This will make ReactiveCocoa compile when used with spm and xcode 12.5