### PR TITLE
Add support for ReactiveSwift 7.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,12 @@ jobs:
             SCHEME=ReactiveCocoa-iOS
             ;;
           "tvOS")
-            DESTINATION="platform=tvOS Simulator,name=Apple TV 4K"
+            DESTINATION="platform=tvOS Simulator,name=Apple TV"
             SCHEME=ReactiveCocoa-tvOS
             ;;
           "watchOS")
             ACTION=build
-            DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 5 - 44mm"
+            DESTINATION="platform=watchOS Simulator,name=Apple Watch Series 5 (44mm)"
             SCHEME=ReactiveCocoa-watchOS
             ;;
           "macCatalyst")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # master
 
+1. Add compatibility with ReactiveSwift 7.1.1 and bump minimum deployment targets to macOS 10.13, iOS 11.0, tvOS 11.0 and watchOS 4.0.
 
-# 12.0.01. Requires ReactiveSwift 7.0.
+# 12.0.0
+
+1. Requires ReactiveSwift 7.0.
 
 # 11.2.2
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "v9.2.1"
 github "Quick/Quick" "v4.0.0"
-github "ReactiveCocoa/ReactiveSwift" "7.0.0"
+github "ReactiveCocoa/ReactiveSwift" "7.1.1"
 github "xcconfigs/xcconfigs" "1.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift",
         "state": {
           "branch": null,
-          "revision": "2c06e9421011a1a4cf57ea4bbcd8936843a6c9da",
-          "version": "6.6.1"
+          "revision": "efb2f0a6f6c8739cce8fb14148a5bd3c83f2f91d",
+          "version": "7.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "682841464136f8c66e04afe5dbd01ab51a3a56f2",
-          "version": "2.1.0"
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
-          "version": "2.0.0"
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "af1730dde4e6c0d45bf01b99f8a41713ce536790",
-          "version": "9.2.0"
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift",
         "state": {
           "branch": null,
-          "revision": "efb2f0a6f6c8739cce8fb14148a5bd3c83f2f91d",
-          "version": "7.0.0"
+          "revision": "40c465af19b993344e84355c00669ba2022ca3cd",
+          "version": "7.1.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveCocoa",
     platforms: [
-        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_13), .iOS(.v11), .tvOS(.v11), .watchOS(.v4)
     ],
     products: [
         .library(name: "ReactiveCocoa", targets: ["ReactiveCocoa"])
@@ -40,5 +40,5 @@ let package = Package(
             ],
             path: "ReactiveCocoaTests"),
     ],
-    swiftLanguageVersions: [.v5]    
+    swiftLanguageVersions: [.v5]
 )

--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -9,10 +9,10 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
   s.author       = "ReactiveCocoa"
 
-  s.osx.deployment_target = "10.9"
-  s.ios.deployment_target = "9.0"
-  s.tvos.deployment_target = "9.0"
-  s.watchos.deployment_target = "2.0"
+  s.osx.deployment_target = "10.13"
+  s.ios.deployment_target = "11.0"
+  s.tvos.deployment_target = "11.0"
+  s.watchos.deployment_target = "4.0"
 
   s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "#{s.version}" }
   s.source_files = "ReactiveCocoa/*.{swift,h,m}", "ReactiveCocoa/Shared/*.{swift}", "ReactiveCocoaObjC/**/*.{h,m}"

--- a/ReactiveCocoa.xcodeproj/project.pbxproj
+++ b/ReactiveCocoa.xcodeproj/project.pbxproj
@@ -2409,7 +2409,6 @@
 			baseConfigurationReference = D047263719E49FE8006002AA /* macOS-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveMapKitTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.ReactiveMapKitTests;
 				PRODUCT_NAME = ReactiveMapKitTests;
 			};
@@ -2420,7 +2419,6 @@
 			baseConfigurationReference = D047263719E49FE8006002AA /* macOS-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveMapKitTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.ReactiveMapKitTests;
 				PRODUCT_NAME = ReactiveMapKitTests;
 			};
@@ -2431,7 +2429,6 @@
 			baseConfigurationReference = D047263719E49FE8006002AA /* macOS-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveMapKitTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.ReactiveMapKitTests;
 				PRODUCT_NAME = ReactiveMapKitTests;
 			};
@@ -2442,7 +2439,6 @@
 			baseConfigurationReference = D047263719E49FE8006002AA /* macOS-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveMapKitTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = org.reactivecocoa.ReactiveMapKitTests;
 				PRODUCT_NAME = ReactiveMapKitTests;
 			};
@@ -2599,16 +2595,16 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactivecocoa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -2627,17 +2623,17 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactivecocoa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};
@@ -2672,7 +2668,6 @@
 			baseConfigurationReference = E6124BA8267DF3C0005A3490 /* macOS-XCTest.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveCocoaTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 				SWIFT_OBJC_BRIDGING_HEADER = "ReactiveCocoaTests/ReactiveCocoaTests-Bridging-Header.h";
 			};
@@ -2683,7 +2678,6 @@
 			baseConfigurationReference = E6124BA8267DF3C0005A3490 /* macOS-XCTest.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveCocoaTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 				SWIFT_OBJC_BRIDGING_HEADER = "ReactiveCocoaTests/ReactiveCocoaTests-Bridging-Header.h";
 			};
@@ -2696,7 +2690,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MODULEMAP_FILE = "$(SRCROOT)/ReactiveCocoa/include/module.modulemap";
 			};
 			name = Debug;
@@ -2708,7 +2701,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MODULEMAP_FILE = "$(SRCROOT)/ReactiveCocoa/include/module.modulemap";
 			};
 			name = Release;
@@ -2747,16 +2739,16 @@
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactivecocoa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Profile;
 		};
@@ -2778,7 +2770,6 @@
 			baseConfigurationReference = E6124BA8267DF3C0005A3490 /* macOS-XCTest.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveCocoaTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 				SWIFT_OBJC_BRIDGING_HEADER = "ReactiveCocoaTests/ReactiveCocoaTests-Bridging-Header.h";
 			};
@@ -2791,7 +2782,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MODULEMAP_FILE = "$(SRCROOT)/ReactiveCocoa/include/module.modulemap";
 			};
 			name = Profile;
@@ -2820,16 +2810,16 @@
 				CODE_SIGNING_REQUIRED = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactivecocoa.$(PRODUCT_NAME:rfc1034identifier)-Tests";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Test;
 		};
@@ -2851,7 +2841,6 @@
 			baseConfigurationReference = E6124BA8267DF3C0005A3490 /* macOS-XCTest.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = ReactiveCocoaTests/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 				SWIFT_OBJC_BRIDGING_HEADER = "ReactiveCocoaTests/ReactiveCocoaTests-Bridging-Header.h";
 			};
@@ -2864,7 +2853,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				INFOPLIST_FILE = ReactiveCocoa/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MODULEMAP_FILE = "$(SRCROOT)/ReactiveCocoa/include/module.modulemap";
 			};
 			name = Test;

--- a/ReactiveCocoa/AppKit/AppKitReusableComponents.swift
+++ b/ReactiveCocoa/AppKit/AppKitReusableComponents.swift
@@ -9,7 +9,6 @@ extension Reactive where Base: NSView {
 }
 
 extension Reactive where Base: NSObject, Base: NSCollectionViewElement {
-	@available(macOS 10.11, *)
 	public var prepareForReuse: Signal<(), Never> {
 		return trigger(for: #selector(base.prepareForReuse))
 	}

--- a/ReactiveCocoa/AppKit/NSCollectionView.swift
+++ b/ReactiveCocoa/AppKit/NSCollectionView.swift
@@ -3,7 +3,6 @@ import AppKit
 import ReactiveSwift
 
 extension Reactive where Base: NSCollectionView {
-	@available(macOS 10.11, *)
 	public var reloadData: BindingTarget<()> {
 		return makeBindingTarget { base, _ in base.reloadData() }
 	}

--- a/ReactiveCocoaTests/AppKit/AppKitReusableComponentsSpec.swift
+++ b/ReactiveCocoaTests/AppKit/AppKitReusableComponentsSpec.swift
@@ -23,21 +23,19 @@ class ReusableComponentsSpec: QuickSpec {
 			}
 		}
 
-		if #available(macOS 10.11, *) {
-			describe("NSCollectionViewItem") {
-				it("should send a `value` event when `prepareForReuse` is triggered") {
-					let item = TestViewItem()
+		describe("NSCollectionViewItem") {
+			it("should send a `value` event when `prepareForReuse` is triggered") {
+				let item = TestViewItem()
 
-					var isTriggered = false
-					item.reactive.prepareForReuse.observeValues {
-						isTriggered = true
-					}
-
-					expect(isTriggered) == false
-
-					item.prepareForReuse()
-					expect(isTriggered) == true
+				var isTriggered = false
+				item.reactive.prepareForReuse.observeValues {
+					isTriggered = true
 				}
+
+				expect(isTriggered) == false
+
+				item.prepareForReuse()
+				expect(isTriggered) == true
 			}
 		}
 	}

--- a/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSButtonSpec.swift
@@ -84,43 +84,42 @@ class NSButtonSpec: QuickSpec {
 
 		}
 		
-		if #available(OSX 10.11, *) {
-			it("should send along state changes embedded within NSStackView") {
-				
-				let window = NSWindow()
-				
-				let button1 = NSButton()
-				let button2 = NSButton()
-				
-				button1.setButtonType(.pushOnPushOff)
-				button1.allowsMixedState = false
-				button1.state = RACNSOffState
-				
-				button2.setButtonType(.pushOnPushOff)
-				button2.allowsMixedState = false
-				button2.state = RACNSOnState
-				
-				let stackView = NSStackView()
-				stackView.addArrangedSubview(button1)
-				stackView.addArrangedSubview(button2)
-				
-				window.contentView?.addSubview(stackView)
-				
-				let state = MutableProperty(RACNSOffState)
-				state <~ button1.reactive.states
-				state <~ button2.reactive.states
-				
-				button1.performClick(nil)
-				expect(state.value) == RACNSOnState
-				
-				button2.performClick(nil)
-				expect(state.value) == RACNSOffState
-				
-				autoreleasepool {
-					button1.removeFromSuperview()
-					button2.removeFromSuperview()
-					stackView.removeFromSuperview()
-				}
+		it("should send along state changes embedded within NSStackView") {
+			let window = NSWindow()
+			let button1 = NSButton()
+			let button2 = NSButton()
+			
+			button1.setButtonType(.pushOnPushOff)
+			button1.allowsMixedState = false
+			button1.state = RACNSOffState
+			
+			button2.setButtonType(.pushOnPushOff)
+			button2.allowsMixedState = false
+			button2.state = RACNSOnState
+			
+			let stackView = NSStackView()
+			stackView.addArrangedSubview(button1)
+			stackView.addArrangedSubview(button2)
+			
+			// This is required to avoid crashing as of 10.15, see https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3690
+			stackView.detachesHiddenViews = false
+			
+			window.contentView?.addSubview(stackView)
+			
+			let state = MutableProperty(RACNSOffState)
+			state <~ button1.reactive.states
+			state <~ button2.reactive.states
+			
+			button1.performClick(nil)
+			expect(state.value) == RACNSOnState
+			
+			button2.performClick(nil)
+			expect(state.value) == RACNSOffState
+			
+			autoreleasepool {
+				button1.removeFromSuperview()
+				button2.removeFromSuperview()
+				stackView.removeFromSuperview()
 			}
 		}
 

--- a/ReactiveCocoaTests/AppKit/NSCollectionViewSpec.swift
+++ b/ReactiveCocoaTests/AppKit/NSCollectionViewSpec.swift
@@ -5,7 +5,6 @@ import ReactiveCocoa
 import ReactiveSwift
 import AppKit
 
-@available(macOS 10.11, *)
 final class NSCollectionViewSpec: QuickSpec {
 	override func spec() {
 		var collectionView: TestCollectionView!
@@ -43,7 +42,6 @@ final class NSCollectionViewSpec: QuickSpec {
 	}
 }
 
-@available(macOS 10.11, *)
 private final class TestCollectionView: NSCollectionView {
 	let reloadDataSignal: Signal<(), Never>
 	private let reloadDataObserver: Signal<(), Never>.Observer

--- a/ReactiveCocoaTests/InterceptingSpec.swift
+++ b/ReactiveCocoaTests/InterceptingSpec.swift
@@ -85,11 +85,7 @@ class InterceptingSpec: QuickSpec {
 					var isDeadlocked = true
 
 					func createQueue() -> DispatchQueue {
-						if #available(*, macOS 10.10) {
-							return .global(qos: .userInitiated)
-						} else {
-							return .global(priority: .high)
-						}
+						.global(qos: .userInitiated)
 					}
 
 					createQueue().async {

--- a/ReactiveCocoaTests/LifetimeSpec.swift
+++ b/ReactiveCocoaTests/LifetimeSpec.swift
@@ -27,11 +27,7 @@ class LifetimeSpec: QuickSpec {
 					var isDeadlocked = true
 
 					func createQueue() -> DispatchQueue {
-						if #available(*, macOS 10.10) {
-							return .global(qos: .userInitiated)
-						} else {
-							return .global(priority: .high)
-						}
+						.global(qos: .userInitiated)
 					}
 
 					createQueue().async {
@@ -68,11 +64,7 @@ class LifetimeSpec: QuickSpec {
 					var isDeadlocked = true
 
 					func createQueue() -> DispatchQueue {
-						if #available(*, macOS 10.10) {
-							return .global(qos: .userInitiated)
-						} else {
-							return .global(priority: .high)
-						}
+						return .global(qos: .userInitiated)
 					}
 
 					createQueue().async {

--- a/ReactiveCocoaTests/QueueScheduler+Factory.swift
+++ b/ReactiveCocoaTests/QueueScheduler+Factory.swift
@@ -5,11 +5,6 @@ extension QueueScheduler {
 	static func makeForTesting(file: String = #file, line: UInt = #line) -> QueueScheduler {
 		let file = URL(string: file)?.lastPathComponent ?? "<unknown>"
 		let label = "reactiveswift:\(file):\(line)"
-
-		if #available(OSX 10.10, iOS 8.0, *) {
-			return QueueScheduler(name: label)
-		} else {
-			return QueueScheduler(name: label)
-		}
+		return QueueScheduler(name: label)
 	}
 }

--- a/ReactiveMapKit.podspec
+++ b/ReactiveMapKit.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
   s.author       = "ReactiveCocoa"
 
-  s.osx.deployment_target = "10.9"
-  s.ios.deployment_target = "9.0"
-  s.tvos.deployment_target = "9.0"
+  s.osx.deployment_target = "10.13"
+  s.ios.deployment_target = "11.0"
+  s.tvos.deployment_target = "11.0"
 
   s.source       = { :git => "https://github.com/ReactiveCocoa/ReactiveCocoa.git", :tag => "#{s.version}" }
   s.source_files = "ReactiveMapKit/*.{swift,h,m}"


### PR DESCRIPTION
This fixes #3735.

- Bump macOS 10.13, iOS 11.0, tvOS 11.0 and watchOS 4.0 as per ReactiveSwift 7.1.1.
- Remove redundant conditional `@available` checks for earlier OS version.
- Fix `NSButtonSpec` when buttons are used inside `NSStackView`.
- Updated CHANGELOG.md.